### PR TITLE
Add app layer CLI entrypoint with backtest dependency assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Starter scaffold for a modular Python trading system.
 ```text
 src/trading_system/
   analytics/
+  app/
   backtest/
   config/
   core/
@@ -39,11 +40,32 @@ pip install -e .[dev]
 pytest
 ```
 
-To run the built-in smoke backtest without installing the package, use:
+## Run commands
+
+Backtest mode:
+
+```bash
+PYTHONPATH=src TRADING_SYSTEM_ENV=local TRADING_SYSTEM_TIMEZONE=Asia/Seoul \
+python -m trading_system.app.main --mode backtest --symbols BTCUSDT
+```
+
+Operational (live placeholder) mode validation:
+
+```bash
+PYTHONPATH=src TRADING_SYSTEM_ENV=local TRADING_SYSTEM_TIMEZONE=Asia/Seoul \
+python -m trading_system.app.main --mode live --symbols BTCUSDT
+```
+
+The built-in smoke backtest module is still available and now routes through the app layer:
 
 ```bash
 PYTHONPATH=src python -m trading_system.backtest.example
 ```
+
+## Required environment variables
+
+- `TRADING_SYSTEM_ENV`: logical runtime environment name (for example `local`, `staging`, `prod`).
+- `TRADING_SYSTEM_TIMEZONE`: operator timezone used for runtime context (for example `Asia/Seoul`).
 
 ## Current status
 

--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -1,11 +1,15 @@
 app:
   environment: local
   timezone: Asia/Seoul
+  mode: backtest
 
 market_data:
   provider: mock
   symbols:
     - BTCUSDT
+
+execution:
+  broker: paper
 
 risk:
   max_position: 1.0
@@ -15,3 +19,4 @@ risk:
 backtest:
   starting_cash: 1000000.0
   fee_bps: 5.0
+  trade_quantity: 0.1

--- a/examples/sample_backtest.yaml
+++ b/examples/sample_backtest.yaml
@@ -1,5 +1,11 @@
 name: mean_reversion_smoke_test
-symbol: BTCUSDT
+app:
+  mode: backtest
+market_data:
+  provider: mock
+  symbol: BTCUSDT
+execution:
+  broker: paper
 timeframe: 1m
 start: 2024-01-01T00:00:00Z
 end: 2024-01-07T00:00:00Z
@@ -11,3 +17,7 @@ strategy:
 risk:
   max_position: 1.0
   max_order_size: 0.2
+backtest:
+  starting_cash: 10000.0
+  fee_bps: 5.0
+  trade_quantity: 0.1

--- a/src/trading_system/app/__init__.py
+++ b/src/trading_system/app/__init__.py
@@ -1,0 +1,5 @@
+"""Application entrypoints and dependency assembly."""
+
+from trading_system.app.settings import AppMode, AppSettings
+
+__all__ = ["AppMode", "AppSettings"]

--- a/src/trading_system/app/backtest_demo.py
+++ b/src/trading_system/app/backtest_demo.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass
+from decimal import Decimal
+
+from trading_system.app.sample_data import build_sample_bars as _build_sample_bars
+from trading_system.app.services import build_services
+from trading_system.app.settings import AppMode, AppSettings, BacktestSettings, RiskSettings
+from trading_system.backtest.engine import BacktestResult
+from trading_system.core.types import MarketBar
+
+
+@dataclass(slots=True)
+class SmokeBacktestConfig:
+    symbol: str = "BTCUSDT"
+    starting_cash: Decimal = Decimal("10000")
+    fee_bps: Decimal = Decimal("5")
+    trade_quantity: Decimal = Decimal("0.1")
+    max_position: Decimal = Decimal("1.0")
+    max_notional: Decimal = Decimal("100000")
+    max_order_size: Decimal = Decimal("0.25")
+
+
+def build_sample_bars(symbol: str = "BTCUSDT") -> list[MarketBar]:
+    return _build_sample_bars(symbol=symbol)
+
+
+def run_smoke_backtest(config: SmokeBacktestConfig | None = None) -> BacktestResult:
+    if config is None:
+        config = SmokeBacktestConfig()
+
+    settings = AppSettings(
+        mode=AppMode.BACKTEST,
+        symbols=(config.symbol,),
+        provider="mock",
+        broker="paper",
+        risk=RiskSettings(
+            max_position=config.max_position,
+            max_notional=config.max_notional,
+            max_order_size=config.max_order_size,
+        ),
+        backtest=BacktestSettings(
+            starting_cash=config.starting_cash,
+            fee_bps=config.fee_bps,
+            trade_quantity=config.trade_quantity,
+        ),
+    )
+    services = build_services(settings)
+    return services.run()
+
+
+def format_result(result: BacktestResult) -> str:
+    final_portfolio = result.final_portfolio
+    position_items = ", ".join(
+        f"{symbol}={quantity}" for symbol, quantity in sorted(final_portfolio.positions.items())
+    ) or "flat"
+    equity_curve = ", ".join(str(value) for value in result.equity_curve)
+
+    return "\n".join(
+        [
+            "Smoke backtest result",
+            f"processed_bars: {result.processed_bars}",
+            f"executed_trades: {result.executed_trades}",
+            f"rejected_signals: {result.rejected_signals}",
+            f"cash: {final_portfolio.cash}",
+            f"positions: {position_items}",
+            f"total_return: {result.total_return}",
+            f"equity_curve: [{equity_curve}]",
+        ]
+    )

--- a/src/trading_system/app/main.py
+++ b/src/trading_system/app/main.py
@@ -1,0 +1,60 @@
+import argparse
+import sys
+
+from trading_system.app.backtest_demo import format_result
+from trading_system.app.services import build_services
+from trading_system.app.settings import AppSettings, SettingsValidationError
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Trading system application entrypoint")
+    parser.add_argument("--mode", default="backtest", help="Runtime mode (backtest|live)")
+    parser.add_argument("--symbols", default="BTCUSDT", help="Comma-separated symbols")
+    parser.add_argument("--provider", default="mock", help="Market data provider")
+    parser.add_argument("--broker", default="paper", help="Execution broker")
+    parser.add_argument("--starting-cash", default="10000", help="Starting cash for backtest")
+    parser.add_argument("--fee-bps", default="5", help="Fee in basis points")
+    parser.add_argument("--trade-quantity", default="0.1", help="Per-trade quantity")
+    parser.add_argument("--max-position", default="1.0", help="Risk max position")
+    parser.add_argument("--max-notional", default="100000", help="Risk max notional")
+    parser.add_argument("--max-order-size", default="0.25", help="Risk max order size")
+    return parser
+
+
+def run(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        settings = AppSettings.from_cli(
+            mode=args.mode,
+            symbols=args.symbols,
+            provider=args.provider,
+            broker=args.broker,
+            starting_cash=args.starting_cash,
+            fee_bps=args.fee_bps,
+            trade_quantity=args.trade_quantity,
+            max_position=args.max_position,
+            max_notional=args.max_notional,
+            max_order_size=args.max_order_size,
+        )
+        settings.validate()
+
+        services = build_services(settings)
+        result = services.run()
+        print(format_result(result))
+        return 0
+    except SettingsValidationError as exc:
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        return 2
+    except RuntimeError as exc:
+        print(f"Runtime error: {exc}", file=sys.stderr)
+        return 3
+
+
+def main() -> None:
+    raise SystemExit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/trading_system/app/sample_data.py
+++ b/src/trading_system/app/sample_data.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from trading_system.core.types import MarketBar
+
+
+def build_sample_bars(symbol: str = "BTCUSDT") -> list[MarketBar]:
+    closes = [
+        Decimal("100"),
+        Decimal("101"),
+        Decimal("103"),
+        Decimal("102"),
+        Decimal("104"),
+        Decimal("105"),
+        Decimal("103"),
+    ]
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    return [
+        MarketBar(
+            symbol=symbol,
+            timestamp=start + timedelta(minutes=index),
+            open=close,
+            high=close,
+            low=close,
+            close=close,
+            volume=Decimal("1"),
+        )
+        for index, close in enumerate(closes)
+    ]

--- a/src/trading_system/app/services.py
+++ b/src/trading_system/app/services.py
@@ -1,0 +1,77 @@
+from collections.abc import Iterable
+from dataclasses import dataclass
+from decimal import Decimal
+
+from trading_system.app.sample_data import build_sample_bars
+from trading_system.app.settings import AppMode, AppSettings
+from trading_system.backtest.engine import BacktestContext, BacktestResult, run_backtest
+from trading_system.core.types import MarketBar
+from trading_system.portfolio.book import PortfolioBook
+from trading_system.risk.limits import RiskLimits
+from trading_system.strategy.base import Strategy
+from trading_system.strategy.example import MomentumStrategy
+
+
+class MockMarketDataProvider:
+    def __init__(self, symbols: tuple[str, ...]) -> None:
+        self._bars_by_symbol: dict[str, list[MarketBar]] = {
+            symbol: build_sample_bars(symbol=symbol) for symbol in symbols
+        }
+
+    def load_bars(self, symbol: str) -> Iterable[MarketBar]:
+        return list(self._bars_by_symbol[symbol])
+
+
+@dataclass(slots=True)
+class PaperExecutionService:
+    broker: str
+
+
+@dataclass(slots=True)
+class AppServices:
+    mode: AppMode
+    strategy: Strategy
+    data_provider: MockMarketDataProvider
+    risk_limits: RiskLimits
+    execution: PaperExecutionService
+    portfolio: PortfolioBook
+    fee_bps: Decimal
+    symbols: tuple[str, ...]
+
+    def run(self) -> BacktestResult:
+        if self.mode != AppMode.BACKTEST:
+            raise RuntimeError(f"Unsupported mode '{self.mode}'.")
+
+        symbol = self._single_symbol()
+        bars = self.data_provider.load_bars(symbol)
+        context = BacktestContext(
+            portfolio=self.portfolio,
+            risk_limits=self.risk_limits,
+            fee_bps=self.fee_bps,
+        )
+        return run_backtest(bars=bars, strategy=self.strategy, context=context)
+
+    def _single_symbol(self) -> str:
+        if len(self.symbols) != 1:
+            raise RuntimeError("Current scaffold supports exactly one symbol for backtest mode.")
+        return self.symbols[0]
+
+
+def build_services(settings: AppSettings) -> AppServices:
+    if settings.mode != AppMode.BACKTEST:
+        raise RuntimeError(f"Mode '{settings.mode}' is not implemented yet.")
+
+    return AppServices(
+        mode=settings.mode,
+        strategy=MomentumStrategy(trade_quantity=settings.backtest.trade_quantity),
+        data_provider=MockMarketDataProvider(symbols=settings.symbols),
+        risk_limits=RiskLimits(
+            max_position=settings.risk.max_position,
+            max_notional=settings.risk.max_notional,
+            max_order_size=settings.risk.max_order_size,
+        ),
+        execution=PaperExecutionService(broker=settings.broker),
+        portfolio=PortfolioBook(cash=settings.backtest.starting_cash),
+        fee_bps=settings.backtest.fee_bps,
+        symbols=settings.symbols,
+    )

--- a/src/trading_system/app/settings.py
+++ b/src/trading_system/app/settings.py
@@ -1,0 +1,117 @@
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from enum import StrEnum
+
+
+class AppMode(StrEnum):
+    BACKTEST = "backtest"
+    LIVE = "live"
+
+
+class SettingsValidationError(ValueError):
+    """Raised when user-provided application settings are invalid."""
+
+
+@dataclass(slots=True)
+class RiskSettings:
+    max_position: Decimal
+    max_notional: Decimal
+    max_order_size: Decimal
+
+
+@dataclass(slots=True)
+class BacktestSettings:
+    starting_cash: Decimal
+    fee_bps: Decimal
+    trade_quantity: Decimal
+
+
+@dataclass(slots=True)
+class AppSettings:
+    mode: AppMode
+    symbols: tuple[str, ...]
+    provider: str
+    broker: str
+    risk: RiskSettings
+    backtest: BacktestSettings
+
+    @classmethod
+    def from_cli(
+        cls,
+        mode: str,
+        symbols: str,
+        provider: str,
+        broker: str,
+        starting_cash: str,
+        fee_bps: str,
+        trade_quantity: str,
+        max_position: str,
+        max_notional: str,
+        max_order_size: str,
+    ) -> "AppSettings":
+        parsed_symbols = tuple(
+            symbol.strip().upper()
+            for symbol in symbols.split(",")
+            if symbol.strip()
+        )
+        try:
+            parsed_mode = AppMode(mode)
+        except ValueError as exc:
+            raise SettingsValidationError(
+                f"Unsupported mode '{mode}'. Allowed modes: {[item.value for item in AppMode]}."
+            ) from exc
+
+        return cls(
+            mode=parsed_mode,
+            symbols=parsed_symbols,
+            provider=provider.strip().lower(),
+            broker=broker.strip().lower(),
+            risk=RiskSettings(
+                max_position=_to_decimal(max_position, "max_position"),
+                max_notional=_to_decimal(max_notional, "max_notional"),
+                max_order_size=_to_decimal(max_order_size, "max_order_size"),
+            ),
+            backtest=BacktestSettings(
+                starting_cash=_to_decimal(starting_cash, "starting_cash"),
+                fee_bps=_to_decimal(fee_bps, "fee_bps"),
+                trade_quantity=_to_decimal(trade_quantity, "trade_quantity"),
+            ),
+        )
+
+    def validate(self) -> None:
+        if not self.symbols:
+            raise SettingsValidationError("At least one symbol is required via --symbols.")
+
+        if self.provider not in {"mock"}:
+            raise SettingsValidationError("--provider must be 'mock' for this scaffold.")
+
+        if self.broker not in {"paper"}:
+            raise SettingsValidationError("--broker must be 'paper' for this scaffold.")
+
+        if self.backtest.starting_cash <= 0:
+            raise SettingsValidationError("--starting-cash must be greater than 0.")
+
+        if self.backtest.trade_quantity <= 0:
+            raise SettingsValidationError("--trade-quantity must be greater than 0.")
+
+        if self.backtest.fee_bps < 0 or self.backtest.fee_bps > Decimal("1000"):
+            raise SettingsValidationError("--fee-bps must be between 0 and 1000.")
+
+        if self.risk.max_position <= 0:
+            raise SettingsValidationError("--max-position must be greater than 0.")
+
+        if self.risk.max_notional <= 0:
+            raise SettingsValidationError("--max-notional must be greater than 0.")
+
+        if self.risk.max_order_size <= 0:
+            raise SettingsValidationError("--max-order-size must be greater than 0.")
+
+        if self.risk.max_order_size > self.risk.max_position:
+            raise SettingsValidationError("--max-order-size cannot exceed --max-position.")
+
+
+def _to_decimal(value: str, field_name: str) -> Decimal:
+    try:
+        return Decimal(value)
+    except InvalidOperation as exc:
+        raise SettingsValidationError(f"{field_name} must be a valid decimal value.") from exc

--- a/src/trading_system/backtest/example.py
+++ b/src/trading_system/backtest/example.py
@@ -1,88 +1,16 @@
-from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
-from decimal import Decimal
+from trading_system.app.backtest_demo import (
+    SmokeBacktestConfig,
+    build_sample_bars,
+    format_result,
+    run_smoke_backtest,
+)
 
-from trading_system.backtest.engine import BacktestContext, BacktestResult, run_backtest
-from trading_system.core.types import MarketBar
-from trading_system.portfolio.book import PortfolioBook
-from trading_system.risk.limits import RiskLimits
-from trading_system.strategy.example import MomentumStrategy
-
-
-@dataclass(slots=True)
-class SmokeBacktestConfig:
-    symbol: str = "BTCUSDT"
-    starting_cash: Decimal = Decimal("10000")
-    fee_bps: Decimal = Decimal("5")
-    trade_quantity: Decimal = Decimal("0.1")
-    max_position: Decimal = Decimal("1.0")
-    max_notional: Decimal = Decimal("100000")
-    max_order_size: Decimal = Decimal("0.25")
-
-
-def build_sample_bars(symbol: str = "BTCUSDT") -> list[MarketBar]:
-    closes = [
-        Decimal("100"),
-        Decimal("101"),
-        Decimal("103"),
-        Decimal("102"),
-        Decimal("104"),
-        Decimal("105"),
-        Decimal("103"),
-    ]
-    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
-
-    return [
-        MarketBar(
-            symbol=symbol,
-            timestamp=start + timedelta(minutes=index),
-            open=close,
-            high=close,
-            low=close,
-            close=close,
-            volume=Decimal("1"),
-        )
-        for index, close in enumerate(closes)
-    ]
-
-
-def run_smoke_backtest(config: SmokeBacktestConfig | None = None) -> BacktestResult:
-    if config is None:
-        config = SmokeBacktestConfig()
-
-    context = BacktestContext(
-        portfolio=PortfolioBook(cash=config.starting_cash),
-        risk_limits=RiskLimits(
-            max_position=config.max_position,
-            max_notional=config.max_notional,
-            max_order_size=config.max_order_size,
-        ),
-        fee_bps=config.fee_bps,
-    )
-    strategy = MomentumStrategy(trade_quantity=config.trade_quantity)
-    bars = build_sample_bars(symbol=config.symbol)
-    return run_backtest(bars=bars, strategy=strategy, context=context)
-
-
-def format_result(result: BacktestResult) -> str:
-    final_portfolio = result.final_portfolio
-    position_items = ", ".join(
-        f"{symbol}={quantity}" for symbol, quantity in sorted(final_portfolio.positions.items())
-    ) or "flat"
-    equity_curve = ", ".join(str(value) for value in result.equity_curve)
-
-    return "\n".join(
-        [
-            "Smoke backtest result",
-            f"processed_bars: {result.processed_bars}",
-            f"executed_trades: {result.executed_trades}",
-            f"rejected_signals: {result.rejected_signals}",
-            f"cash: {final_portfolio.cash}",
-            f"positions: {position_items}",
-            f"total_return: {result.total_return}",
-            f"equity_curve: [{equity_curve}]",
-        ]
-    )
+__all__ = [
+    "SmokeBacktestConfig",
+    "build_sample_bars",
+    "run_smoke_backtest",
+    "format_result",
+]
 
 
 def main() -> None:

--- a/tests/unit/test_app_main.py
+++ b/tests/unit/test_app_main.py
@@ -1,0 +1,27 @@
+from trading_system.app.main import run
+
+
+def test_cli_backtest_mode_runs_successfully(capsys) -> None:
+    exit_code = run(["--mode", "backtest", "--symbols", "BTCUSDT"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Smoke backtest result" in captured.out
+
+
+def test_cli_returns_validation_error_for_invalid_fee_bps(capsys) -> None:
+    exit_code = run(["--mode", "backtest", "--fee-bps", "-1"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "Configuration error:" in captured.err
+    assert "--fee-bps must be between 0 and 1000." in captured.err
+
+
+def test_cli_returns_runtime_error_for_unsupported_multi_symbol_backtest(capsys) -> None:
+    exit_code = run(["--mode", "backtest", "--symbols", "BTCUSDT,ETHUSDT"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 3
+    assert "Runtime error:" in captured.err
+    assert "supports exactly one symbol" in captured.err


### PR DESCRIPTION
### Motivation

- Provide a single validated CLI entrypoint and clear exit semantics for running the system by mode.
- Separate runtime concerns (settings, dependency assembly, execution mode) from the backtest demo to enable future expansion to live mode.
- Preserve deterministic smoke backtest behavior while moving orchestration into an application layer.

### Description

- Add a new `src/trading_system/app` package with `AppSettings`, `AppMode`, input parsing, decimal normalization, and validation in `settings.py` and `__all__` exports in `__init__.py`.
- Implement service assembly in `services.py` that builds `Strategy`, `DataProvider`, `RiskLimits`, `Execution`, and `Portfolio` objects and exposes an `AppServices.run()` entry for backtest mode.
- Add a CLI entrypoint at `src/trading_system/app/main.py` supporting `python -m trading_system.app.main`, returning explicit exit codes (0 success, 2 settings error, 3 runtime error) and user-friendly error messages.
- Move the smoke backtest orchestration into `app/backtest_demo.py` and make `backtest/example.py` a thin compatibility wrapper that re-exports the demo symbols; extract sample data into `app/sample_data.py` to avoid import cycles.
- Update `README.md`, `configs/base.yaml`, and `examples/sample_backtest.yaml` to document commands, required environment variables, and the new config shape, and add `tests/unit/test_app_main.py` to cover CLI happy/failure paths.

### Testing

- Ran `ruff check src tests` and it passed with no remaining issues.
- Ran `pytest` for the test suite and all tests passed (`11 passed`).
- Ran targeted backtest/CLI tests (`tests/unit/test_backtest_example.py`, `tests/unit/test_app_main.py`, `tests/unit/test_backtest_engine.py`, `tests/unit/test_risk_limits.py`) and they all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b368b00f088333900f7e378726dc3d)