### PR TITLE
Add deterministic data providers and policy-driven broker simulator

### DIFF
--- a/src/trading_system/app/services.py
+++ b/src/trading_system/app/services.py
@@ -1,41 +1,29 @@
-from collections.abc import Iterable
 from dataclasses import dataclass
-from decimal import Decimal
 
 from trading_system.app.sample_data import build_sample_bars
 from trading_system.app.settings import AppMode, AppSettings
 from trading_system.backtest.engine import BacktestContext, BacktestResult, run_backtest
-from trading_system.core.types import MarketBar
+from trading_system.data.provider import InMemoryMarketDataProvider, MarketDataProvider
 from trading_system.portfolio.book import PortfolioBook
 from trading_system.risk.limits import RiskLimits
 from trading_system.strategy.base import Strategy
 from trading_system.strategy.example import MomentumStrategy
-
-
-class MockMarketDataProvider:
-    def __init__(self, symbols: tuple[str, ...]) -> None:
-        self._bars_by_symbol: dict[str, list[MarketBar]] = {
-            symbol: build_sample_bars(symbol=symbol) for symbol in symbols
-        }
-
-    def load_bars(self, symbol: str) -> Iterable[MarketBar]:
-        return list(self._bars_by_symbol[symbol])
-
-
-@dataclass(slots=True)
-class PaperExecutionService:
-    broker: str
+from trading_system.execution.broker import (
+    BpsCommissionPolicy,
+    BpsSlippagePolicy,
+    FixedRatioFillPolicy,
+    PolicyBrokerSimulator,
+)
 
 
 @dataclass(slots=True)
 class AppServices:
     mode: AppMode
     strategy: Strategy
-    data_provider: MockMarketDataProvider
+    data_provider: MarketDataProvider
     risk_limits: RiskLimits
-    execution: PaperExecutionService
+    broker_simulator: PolicyBrokerSimulator
     portfolio: PortfolioBook
-    fee_bps: Decimal
     symbols: tuple[str, ...]
 
     def run(self) -> BacktestResult:
@@ -47,7 +35,7 @@ class AppServices:
         context = BacktestContext(
             portfolio=self.portfolio,
             risk_limits=self.risk_limits,
-            fee_bps=self.fee_bps,
+            broker=self.broker_simulator,
         )
         return run_backtest(bars=bars, strategy=self.strategy, context=context)
 
@@ -61,17 +49,21 @@ def build_services(settings: AppSettings) -> AppServices:
     if settings.mode != AppMode.BACKTEST:
         raise RuntimeError(f"Mode '{settings.mode}' is not implemented yet.")
 
+    bars_by_symbol = {symbol: build_sample_bars(symbol=symbol) for symbol in settings.symbols}
     return AppServices(
         mode=settings.mode,
         strategy=MomentumStrategy(trade_quantity=settings.backtest.trade_quantity),
-        data_provider=MockMarketDataProvider(symbols=settings.symbols),
+        data_provider=InMemoryMarketDataProvider(bars_by_symbol=bars_by_symbol),
         risk_limits=RiskLimits(
             max_position=settings.risk.max_position,
             max_notional=settings.risk.max_notional,
             max_order_size=settings.risk.max_order_size,
         ),
-        execution=PaperExecutionService(broker=settings.broker),
+        broker_simulator=PolicyBrokerSimulator(
+            fill_quantity_policy=FixedRatioFillPolicy(),
+            slippage_policy=BpsSlippagePolicy(),
+            commission_policy=BpsCommissionPolicy(bps=settings.backtest.fee_bps),
+        ),
         portfolio=PortfolioBook(cash=settings.backtest.starting_cash),
-        fee_bps=settings.backtest.fee_bps,
         symbols=settings.symbols,
     )

--- a/src/trading_system/backtest/engine.py
+++ b/src/trading_system/backtest/engine.py
@@ -4,16 +4,19 @@ from decimal import Decimal
 
 from trading_system.analytics.metrics import cumulative_return
 from trading_system.core.types import MarketBar
+from trading_system.execution.adapters import signal_to_order_request
+from trading_system.execution.broker import BrokerSimulator
+from trading_system.execution.orders import OrderSide
 from trading_system.portfolio.book import PortfolioBook
 from trading_system.risk.limits import RiskLimits
-from trading_system.strategy.base import SignalSide, Strategy
+from trading_system.strategy.base import Strategy
 
 
 @dataclass(slots=True)
 class BacktestContext:
     portfolio: PortfolioBook
     risk_limits: RiskLimits
-    fee_bps: Decimal
+    broker: BrokerSimulator
 
 
 @dataclass(slots=True)
@@ -42,15 +45,17 @@ def run_backtest(
     for bar in bars:
         processed_bars += 1
         signal = strategy.evaluate(bar)
-        signed_quantity = _signed_quantity(signal.side, signal.quantity)
+        order = signal_to_order_request(bar.symbol, signal)
 
-        if signed_quantity != 0:
+        if order is not None:
+            signed_quantity = order.quantity if order.side == OrderSide.BUY else -order.quantity
             current_position = context.portfolio.positions.get(bar.symbol, Decimal("0"))
             if context.risk_limits.allows_order(current_position, signed_quantity, bar.close):
-                context.portfolio.apply_fill(bar.symbol, signed_quantity, bar.close)
-                fee = _calculate_fee(signed_quantity, bar.close, context.fee_bps)
-                context.portfolio.cash -= fee
-                executed_trades += 1
+                fill = context.broker.submit_order(order, bar)
+                if fill.filled_quantity > 0:
+                    context.portfolio.apply_fill(fill.symbol, fill.signed_quantity, fill.fill_price)
+                    context.portfolio.cash -= fill.fee
+                    executed_trades += 1
             else:
                 rejected_signals += 1
 
@@ -63,18 +68,6 @@ def run_backtest(
         executed_trades=executed_trades,
         rejected_signals=rejected_signals,
     )
-
-
-def _signed_quantity(side: SignalSide, quantity: Decimal) -> Decimal:
-    if side == SignalSide.BUY:
-        return quantity
-    if side == SignalSide.SELL:
-        return -quantity
-    return Decimal("0")
-
-
-def _calculate_fee(quantity: Decimal, price: Decimal, fee_bps: Decimal) -> Decimal:
-    return abs(quantity * price) * fee_bps / Decimal("10000")
 
 
 def _equity_for_symbol(portfolio: PortfolioBook, symbol: str, mark_price: Decimal) -> Decimal:

--- a/src/trading_system/data/__init__.py
+++ b/src/trading_system/data/__init__.py
@@ -1,1 +1,5 @@
 """Market data contracts."""
+
+from trading_system.data.provider import CsvMarketDataProvider, InMemoryMarketDataProvider, MarketDataProvider
+
+__all__ = ["CsvMarketDataProvider", "InMemoryMarketDataProvider", "MarketDataProvider"]

--- a/src/trading_system/data/provider.py
+++ b/src/trading_system/data/provider.py
@@ -1,4 +1,9 @@
 from collections.abc import Iterable
+from csv import DictReader
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
 from typing import Protocol
 
 from trading_system.core.types import MarketBar
@@ -7,3 +12,36 @@ from trading_system.core.types import MarketBar
 class MarketDataProvider(Protocol):
     def load_bars(self, symbol: str) -> Iterable[MarketBar]:
         """Return historical or live-like bars for the given symbol."""
+
+
+@dataclass(slots=True)
+class InMemoryMarketDataProvider:
+    bars_by_symbol: dict[str, list[MarketBar]]
+
+    def load_bars(self, symbol: str) -> Iterable[MarketBar]:
+        return list(self.bars_by_symbol.get(symbol, []))
+
+
+@dataclass(slots=True)
+class CsvMarketDataProvider:
+    csv_by_symbol: dict[str, Path]
+
+    def load_bars(self, symbol: str) -> Iterable[MarketBar]:
+        csv_path = self.csv_by_symbol.get(symbol)
+        if csv_path is None:
+            return []
+
+        with csv_path.open("r", encoding="utf-8", newline="") as handle:
+            reader = DictReader(handle)
+            return [self._row_to_bar(symbol, row) for row in reader]
+
+    def _row_to_bar(self, symbol: str, row: dict[str, str]) -> MarketBar:
+        return MarketBar(
+            symbol=symbol,
+            timestamp=datetime.fromisoformat(row["timestamp"]),
+            open=Decimal(row["open"]),
+            high=Decimal(row["high"]),
+            low=Decimal(row["low"]),
+            close=Decimal(row["close"]),
+            volume=Decimal(row["volume"]),
+        )

--- a/src/trading_system/execution/__init__.py
+++ b/src/trading_system/execution/__init__.py
@@ -1,1 +1,26 @@
 """Execution models and broker contracts."""
+
+from trading_system.execution.adapters import signal_to_order_request
+from trading_system.execution.broker import (
+    BpsCommissionPolicy,
+    BpsSlippagePolicy,
+    BrokerSimulator,
+    FillEvent,
+    FillStatus,
+    FixedRatioFillPolicy,
+    PolicyBrokerSimulator,
+)
+from trading_system.execution.orders import OrderRequest, OrderSide
+
+__all__ = [
+    "BpsCommissionPolicy",
+    "BpsSlippagePolicy",
+    "BrokerSimulator",
+    "FillEvent",
+    "FillStatus",
+    "FixedRatioFillPolicy",
+    "OrderRequest",
+    "OrderSide",
+    "PolicyBrokerSimulator",
+    "signal_to_order_request",
+]

--- a/src/trading_system/execution/adapters.py
+++ b/src/trading_system/execution/adapters.py
@@ -1,0 +1,10 @@
+from trading_system.execution.orders import OrderRequest, OrderSide
+from trading_system.strategy.base import SignalSide, StrategySignal
+
+
+def signal_to_order_request(symbol: str, signal: StrategySignal) -> OrderRequest | None:
+    if signal.side == SignalSide.HOLD or signal.quantity <= 0:
+        return None
+
+    side = OrderSide.BUY if signal.side == SignalSide.BUY else OrderSide.SELL
+    return OrderRequest(symbol=symbol, side=side, quantity=signal.quantity)

--- a/src/trading_system/execution/broker.py
+++ b/src/trading_system/execution/broker.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import StrEnum
+from typing import Protocol
+
+from trading_system.core.types import MarketBar
+from trading_system.execution.orders import OrderRequest, OrderSide
+
+
+class FillStatus(StrEnum):
+    FILLED = "filled"
+    PARTIALLY_FILLED = "partially_filled"
+    UNFILLED = "unfilled"
+
+
+@dataclass(slots=True)
+class FillEvent:
+    symbol: str
+    side: OrderSide
+    requested_quantity: Decimal
+    filled_quantity: Decimal
+    fill_price: Decimal
+    fee: Decimal
+    status: FillStatus
+
+    @property
+    def signed_quantity(self) -> Decimal:
+        return self.filled_quantity if self.side == OrderSide.BUY else -self.filled_quantity
+
+
+class FillQuantityPolicy(Protocol):
+    def fill_quantity(self, order: OrderRequest, bar: MarketBar) -> Decimal:
+        """Return absolute filled quantity."""
+
+
+class SlippagePolicy(Protocol):
+    def fill_price(self, order: OrderRequest, bar: MarketBar) -> Decimal:
+        """Return the execution price after slippage."""
+
+
+class CommissionPolicy(Protocol):
+    def calculate_fee(self, order: OrderRequest, fill_quantity: Decimal, fill_price: Decimal) -> Decimal:
+        """Return absolute fee for the fill."""
+
+
+@dataclass(slots=True)
+class FixedRatioFillPolicy:
+    fill_ratio: Decimal = Decimal("1")
+
+    def fill_quantity(self, order: OrderRequest, bar: MarketBar) -> Decimal:
+        del bar
+        ratio = min(max(self.fill_ratio, Decimal("0")), Decimal("1"))
+        return order.quantity * ratio
+
+
+@dataclass(slots=True)
+class BpsSlippagePolicy:
+    bps: Decimal = Decimal("0")
+
+    def fill_price(self, order: OrderRequest, bar: MarketBar) -> Decimal:
+        if order.side == OrderSide.BUY:
+            return bar.close * (Decimal("1") + self.bps / Decimal("10000"))
+        return bar.close * (Decimal("1") - self.bps / Decimal("10000"))
+
+
+@dataclass(slots=True)
+class BpsCommissionPolicy:
+    bps: Decimal = Decimal("0")
+
+    def calculate_fee(self, order: OrderRequest, fill_quantity: Decimal, fill_price: Decimal) -> Decimal:
+        del order
+        return abs(fill_quantity * fill_price) * self.bps / Decimal("10000")
+
+
+class BrokerSimulator(Protocol):
+    def submit_order(self, order: OrderRequest, bar: MarketBar) -> FillEvent:
+        """Submit one order and return a deterministic fill event."""
+
+
+@dataclass(slots=True)
+class PolicyBrokerSimulator:
+    fill_quantity_policy: FillQuantityPolicy
+    slippage_policy: SlippagePolicy
+    commission_policy: CommissionPolicy
+
+    def submit_order(self, order: OrderRequest, bar: MarketBar) -> FillEvent:
+        filled_quantity = self.fill_quantity_policy.fill_quantity(order, bar)
+        if filled_quantity <= 0:
+            return FillEvent(
+                symbol=order.symbol,
+                side=order.side,
+                requested_quantity=order.quantity,
+                filled_quantity=Decimal("0"),
+                fill_price=bar.close,
+                fee=Decimal("0"),
+                status=FillStatus.UNFILLED,
+            )
+
+        fill_price = self.slippage_policy.fill_price(order, bar)
+        fee = self.commission_policy.calculate_fee(order, filled_quantity, fill_price)
+        status = FillStatus.FILLED if filled_quantity == order.quantity else FillStatus.PARTIALLY_FILLED
+        return FillEvent(
+            symbol=order.symbol,
+            side=order.side,
+            requested_quantity=order.quantity,
+            filled_quantity=filled_quantity,
+            fill_price=fill_price,
+            fee=fee,
+            status=status,
+        )

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -5,6 +5,12 @@ from decimal import Decimal
 
 from trading_system.backtest.engine import BacktestContext, run_backtest
 from trading_system.core.types import MarketBar
+from trading_system.execution.broker import (
+    BpsCommissionPolicy,
+    BpsSlippagePolicy,
+    FixedRatioFillPolicy,
+    PolicyBrokerSimulator,
+)
 from trading_system.portfolio.book import PortfolioBook
 from trading_system.risk.limits import RiskLimits
 from trading_system.strategy.base import SignalSide, StrategySignal
@@ -26,7 +32,7 @@ def test_run_backtest_executes_buy_at_close_and_records_return() -> None:
     context = BacktestContext(
         portfolio=PortfolioBook(cash=Decimal("1000")),
         risk_limits=_limits(),
-        fee_bps=Decimal("0"),
+        broker=_broker(),
     )
     strategy = StubStrategy(
         signals=[
@@ -53,7 +59,7 @@ def test_run_backtest_executes_sell_using_negative_signed_quantity() -> None:
             positions={"BTCUSDT": Decimal("2")},
         ),
         risk_limits=_limits(),
-        fee_bps=Decimal("0"),
+        broker=_broker(),
     )
     strategy = StubStrategy(
         signals=[StrategySignal(side=SignalSide.SELL, quantity=Decimal("1.5"), reason="trim")]
@@ -75,7 +81,7 @@ def test_run_backtest_rejects_signal_when_risk_limits_fail() -> None:
             max_notional=Decimal("100000"),
             max_order_size=Decimal("0.5"),
         ),
-        fee_bps=Decimal("0"),
+        broker=_broker(),
     )
     strategy = StubStrategy(
         signals=[StrategySignal(side=SignalSide.BUY, quantity=Decimal("1"), reason="too_big")]
@@ -90,11 +96,11 @@ def test_run_backtest_rejects_signal_when_risk_limits_fail() -> None:
     assert result.equity_curve == [Decimal("1000")]
 
 
-def test_run_backtest_applies_fee_bps_to_cash() -> None:
+def test_run_backtest_applies_commission_fee() -> None:
     context = BacktestContext(
         portfolio=PortfolioBook(cash=Decimal("1000")),
         risk_limits=_limits(),
-        fee_bps=Decimal("10"),
+        broker=_broker(commission_bps=Decimal("10")),
     )
     strategy = StubStrategy(
         signals=[StrategySignal(side=SignalSide.BUY, quantity=Decimal("2"), reason="entry")]
@@ -107,11 +113,71 @@ def test_run_backtest_applies_fee_bps_to_cash() -> None:
     assert result.equity_curve == [Decimal("999.8")]
 
 
+def test_run_backtest_supports_partial_fill_and_unfilled_order() -> None:
+    partial_context = BacktestContext(
+        portfolio=PortfolioBook(cash=Decimal("1000")),
+        risk_limits=_limits(),
+        broker=_broker(fill_ratio=Decimal("0.5")),
+    )
+    partial_result = run_backtest(
+        _bars([Decimal("100")]),
+        StubStrategy([StrategySignal(side=SignalSide.BUY, quantity=Decimal("2"), reason="partial")]),
+        partial_context,
+    )
+
+    assert partial_result.executed_trades == 1
+    assert partial_result.final_portfolio.positions["BTCUSDT"] == Decimal("1")
+    assert partial_result.final_portfolio.cash == Decimal("900")
+
+    unfilled_context = BacktestContext(
+        portfolio=PortfolioBook(cash=Decimal("1000")),
+        risk_limits=_limits(),
+        broker=_broker(fill_ratio=Decimal("0")),
+    )
+    unfilled_result = run_backtest(
+        _bars([Decimal("100")]),
+        StubStrategy([StrategySignal(side=SignalSide.BUY, quantity=Decimal("2"), reason="no_fill")]),
+        unfilled_context,
+    )
+
+    assert unfilled_result.executed_trades == 0
+    assert unfilled_result.final_portfolio.positions == {}
+    assert unfilled_result.final_portfolio.cash == Decimal("1000")
+
+
+def test_run_backtest_applies_slippage_to_fill_price() -> None:
+    context = BacktestContext(
+        portfolio=PortfolioBook(cash=Decimal("1000")),
+        risk_limits=_limits(),
+        broker=_broker(slippage_bps=Decimal("100")),
+    )
+    strategy = StubStrategy(
+        signals=[StrategySignal(side=SignalSide.BUY, quantity=Decimal("1"), reason="slippage")]
+    )
+
+    result = run_backtest(_bars([Decimal("100")]), strategy, context)
+
+    assert result.final_portfolio.cash == Decimal("899")
+    assert result.equity_curve == [Decimal("999")]
+
+
 def _limits() -> RiskLimits:
     return RiskLimits(
         max_position=Decimal("10"),
         max_notional=Decimal("100000"),
         max_order_size=Decimal("10"),
+    )
+
+
+def _broker(
+    fill_ratio: Decimal = Decimal("1"),
+    slippage_bps: Decimal = Decimal("0"),
+    commission_bps: Decimal = Decimal("0"),
+) -> PolicyBrokerSimulator:
+    return PolicyBrokerSimulator(
+        fill_quantity_policy=FixedRatioFillPolicy(fill_ratio=fill_ratio),
+        slippage_policy=BpsSlippagePolicy(bps=slippage_bps),
+        commission_policy=BpsCommissionPolicy(bps=commission_bps),
     )
 
 

--- a/tests/unit/test_data_provider.py
+++ b/tests/unit/test_data_provider.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+
+from trading_system.core.types import MarketBar
+from trading_system.data.provider import CsvMarketDataProvider, InMemoryMarketDataProvider
+
+
+def test_in_memory_provider_loads_symbol_bars() -> None:
+    bars = [_bar(Decimal("100")), _bar(Decimal("101"))]
+    provider = InMemoryMarketDataProvider(bars_by_symbol={"BTCUSDT": bars})
+
+    loaded = list(provider.load_bars("BTCUSDT"))
+
+    assert loaded == bars
+
+
+def test_csv_provider_loads_bars(tmp_path: Path) -> None:
+    csv_path = tmp_path / "btc.csv"
+    csv_path.write_text(
+        "timestamp,open,high,low,close,volume\n"
+        "2024-01-01T00:00:00+00:00,100,101,99,100,1\n"
+        "2024-01-01T00:01:00+00:00,100,102,100,101,2\n",
+        encoding="utf-8",
+    )
+    provider = CsvMarketDataProvider(csv_by_symbol={"BTCUSDT": csv_path})
+
+    loaded = list(provider.load_bars("BTCUSDT"))
+
+    assert [bar.close for bar in loaded] == [Decimal("100"), Decimal("101")]
+    assert loaded[0].timestamp == datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+
+def _bar(close: Decimal) -> MarketBar:
+    return MarketBar(
+        symbol="BTCUSDT",
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        open=close,
+        high=close,
+        low=close,
+        close=close,
+        volume=Decimal("1"),
+    )

--- a/tests/unit/test_execution_adapters_and_broker.py
+++ b/tests/unit/test_execution_adapters_and_broker.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from trading_system.core.types import MarketBar
+from trading_system.execution.adapters import signal_to_order_request
+from trading_system.execution.broker import (
+    BpsCommissionPolicy,
+    BpsSlippagePolicy,
+    FillStatus,
+    FixedRatioFillPolicy,
+    PolicyBrokerSimulator,
+)
+from trading_system.strategy.base import SignalSide, StrategySignal
+
+
+def test_signal_to_order_request_maps_buy_signal() -> None:
+    signal = StrategySignal(side=SignalSide.BUY, quantity=Decimal("1.2"), reason="entry")
+
+    order = signal_to_order_request("BTCUSDT", signal)
+
+    assert order is not None
+    assert order.symbol == "BTCUSDT"
+    assert order.side.value == "buy"
+    assert order.quantity == Decimal("1.2")
+
+
+def test_signal_to_order_request_returns_none_for_hold() -> None:
+    signal = StrategySignal(side=SignalSide.HOLD, quantity=Decimal("0"), reason="wait")
+
+    order = signal_to_order_request("BTCUSDT", signal)
+
+    assert order is None
+
+
+def test_policy_broker_simulator_returns_partial_fill_event() -> None:
+    broker = PolicyBrokerSimulator(
+        fill_quantity_policy=FixedRatioFillPolicy(fill_ratio=Decimal("0.25")),
+        slippage_policy=BpsSlippagePolicy(bps=Decimal("10")),
+        commission_policy=BpsCommissionPolicy(bps=Decimal("5")),
+    )
+
+    fill = broker.submit_order(_buy_signal_order(), _bar())
+
+    assert fill.status == FillStatus.PARTIALLY_FILLED
+    assert fill.filled_quantity == Decimal("0.25")
+    assert fill.fill_price == Decimal("100.10")
+    assert fill.fee == Decimal("0.0125125")
+
+
+def test_policy_broker_simulator_returns_unfilled_event() -> None:
+    broker = PolicyBrokerSimulator(
+        fill_quantity_policy=FixedRatioFillPolicy(fill_ratio=Decimal("0")),
+        slippage_policy=BpsSlippagePolicy(),
+        commission_policy=BpsCommissionPolicy(),
+    )
+
+    fill = broker.submit_order(_buy_signal_order(), _bar())
+
+    assert fill.status == FillStatus.UNFILLED
+    assert fill.filled_quantity == Decimal("0")
+    assert fill.fee == Decimal("0")
+
+
+def _bar() -> MarketBar:
+    return MarketBar(
+        symbol="BTCUSDT",
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        open=Decimal("100"),
+        high=Decimal("100"),
+        low=Decimal("100"),
+        close=Decimal("100"),
+        volume=Decimal("1"),
+    )
+
+
+def _buy_signal_order():
+    signal = StrategySignal(side=SignalSide.BUY, quantity=Decimal("1"), reason="entry")
+    order = signal_to_order_request("BTCUSDT", signal)
+    assert order is not None
+    return order


### PR DESCRIPTION
### Motivation
- Decouple market-data, signal→order translation, and execution to make backtests configurable and testable. 
- Support partial fills, unfilled orders, slippage and commission as injectable policies instead of hard-coded engine math. 
- Preserve deterministic smoke-backtest behavior while exposing pluggable providers and broker policies for future extension.

### Description
- Add concrete market-data implementations `InMemoryMarketDataProvider` and `CsvMarketDataProvider` and export them from `trading_system.data` so `load_bars(symbol)` can use memory/CSV sources. 
- Introduce execution adapter `signal_to_order_request` and an execution package with `BrokerSimulator` protocol, `PolicyBrokerSimulator`, `FillEvent`/`FillStatus`, and policy types `FixedRatioFillPolicy`, `BpsSlippagePolicy`, `BpsCommissionPolicy`. 
- Refactor `run_backtest` and `BacktestContext` to convert `StrategySignal -> OrderRequest`, run risk checks, submit to `broker.submit_order(...)`, apply fills via `PortfolioBook.apply_fill()` and deduct `FillEvent.fee`. 
- Wire defaults in `build_services` to use `InMemoryMarketDataProvider` and a `PolicyBrokerSimulator` (default policies preserve prior deterministic behavior) and keep the app/backtest surface area small.

### Testing
- Added unit tests `tests/unit/test_data_provider.py` and `tests/unit/test_execution_adapters_and_broker.py` and extended `tests/unit/test_backtest_engine.py` to cover partial/unfilled fills, slippage, and commission. 
- Ran `pytest -q` locally and all tests passed (`19 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b36d0220408333a8de241b6c2c41ea)