### PR TITLE
Add typed config models and validated YAML `load_settings` loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ PYTHONPATH=src python -m trading_system.backtest.example
 - `TRADING_SYSTEM_ENV`: logical runtime environment name (for example `local`, `staging`, `prod`).
 - `TRADING_SYSTEM_TIMEZONE`: operator timezone used for runtime context (for example `Asia/Seoul`).
 
+
+## Configuration schema
+
+`src/trading_system/config/settings.py` provides a YAML loader with validation:
+
+```python
+from trading_system.config import load_settings
+
+settings = load_settings("configs/base.yaml")
+```
+
+Required top-level sections:
+
+- `app`: `environment` (str), `timezone` (str), `mode` (`backtest`|`live`)
+- `market_data`: `provider` (str), `symbols` (list[str])
+- `risk`: `max_position`, `max_notional`, `max_order_size` (Decimal, > 0)
+- `backtest`: `starting_cash` (> 0), `fee_bps` (0~1000), `trade_quantity` (> 0)
+
+All amount/quantity/fee fields are parsed as `Decimal`. Validation errors return human-friendly messages for missing keys, invalid types, and out-of-range values.
+
 ## Current status
 
 This repository currently provides a clean package skeleton, a small risk-rule example, a deterministic single-symbol backtest loop, and repository-level skills for planning, implementation, review, and documentation work.

--- a/examples/sample_backtest.yaml
+++ b/examples/sample_backtest.yaml
@@ -1,9 +1,12 @@
 name: mean_reversion_smoke_test
 app:
+  environment: local
+  timezone: Asia/Seoul
   mode: backtest
 market_data:
   provider: mock
-  symbol: BTCUSDT
+  symbols:
+    - BTCUSDT
 execution:
   broker: paper
 timeframe: 1m
@@ -16,6 +19,7 @@ strategy:
   zscore_exit: 0.5
 risk:
   max_position: 1.0
+  max_notional: 100000.0
   max_order_size: 0.2
 backtest:
   starting_cash: 10000.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ version = "0.1.0"
 description = "Starter scaffold for a modular Python trading system"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+  "PyYAML>=6.0",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/src/trading_system/config/__init__.py
+++ b/src/trading_system/config/__init__.py
@@ -1,1 +1,23 @@
 """Configuration models and loaders."""
+
+from trading_system.config.settings import (
+    AppMode,
+    AppSettings,
+    BacktestSettings,
+    MarketDataSettings,
+    RiskSettings,
+    Settings,
+    SettingsValidationError,
+    load_settings,
+)
+
+__all__ = [
+    "AppMode",
+    "AppSettings",
+    "BacktestSettings",
+    "MarketDataSettings",
+    "RiskSettings",
+    "Settings",
+    "SettingsValidationError",
+    "load_settings",
+]

--- a/src/trading_system/config/settings.py
+++ b/src/trading_system/config/settings.py
@@ -1,14 +1,224 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class SettingsValidationError(ValueError):
+    """Raised when configuration input is missing or invalid."""
+
+
+class AppMode(StrEnum):
+    BACKTEST = "backtest"
+    LIVE = "live"
+
+
+@dataclass(slots=True)
+class AppSettings:
+    environment: str
+    timezone: str
+    mode: AppMode
+
+
+@dataclass(slots=True)
+class MarketDataSettings:
+    provider: str
+    symbols: tuple[str, ...]
 
 
 @dataclass(slots=True)
 class RiskSettings:
-    max_position: float
-    max_notional: float
-    max_order_size: float
+    max_position: Decimal
+    max_notional: Decimal
+    max_order_size: Decimal
 
 
 @dataclass(slots=True)
 class BacktestSettings:
-    starting_cash: float
-    fee_bps: float
+    starting_cash: Decimal
+    fee_bps: Decimal
+    trade_quantity: Decimal
+
+
+@dataclass(slots=True)
+class Settings:
+    app: AppSettings
+    market_data: MarketDataSettings
+    risk: RiskSettings
+    backtest: BacktestSettings
+
+
+REQUIRED_ROOT_KEYS = ("app", "market_data", "risk", "backtest")
+
+
+def load_settings(path: str | Path) -> Settings:
+    config_path = Path(path)
+    if not config_path.exists():
+        raise SettingsValidationError(f"Configuration file not found: {config_path}")
+
+    try:
+        payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise SettingsValidationError(f"Failed to parse YAML in {config_path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise SettingsValidationError("Configuration root must be a mapping.")
+
+    for key in REQUIRED_ROOT_KEYS:
+        _require_key(payload, key, path=key)
+
+    app_section = _as_dict(payload["app"], "app")
+    market_data_section = _as_dict(payload["market_data"], "market_data")
+    risk_section = _as_dict(payload["risk"], "risk")
+    backtest_section = _as_dict(payload["backtest"], "backtest")
+
+    settings = Settings(
+        app=AppSettings(
+            environment=_as_non_empty_str(
+                _require_key(app_section, "environment", "app.environment"),
+                "app.environment",
+            ),
+            timezone=_as_non_empty_str(
+                _require_key(app_section, "timezone", "app.timezone"),
+                "app.timezone",
+            ),
+            mode=_as_mode(
+                _require_key(app_section, "mode", "app.mode"),
+                "app.mode",
+            ),
+        ),
+        market_data=MarketDataSettings(
+            provider=_as_non_empty_str(
+                _require_key(market_data_section, "provider", "market_data.provider"),
+                "market_data.provider",
+            ),
+            symbols=_as_symbols(
+                _require_key(market_data_section, "symbols", "market_data.symbols"),
+                "market_data.symbols",
+            ),
+        ),
+        risk=RiskSettings(
+            max_position=_as_decimal(
+                _require_key(risk_section, "max_position", "risk.max_position"),
+                "risk.max_position",
+                minimum=Decimal("0"),
+            ),
+            max_notional=_as_decimal(
+                _require_key(risk_section, "max_notional", "risk.max_notional"),
+                "risk.max_notional",
+                minimum=Decimal("0"),
+            ),
+            max_order_size=_as_decimal(
+                _require_key(risk_section, "max_order_size", "risk.max_order_size"),
+                "risk.max_order_size",
+                minimum=Decimal("0"),
+            ),
+        ),
+        backtest=BacktestSettings(
+            starting_cash=_as_decimal(
+                _require_key(backtest_section, "starting_cash", "backtest.starting_cash"),
+                "backtest.starting_cash",
+                minimum=Decimal("0"),
+            ),
+            fee_bps=_as_decimal(
+                _require_key(backtest_section, "fee_bps", "backtest.fee_bps"),
+                "backtest.fee_bps",
+                minimum=Decimal("0"),
+                maximum=Decimal("1000"),
+            ),
+            trade_quantity=_as_decimal(
+                _require_key(backtest_section, "trade_quantity", "backtest.trade_quantity"),
+                "backtest.trade_quantity",
+                minimum=Decimal("0"),
+            ),
+        ),
+    )
+
+    if settings.risk.max_order_size > settings.risk.max_position:
+        raise SettingsValidationError(
+            "Invalid value for 'risk.max_order_size': "
+            "must be less than or equal to 'risk.max_position'."
+        )
+
+    return settings
+
+
+def _require_key(payload: dict[str, Any], key: str, path: str) -> Any:
+    if key not in payload:
+        raise SettingsValidationError(f"Missing required key: '{path}'.")
+    return payload[key]
+
+
+def _as_dict(value: Any, path: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise SettingsValidationError(f"Invalid type for '{path}': expected mapping.")
+    return value
+
+
+def _as_non_empty_str(value: Any, path: str) -> str:
+    if not isinstance(value, str):
+        raise SettingsValidationError(f"Invalid type for '{path}': expected string.")
+    normalized = value.strip()
+    if not normalized:
+        raise SettingsValidationError(f"Invalid value for '{path}': must be a non-empty string.")
+    return normalized
+
+
+def _as_mode(value: Any, path: str) -> AppMode:
+    parsed = _as_non_empty_str(value, path)
+    try:
+        return AppMode(parsed)
+    except ValueError as exc:
+        allowed = ", ".join(item.value for item in AppMode)
+        raise SettingsValidationError(
+            f"Invalid value for '{path}': expected one of [{allowed}]."
+        ) from exc
+
+
+def _as_symbols(value: Any, path: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise SettingsValidationError(f"Invalid type for '{path}': expected list of strings.")
+
+    normalized_symbols: list[str] = []
+    for idx, item in enumerate(value):
+        item_path = f"{path}[{idx}]"
+        normalized = _as_non_empty_str(item, item_path).upper()
+        normalized_symbols.append(normalized)
+
+    if not normalized_symbols:
+        raise SettingsValidationError(
+            f"Invalid value for '{path}': at least one symbol is required."
+        )
+
+    return tuple(normalized_symbols)
+
+
+def _as_decimal(
+    value: Any,
+    path: str,
+    minimum: Decimal | None = None,
+    maximum: Decimal | None = None,
+) -> Decimal:
+    try:
+        number = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise SettingsValidationError(
+            f"Invalid type for '{path}': expected decimal-compatible value."
+        ) from exc
+
+    if minimum is not None and number <= minimum:
+        raise SettingsValidationError(
+            f"Invalid value for '{path}': must be greater than {minimum}."
+        )
+
+    if maximum is not None and number > maximum:
+        raise SettingsValidationError(
+            f"Invalid value for '{path}': must be less than or equal to {maximum}."
+        )
+
+    return number

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -1,0 +1,119 @@
+from decimal import Decimal
+
+import pytest
+
+from trading_system.config.settings import SettingsValidationError, load_settings
+
+
+def test_load_settings_parses_base_schema(tmp_path) -> None:
+    config_path = tmp_path / "settings.yaml"
+    config_path.write_text(
+        """
+app:
+  environment: local
+  timezone: Asia/Seoul
+  mode: backtest
+market_data:
+  provider: mock
+  symbols:
+    - btcusdt
+risk:
+  max_position: 1.0
+  max_notional: 100000.0
+  max_order_size: 0.25
+backtest:
+  starting_cash: 10000.0
+  fee_bps: 5.0
+  trade_quantity: 0.1
+""".strip(),
+        encoding="utf-8",
+    )
+
+    settings = load_settings(config_path)
+
+    assert settings.app.environment == "local"
+    assert settings.market_data.symbols == ("BTCUSDT",)
+    assert settings.risk.max_notional == Decimal("100000.0")
+    assert settings.backtest.fee_bps == Decimal("5.0")
+
+
+def test_load_settings_reports_missing_required_key(tmp_path) -> None:
+    config_path = tmp_path / "settings.yaml"
+    config_path.write_text(
+        """
+app:
+  environment: local
+  timezone: Asia/Seoul
+  mode: backtest
+market_data:
+  provider: mock
+  symbols:
+    - BTCUSDT
+risk:
+  max_position: 1.0
+  max_order_size: 0.25
+backtest:
+  starting_cash: 10000.0
+  fee_bps: 5.0
+  trade_quantity: 0.1
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SettingsValidationError, match="Missing required key: 'risk.max_notional'"):
+        load_settings(config_path)
+
+
+def test_load_settings_reports_invalid_type(tmp_path) -> None:
+    config_path = tmp_path / "settings.yaml"
+    config_path.write_text(
+        """
+app:
+  environment: local
+  timezone: Asia/Seoul
+  mode: backtest
+market_data:
+  provider: mock
+  symbols: BTCUSDT
+risk:
+  max_position: 1.0
+  max_notional: 100000.0
+  max_order_size: 0.25
+backtest:
+  starting_cash: 10000.0
+  fee_bps: 5.0
+  trade_quantity: 0.1
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SettingsValidationError, match="Invalid type for 'market_data.symbols'"):
+        load_settings(config_path)
+
+
+def test_load_settings_reports_out_of_range_value(tmp_path) -> None:
+    config_path = tmp_path / "settings.yaml"
+    config_path.write_text(
+        """
+app:
+  environment: local
+  timezone: Asia/Seoul
+  mode: backtest
+market_data:
+  provider: mock
+  symbols:
+    - BTCUSDT
+risk:
+  max_position: 1.0
+  max_notional: 100000.0
+  max_order_size: 0.25
+backtest:
+  starting_cash: 10000.0
+  fee_bps: 1001
+  trade_quantity: 0.1
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SettingsValidationError, match="backtest.fee_bps"):
+        load_settings(config_path)


### PR DESCRIPTION
### Motivation
- Unify configuration shape with `configs/base.yaml` and examples by providing top-level models for `app`, `market_data`, `risk`, and `backtest` sections. 
- Treat monetary/quantity/fee values as `Decimal` to avoid floating-point rounding issues in backtests and risk checks. 
- Provide clear, user-friendly validation errors for missing keys, invalid types, and out-of-range values so operator errors surface early.

### Description
- Add typed dataclass models `AppSettings`, `MarketDataSettings`, `RiskSettings`, `BacktestSettings` and a root `Settings` container in `src/trading_system/config/settings.py` and implement a YAML loader `load_settings(path)` that parses and validates the schema. 
- Convert numeric amounts/quantities/fees to `Decimal` and enforce basic range rules (e.g. `starting_cash > 0`, `fee_bps` in `0..1000`, `trade_quantity > 0`) and cross-field rule `risk.max_order_size <= risk.max_position`. 
- Implement detailed validation helpers that raise `SettingsValidationError` with friendly messages for missing keys, wrong types, or out-of-range values. 
- Export the new API from `trading_system.config` and sync `examples/sample_backtest.yaml` and `README.md` to the new schema. 
- Add unit tests `tests/unit/test_config_settings.py` covering the happy path and three failure cases, and declare `PyYAML` in `pyproject.toml` for YAML parsing.

### Testing
- Ran `pytest tests/unit/test_config_settings.py` which passed (4 tests). 
- Ran the full test suite with `pytest` which passed (15 tests total). 
- Ran static checks with `ruff check src tests` which passed with no reported errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b36cff95a883338bb8e1dbc298b64e)