### PR TITLE
Add structured boundary observability, resilience primitives, and incident runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ PYTHONPATH=src python -m trading_system.backtest.example
 - `TRADING_SYSTEM_ENV`: logical runtime environment name (for example `local`, `staging`, `prod`).
 - `TRADING_SYSTEM_TIMEZONE`: operator timezone used for runtime context (for example `Asia/Seoul`).
 
+- `TRADING_SYSTEM_API_KEY`: live execution adapter credential injected from environment/secret manager only.
+
 
 ## Configuration schema
 
@@ -110,3 +112,11 @@ It runs a small single-symbol bar sequence through the v1 backtest loop with:
 - close-price immediate fills
 - fee-aware cash updates
 - a printed equity curve and return summary
+
+
+## Operations baseline
+
+- Boundary layers (`app`, `data`, `execution`) emit structured logs with a propagated `correlation_id`.
+- Key events use fixed schema names: `order.created`, `order.rejected`, `order.filled`, `risk.rejected`, `exception`.
+- Retry/timeout/circuit-breaker policies are applied only at external I/O boundaries.
+- Runbook for outage response: `docs/runbooks/incident-response.md`.

--- a/docs/runbooks/incident-response.md
+++ b/docs/runbooks/incident-response.md
@@ -1,0 +1,50 @@
+# Incident runbook
+
+## Scope
+
+운영 경계 계층(`app`, `data`, `execution`)에서 발생하는 장애를 빠르게 분류하고 복구한다.
+모든 로그는 구조화 포맷(JSON 또는 key-value)과 `correlation_id`를 포함한다.
+
+## 공통 점검 절차
+
+1. `correlation_id` 기준으로 `order.created`, `order.rejected`, `order.filled`, `risk.rejected`, `exception` 이벤트를 시간순으로 조회한다.
+2. 민감정보(`api_key`, `token`, `password`, `secret`)가 로그에 마스킹(`***`)되었는지 확인한다.
+3. 외부 I/O 경계(`data` 공급자, `execution` 브로커 어댑터)의 재시도/타임아웃/서킷브레이커 상태를 확인한다.
+
+## 시나리오 A: 데이터 끊김(data disconnect)
+
+증상:
+- `data.load.success` 이벤트가 중단됨
+- `exception` 이벤트에서 파일/네트워크 I/O 오류 증가
+
+대응:
+1. 데이터 소스 접근성 확인(파일 경로, 네트워크, 권한).
+2. 서킷브레이커 열림 여부 확인. 열려 있으면 `reset_timeout_seconds` 경과 후 재시도.
+3. 장애 구간을 건너뛰지 말고 재수집 후 재실행(결정론 보존).
+
+## 시나리오 B: 주문 실패(order failure)
+
+증상:
+- `order.rejected` 급증
+- `order.filled` 감소
+
+대응:
+1. `reason=risk_limits` 인지 `reason=unfilled` 인지 구분.
+2. `risk.rejected` 이벤트의 `requested_quantity/current_position/price`를 검토해 제한값 재검증.
+3. 브로커 경계의 재시도 횟수와 타임아웃을 확인해 중복 주문이 없는지 점검.
+
+## 시나리오 C: 시계열 지연(time-series lag)
+
+증상:
+- 바 타임스탬프와 처리 시각의 차이가 증가
+- 전략 평가 주기 누락
+
+대응:
+1. 지연 구간의 원본 데이터 타임존/포맷 검증(UTC, DST 변환 확인).
+2. 지연 원인이 데이터 경계인지 실행 경계인지 분리.
+3. 지연 허용 임계치 초과 시 주문 생성 중단 후 알림, 데이터 정상화 후 재개.
+
+## 시크릿 운영 원칙
+
+- API 키는 `TRADING_SYSTEM_API_KEY` 같은 환경변수 또는 시크릿 매니저에서만 주입한다.
+- 코드 저장소, 설정 파일, 로그, 티켓에 시크릿을 남기지 않는다.

--- a/src/trading_system/app/services.py
+++ b/src/trading_system/app/services.py
@@ -3,17 +3,25 @@ from dataclasses import dataclass
 from trading_system.app.sample_data import build_sample_bars
 from trading_system.app.settings import AppMode, AppSettings
 from trading_system.backtest.engine import BacktestContext, BacktestResult, run_backtest
+from trading_system.core.ops import (
+    EnvSecretProvider,
+    StructuredLogFormat,
+    StructuredLogger,
+    correlation_scope,
+    ensure_logging,
+)
 from trading_system.data.provider import InMemoryMarketDataProvider, MarketDataProvider
-from trading_system.portfolio.book import PortfolioBook
-from trading_system.risk.limits import RiskLimits
-from trading_system.strategy.base import Strategy
-from trading_system.strategy.example import MomentumStrategy
 from trading_system.execution.broker import (
     BpsCommissionPolicy,
     BpsSlippagePolicy,
     FixedRatioFillPolicy,
     PolicyBrokerSimulator,
+    ResilientBroker,
 )
+from trading_system.portfolio.book import PortfolioBook
+from trading_system.risk.limits import RiskLimits
+from trading_system.strategy.base import Strategy
+from trading_system.strategy.example import MomentumStrategy
 
 
 @dataclass(slots=True)
@@ -22,22 +30,25 @@ class AppServices:
     strategy: Strategy
     data_provider: MarketDataProvider
     risk_limits: RiskLimits
-    broker_simulator: PolicyBrokerSimulator
+    broker_simulator: ResilientBroker
     portfolio: PortfolioBook
     symbols: tuple[str, ...]
+    logger: StructuredLogger
 
     def run(self) -> BacktestResult:
         if self.mode != AppMode.BACKTEST:
             raise RuntimeError(f"Unsupported mode '{self.mode}'.")
 
         symbol = self._single_symbol()
-        bars = self.data_provider.load_bars(symbol)
-        context = BacktestContext(
-            portfolio=self.portfolio,
-            risk_limits=self.risk_limits,
-            broker=self.broker_simulator,
-        )
-        return run_backtest(bars=bars, strategy=self.strategy, context=context)
+        with correlation_scope():
+            bars = self.data_provider.load_bars(symbol)
+            context = BacktestContext(
+                portfolio=self.portfolio,
+                risk_limits=self.risk_limits,
+                broker=self.broker_simulator,
+                logger=self.logger,
+            )
+            return run_backtest(bars=bars, strategy=self.strategy, context=context)
 
     def _single_symbol(self) -> str:
         if len(self.symbols) != 1:
@@ -49,6 +60,10 @@ def build_services(settings: AppSettings) -> AppServices:
     if settings.mode != AppMode.BACKTEST:
         raise RuntimeError(f"Mode '{settings.mode}' is not implemented yet.")
 
+    ensure_logging()
+    logger = StructuredLogger("trading_system", log_format=StructuredLogFormat.JSON)
+    _load_live_api_key_if_present()
+
     bars_by_symbol = {symbol: build_sample_bars(symbol=symbol) for symbol in settings.symbols}
     return AppServices(
         mode=settings.mode,
@@ -59,11 +74,22 @@ def build_services(settings: AppSettings) -> AppServices:
             max_notional=settings.risk.max_notional,
             max_order_size=settings.risk.max_order_size,
         ),
-        broker_simulator=PolicyBrokerSimulator(
-            fill_quantity_policy=FixedRatioFillPolicy(),
-            slippage_policy=BpsSlippagePolicy(),
-            commission_policy=BpsCommissionPolicy(bps=settings.backtest.fee_bps),
+        broker_simulator=ResilientBroker(
+            delegate=PolicyBrokerSimulator(
+                fill_quantity_policy=FixedRatioFillPolicy(),
+                slippage_policy=BpsSlippagePolicy(),
+                commission_policy=BpsCommissionPolicy(bps=settings.backtest.fee_bps),
+            )
         ),
         portfolio=PortfolioBook(cash=settings.backtest.starting_cash),
         symbols=settings.symbols,
+        logger=logger,
     )
+
+
+def _load_live_api_key_if_present() -> None:
+    provider = EnvSecretProvider()
+    try:
+        provider.get_secret("TRADING_SYSTEM_API_KEY")
+    except RuntimeError:
+        return

--- a/src/trading_system/backtest/engine.py
+++ b/src/trading_system/backtest/engine.py
@@ -3,6 +3,15 @@ from dataclasses import dataclass
 from decimal import Decimal
 
 from trading_system.analytics.metrics import cumulative_return
+from trading_system.core.ops import (
+    ExceptionEvent,
+    OrderCreatedEvent,
+    OrderFilledEvent,
+    OrderRejectedEvent,
+    RiskRejectedEvent,
+    StructuredLogger,
+    event_payload,
+)
 from trading_system.core.types import MarketBar
 from trading_system.execution.adapters import signal_to_order_request
 from trading_system.execution.broker import BrokerSimulator
@@ -17,6 +26,7 @@ class BacktestContext:
     portfolio: PortfolioBook
     risk_limits: RiskLimits
     broker: BrokerSimulator
+    logger: StructuredLogger | None = None
 
 
 @dataclass(slots=True)
@@ -44,22 +54,19 @@ def run_backtest(
 
     for bar in bars:
         processed_bars += 1
-        signal = strategy.evaluate(bar)
-        order = signal_to_order_request(bar.symbol, signal)
-
-        if order is not None:
-            signed_quantity = order.quantity if order.side == OrderSide.BUY else -order.quantity
-            current_position = context.portfolio.positions.get(bar.symbol, Decimal("0"))
-            if context.risk_limits.allows_order(current_position, signed_quantity, bar.close):
-                fill = context.broker.submit_order(order, bar)
-                if fill.filled_quantity > 0:
-                    context.portfolio.apply_fill(fill.symbol, fill.signed_quantity, fill.fill_price)
-                    context.portfolio.cash -= fill.fee
-                    executed_trades += 1
-            else:
-                rejected_signals += 1
-
-        equity_curve.append(_equity_for_symbol(context.portfolio, bar.symbol, bar.close))
+        try:
+            signal = strategy.evaluate(bar)
+            order = signal_to_order_request(bar.symbol, signal)
+            if order is not None:
+                _log_order_created(context, order.symbol, order.side.value, order.quantity)
+                if _order_allowed(context, bar.symbol, bar.close, order.side, order.quantity):
+                    executed_trades += _apply_fill(context, order, bar)
+                else:
+                    rejected_signals += 1
+            equity_curve.append(_equity_for_symbol(context.portfolio, bar.symbol, bar.close))
+        except (RuntimeError, ValueError) as exc:
+            _log_exception(context, exc)
+            raise
 
     return BacktestResult(
         final_portfolio=context.portfolio,
@@ -68,6 +75,119 @@ def run_backtest(
         executed_trades=executed_trades,
         rejected_signals=rejected_signals,
     )
+
+
+def _order_allowed(
+    context: BacktestContext,
+    symbol: str,
+    price: Decimal,
+    side: OrderSide,
+    quantity: Decimal,
+) -> bool:
+    signed_quantity = quantity if side == OrderSide.BUY else -quantity
+    current_position = context.portfolio.positions.get(symbol, Decimal("0"))
+    allowed = context.risk_limits.allows_order(current_position, signed_quantity, price)
+    if allowed:
+        return True
+
+    _log_risk_rejected(context, symbol, signed_quantity, current_position, price)
+    _log_order_rejected(context, symbol, side.value, quantity, "risk_limits")
+    return False
+
+
+def _apply_fill(context: BacktestContext, order, bar: MarketBar) -> int:
+    fill = context.broker.submit_order(order, bar)
+    if fill.filled_quantity <= 0:
+        _log_order_rejected(context, order.symbol, order.side.value, order.quantity, "unfilled")
+        return 0
+
+    context.portfolio.apply_fill(fill.symbol, fill.signed_quantity, fill.fill_price)
+    context.portfolio.cash -= fill.fee
+    _log_order_filled(
+        context,
+        fill.symbol,
+        fill.side.value,
+        fill.requested_quantity,
+        fill.filled_quantity,
+        fill.fill_price,
+        fill.fee,
+        fill.status.value,
+    )
+    return 1
+
+
+def _log_order_created(context: BacktestContext, symbol: str, side: str, quantity: Decimal) -> None:
+    _emit(context, "order.created", event_payload(OrderCreatedEvent(symbol, side, quantity)))
+
+
+def _log_order_rejected(
+    context: BacktestContext,
+    symbol: str,
+    side: str,
+    quantity: Decimal,
+    reason: str,
+) -> None:
+    _emit(
+        context,
+        "order.rejected",
+        event_payload(OrderRejectedEvent(symbol, side, quantity, reason)),
+    )
+
+
+def _log_order_filled(
+    context: BacktestContext,
+    symbol: str,
+    side: str,
+    requested_quantity: Decimal,
+    filled_quantity: Decimal,
+    fill_price: Decimal,
+    fee: Decimal,
+    status: str,
+) -> None:
+    _emit(
+        context,
+        "order.filled",
+        event_payload(
+            OrderFilledEvent(
+                symbol,
+                side,
+                requested_quantity,
+                filled_quantity,
+                fill_price,
+                fee,
+                status,
+            )
+        ),
+    )
+
+
+def _log_risk_rejected(
+    context: BacktestContext,
+    symbol: str,
+    requested_quantity: Decimal,
+    current_position: Decimal,
+    price: Decimal,
+) -> None:
+    _emit(
+        context,
+        "risk.rejected",
+        event_payload(RiskRejectedEvent(symbol, requested_quantity, current_position, price)),
+    )
+
+
+def _log_exception(context: BacktestContext, error: Exception) -> None:
+    _emit(context, "exception", event_payload(ExceptionEvent(type(error).__name__, str(error))), 40)
+
+
+def _emit(
+    context: BacktestContext,
+    event: str,
+    payload: dict[str, object],
+    severity: int = 20,
+) -> None:
+    if context.logger is None:
+        return
+    context.logger.emit(event, severity=severity, payload=payload)
 
 
 def _equity_for_symbol(portfolio: PortfolioBook, symbol: str, mark_price: Decimal) -> Decimal:

--- a/src/trading_system/core/ops.py
+++ b/src/trading_system/core/ops.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import StrEnum
+from typing import Any, Protocol
+
+_CORRELATION_ID: ContextVar[str | None] = ContextVar("correlation_id", default=None)
+_SENSITIVE_KEYWORDS = ("secret", "token", "password", "api_key", "apikey")
+
+
+class StructuredLogFormat(StrEnum):
+    JSON = "json"
+    KEY_VALUE = "key_value"
+
+
+@dataclass(slots=True)
+class RetryPolicy:
+    max_attempts: int = 3
+    backoff_seconds: float = 0.01
+
+
+@dataclass(slots=True)
+class TimeoutPolicy:
+    timeout_seconds: float = 1.0
+
+
+@dataclass(slots=True)
+class CircuitBreakerPolicy:
+    failure_threshold: int = 3
+    reset_timeout_seconds: float = 5.0
+
+
+class SecretProvider(Protocol):
+    def get_secret(self, name: str) -> str:
+        """Load one secret value from a protected source."""
+
+
+class EnvSecretProvider:
+    def get_secret(self, name: str) -> str:
+        value = os.getenv(name)
+        if value is None or not value.strip():
+            raise RuntimeError(f"Missing required secret: {name}")
+        return value
+
+
+@dataclass(slots=True)
+class EventRecord:
+    event: str
+    severity: str
+    correlation_id: str
+    timestamp: str
+    payload: dict[str, Any]
+
+
+@dataclass(slots=True)
+class OrderCreatedEvent:
+    symbol: str
+    side: str
+    quantity: Decimal
+
+
+@dataclass(slots=True)
+class OrderRejectedEvent:
+    symbol: str
+    side: str
+    quantity: Decimal
+    reason: str
+
+
+@dataclass(slots=True)
+class OrderFilledEvent:
+    symbol: str
+    side: str
+    requested_quantity: Decimal
+    filled_quantity: Decimal
+    fill_price: Decimal
+    fee: Decimal
+    status: str
+
+
+@dataclass(slots=True)
+class RiskRejectedEvent:
+    symbol: str
+    requested_quantity: Decimal
+    current_position: Decimal
+    price: Decimal
+
+
+@dataclass(slots=True)
+class ExceptionEvent:
+    error_type: str
+    message: str
+
+
+class StructuredLogger:
+    def __init__(
+        self,
+        name: str,
+        log_format: StructuredLogFormat = StructuredLogFormat.JSON,
+    ) -> None:
+        self._logger = logging.getLogger(name)
+        self._format = log_format
+
+    def emit(self, event: str, severity: int, payload: dict[str, Any]) -> None:
+        correlation_id = get_or_create_correlation_id()
+        record = EventRecord(
+            event=event,
+            severity=logging.getLevelName(severity),
+            correlation_id=correlation_id,
+            timestamp=datetime.now(tz=UTC).isoformat(),
+            payload=redact_payload(payload),
+        )
+        self._logger.log(severity, self._serialize(record))
+
+    def _serialize(self, record: EventRecord) -> str:
+        if self._format == StructuredLogFormat.KEY_VALUE:
+            parts = [
+                f"event={record.event}",
+                f"severity={record.severity}",
+                f"correlation_id={record.correlation_id}",
+                f"timestamp={record.timestamp}",
+            ]
+            for key, value in sorted(record.payload.items()):
+                parts.append(f"{key}={value}")
+            return " ".join(parts)
+
+        return json.dumps(
+            {
+                "event": record.event,
+                "severity": record.severity,
+                "correlation_id": record.correlation_id,
+                "timestamp": record.timestamp,
+                "payload": record.payload,
+            },
+            default=str,
+            sort_keys=True,
+        )
+
+
+@dataclass(slots=True)
+class CircuitBreakerState:
+    failures: int = 0
+    opened_at: float | None = None
+
+    def can_execute(self, policy: CircuitBreakerPolicy, now: float) -> bool:
+        if self.opened_at is None:
+            return True
+        if now - self.opened_at >= policy.reset_timeout_seconds:
+            self.failures = 0
+            self.opened_at = None
+            return True
+        return False
+
+    def on_success(self) -> None:
+        self.failures = 0
+        self.opened_at = None
+
+    def on_failure(self, policy: CircuitBreakerPolicy, now: float) -> None:
+        self.failures += 1
+        if self.failures >= policy.failure_threshold:
+            self.opened_at = now
+
+
+def ensure_logging() -> None:
+    root = logging.getLogger()
+    if root.handlers:
+        return
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+def get_or_create_correlation_id() -> str:
+    existing = _CORRELATION_ID.get()
+    if existing is not None:
+        return existing
+    generated = uuid.uuid4().hex
+    _CORRELATION_ID.set(generated)
+    return generated
+
+
+@contextmanager
+def correlation_scope(correlation_id: str | None = None):
+    token = _CORRELATION_ID.set(correlation_id or uuid.uuid4().hex)
+    try:
+        yield _CORRELATION_ID.get()
+    finally:
+        _CORRELATION_ID.reset(token)
+
+
+def redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    safe_payload: dict[str, Any] = {}
+    for key, value in payload.items():
+        normalized = key.lower()
+        if any(secret_key in normalized for secret_key in _SENSITIVE_KEYWORDS):
+            safe_payload[key] = "***"
+        else:
+            safe_payload[key] = value
+    return safe_payload
+
+
+def event_payload(event: Any) -> dict[str, Any]:
+    return asdict(event)
+
+
+def execute_with_resilience(
+    operation: str,
+    callback,
+    *,
+    retry: RetryPolicy,
+    timeout: TimeoutPolicy,
+    circuit_breaker: CircuitBreakerPolicy,
+    circuit_state: CircuitBreakerState,
+) -> Any:
+    now = time.monotonic()
+    if not circuit_state.can_execute(circuit_breaker, now):
+        raise RuntimeError(f"Circuit breaker open for operation '{operation}'.")
+
+    for attempt in range(1, retry.max_attempts + 1):
+        started_at = time.monotonic()
+        try:
+            result = callback()
+            elapsed = time.monotonic() - started_at
+            if elapsed > timeout.timeout_seconds:
+                raise TimeoutError(
+                    f"Operation '{operation}' exceeded timeout {timeout.timeout_seconds}s."
+                )
+            circuit_state.on_success()
+            return result
+        except (TimeoutError, OSError, ValueError) as exc:
+            circuit_state.on_failure(circuit_breaker, time.monotonic())
+            if attempt == retry.max_attempts:
+                raise RuntimeError(
+                    f"Operation '{operation}' failed after {retry.max_attempts} attempts."
+                ) from exc
+            time.sleep(retry.backoff_seconds)

--- a/src/trading_system/data/__init__.py
+++ b/src/trading_system/data/__init__.py
@@ -1,5 +1,9 @@
 """Market data contracts."""
 
-from trading_system.data.provider import CsvMarketDataProvider, InMemoryMarketDataProvider, MarketDataProvider
+from trading_system.data.provider import (
+    CsvMarketDataProvider,
+    InMemoryMarketDataProvider,
+    MarketDataProvider,
+)
 
 __all__ = ["CsvMarketDataProvider", "InMemoryMarketDataProvider", "MarketDataProvider"]

--- a/src/trading_system/data/provider.py
+++ b/src/trading_system/data/provider.py
@@ -1,11 +1,19 @@
 from collections.abc import Iterable
 from csv import DictReader
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
 from typing import Protocol
 
+from trading_system.core.ops import (
+    CircuitBreakerPolicy,
+    CircuitBreakerState,
+    RetryPolicy,
+    StructuredLogger,
+    TimeoutPolicy,
+    execute_with_resilience,
+)
 from trading_system.core.types import MarketBar
 
 
@@ -25,19 +33,42 @@ class InMemoryMarketDataProvider:
 @dataclass(slots=True)
 class CsvMarketDataProvider:
     csv_by_symbol: dict[str, Path]
+    retry_policy: RetryPolicy = field(default_factory=RetryPolicy)
+    timeout_policy: TimeoutPolicy = field(default_factory=TimeoutPolicy)
+    circuit_breaker_policy: CircuitBreakerPolicy = field(default_factory=CircuitBreakerPolicy)
+    logger: StructuredLogger | None = None
+    _circuit_state: CircuitBreakerState = field(default_factory=CircuitBreakerState, init=False)
 
     def load_bars(self, symbol: str) -> Iterable[MarketBar]:
         csv_path = self.csv_by_symbol.get(symbol)
         if csv_path is None:
             return []
 
+        rows = execute_with_resilience(
+            operation=f"csv_load:{symbol}",
+            callback=lambda: self._load_rows(symbol, csv_path),
+            retry=self.retry_policy,
+            timeout=self.timeout_policy,
+            circuit_breaker=self.circuit_breaker_policy,
+            circuit_state=self._circuit_state,
+        )
+        if self.logger is not None:
+            self.logger.emit(
+                "data.load.success",
+                severity=20,
+                payload={"symbol": symbol, "rows": len(rows), "path": str(csv_path)},
+            )
+        return rows
+
+    def _load_rows(self, symbol: str, csv_path: Path) -> list[MarketBar]:
         with csv_path.open("r", encoding="utf-8", newline="") as handle:
             reader = DictReader(handle)
-            return [self._row_to_bar(symbol, row) for row in reader]
+            return [self._row_to_bar(symbol=symbol, row=row) for row in reader]
 
     def _row_to_bar(self, symbol: str, row: dict[str, str]) -> MarketBar:
+        resolved_symbol = symbol or row.get("symbol", "UNKNOWN")
         return MarketBar(
-            symbol=symbol,
+            symbol=resolved_symbol,
             timestamp=datetime.fromisoformat(row["timestamp"]),
             open=Decimal(row["open"]),
             high=Decimal(row["high"]),

--- a/src/trading_system/execution/__init__.py
+++ b/src/trading_system/execution/__init__.py
@@ -9,6 +9,7 @@ from trading_system.execution.broker import (
     FillStatus,
     FixedRatioFillPolicy,
     PolicyBrokerSimulator,
+    ResilientBroker,
 )
 from trading_system.execution.orders import OrderRequest, OrderSide
 
@@ -22,5 +23,6 @@ __all__ = [
     "OrderRequest",
     "OrderSide",
     "PolicyBrokerSimulator",
+    "ResilientBroker",
     "signal_to_order_request",
 ]

--- a/src/trading_system/execution/broker.py
+++ b/src/trading_system/execution/broker.py
@@ -1,8 +1,15 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from decimal import Decimal
 from enum import StrEnum
 from typing import Protocol
 
+from trading_system.core.ops import (
+    CircuitBreakerPolicy,
+    CircuitBreakerState,
+    RetryPolicy,
+    TimeoutPolicy,
+    execute_with_resilience,
+)
 from trading_system.core.types import MarketBar
 from trading_system.execution.orders import OrderRequest, OrderSide
 
@@ -39,7 +46,12 @@ class SlippagePolicy(Protocol):
 
 
 class CommissionPolicy(Protocol):
-    def calculate_fee(self, order: OrderRequest, fill_quantity: Decimal, fill_price: Decimal) -> Decimal:
+    def calculate_fee(
+        self,
+        order: OrderRequest,
+        fill_quantity: Decimal,
+        fill_price: Decimal,
+    ) -> Decimal:
         """Return absolute fee for the fill."""
 
 
@@ -67,7 +79,12 @@ class BpsSlippagePolicy:
 class BpsCommissionPolicy:
     bps: Decimal = Decimal("0")
 
-    def calculate_fee(self, order: OrderRequest, fill_quantity: Decimal, fill_price: Decimal) -> Decimal:
+    def calculate_fee(
+        self,
+        order: OrderRequest,
+        fill_quantity: Decimal,
+        fill_price: Decimal,
+    ) -> Decimal:
         del order
         return abs(fill_quantity * fill_price) * self.bps / Decimal("10000")
 
@@ -98,7 +115,11 @@ class PolicyBrokerSimulator:
 
         fill_price = self.slippage_policy.fill_price(order, bar)
         fee = self.commission_policy.calculate_fee(order, filled_quantity, fill_price)
-        status = FillStatus.FILLED if filled_quantity == order.quantity else FillStatus.PARTIALLY_FILLED
+        status = (
+            FillStatus.FILLED
+            if filled_quantity == order.quantity
+            else FillStatus.PARTIALLY_FILLED
+        )
         return FillEvent(
             symbol=order.symbol,
             side=order.side,
@@ -107,4 +128,23 @@ class PolicyBrokerSimulator:
             fill_price=fill_price,
             fee=fee,
             status=status,
+        )
+
+
+@dataclass(slots=True)
+class ResilientBroker:
+    delegate: BrokerSimulator
+    retry_policy: RetryPolicy = field(default_factory=RetryPolicy)
+    timeout_policy: TimeoutPolicy = field(default_factory=TimeoutPolicy)
+    circuit_breaker_policy: CircuitBreakerPolicy = field(default_factory=CircuitBreakerPolicy)
+    _circuit_state: CircuitBreakerState = field(default_factory=CircuitBreakerState, init=False)
+
+    def submit_order(self, order: OrderRequest, bar: MarketBar) -> FillEvent:
+        return execute_with_resilience(
+            operation=f"broker_submit:{order.symbol}",
+            callback=lambda: self.delegate.submit_order(order, bar),
+            retry=self.retry_policy,
+            timeout=self.timeout_policy,
+            circuit_breaker=self.circuit_breaker_policy,
+            circuit_state=self._circuit_state,
         )

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -1,9 +1,12 @@
+import json
+import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 
 from trading_system.backtest.engine import BacktestContext, run_backtest
+from trading_system.core.ops import StructuredLogFormat, StructuredLogger
 from trading_system.core.types import MarketBar
 from trading_system.execution.broker import (
     BpsCommissionPolicy,
@@ -121,7 +124,9 @@ def test_run_backtest_supports_partial_fill_and_unfilled_order() -> None:
     )
     partial_result = run_backtest(
         _bars([Decimal("100")]),
-        StubStrategy([StrategySignal(side=SignalSide.BUY, quantity=Decimal("2"), reason="partial")]),
+        StubStrategy(
+            [StrategySignal(side=SignalSide.BUY, quantity=Decimal("2"), reason="partial")]
+        ),
         partial_context,
     )
 
@@ -136,7 +141,9 @@ def test_run_backtest_supports_partial_fill_and_unfilled_order() -> None:
     )
     unfilled_result = run_backtest(
         _bars([Decimal("100")]),
-        StubStrategy([StrategySignal(side=SignalSide.BUY, quantity=Decimal("2"), reason="no_fill")]),
+        StubStrategy(
+            [StrategySignal(side=SignalSide.BUY, quantity=Decimal("2"), reason="no_fill")]
+        ),
         unfilled_context,
     )
 
@@ -159,6 +166,30 @@ def test_run_backtest_applies_slippage_to_fill_price() -> None:
 
     assert result.final_portfolio.cash == Decimal("899")
     assert result.equity_curve == [Decimal("999")]
+
+
+def test_run_backtest_emits_order_and_risk_events(caplog) -> None:
+    context = BacktestContext(
+        portfolio=PortfolioBook(cash=Decimal("1000")),
+        risk_limits=RiskLimits(
+            max_position=Decimal("1"),
+            max_notional=Decimal("100000"),
+            max_order_size=Decimal("0.5"),
+        ),
+        broker=_broker(),
+        logger=StructuredLogger("trading_system.backtest.tests", StructuredLogFormat.JSON),
+    )
+    strategy = StubStrategy(
+        [StrategySignal(side=SignalSide.BUY, quantity=Decimal("1"), reason="too_big")]
+    )
+
+    with caplog.at_level(logging.INFO):
+        run_backtest(_bars([Decimal("100")]), strategy, context)
+
+    events = [json.loads(record.message)["event"] for record in caplog.records]
+    assert "order.created" in events
+    assert "risk.rejected" in events
+    assert "order.rejected" in events
 
 
 def _limits() -> RiskLimits:

--- a/tests/unit/test_core_ops.py
+++ b/tests/unit/test_core_ops.py
@@ -1,0 +1,73 @@
+import json
+import logging
+from decimal import Decimal
+
+import pytest
+
+from trading_system.core.ops import (
+    CircuitBreakerPolicy,
+    CircuitBreakerState,
+    OrderCreatedEvent,
+    RetryPolicy,
+    StructuredLogFormat,
+    StructuredLogger,
+    TimeoutPolicy,
+    correlation_scope,
+    event_payload,
+    execute_with_resilience,
+    redact_payload,
+)
+
+
+def test_redact_payload_masks_sensitive_fields() -> None:
+    payload = {"api_key": "abc", "token_value": "def", "symbol": "BTCUSDT"}
+
+    redacted = redact_payload(payload)
+
+    assert redacted["api_key"] == "***"
+    assert redacted["token_value"] == "***"
+    assert redacted["symbol"] == "BTCUSDT"
+
+
+def test_structured_logger_emits_json_with_correlation_id(caplog) -> None:
+    logger = StructuredLogger("trading_system.tests", log_format=StructuredLogFormat.JSON)
+
+    with correlation_scope("corr-123"):
+        with caplog.at_level(logging.INFO):
+            logger.emit(
+                "order.created",
+                logging.INFO,
+                event_payload(OrderCreatedEvent("BTCUSDT", "buy", Decimal("1"))),
+            )
+
+    message = caplog.records[-1].message
+    body = json.loads(message)
+    assert body["correlation_id"] == "corr-123"
+    assert body["event"] == "order.created"
+
+
+def test_execute_with_resilience_opens_circuit_breaker_after_failures() -> None:
+    state = CircuitBreakerState()
+    retry = RetryPolicy(max_attempts=1, backoff_seconds=0)
+    timeout = TimeoutPolicy(timeout_seconds=1)
+    breaker = CircuitBreakerPolicy(failure_threshold=1, reset_timeout_seconds=10)
+
+    with pytest.raises(RuntimeError):
+        execute_with_resilience(
+            operation="io-call",
+            callback=lambda: (_ for _ in ()).throw(ValueError("boom")),
+            retry=retry,
+            timeout=timeout,
+            circuit_breaker=breaker,
+            circuit_state=state,
+        )
+
+    with pytest.raises(RuntimeError, match="Circuit breaker open"):
+        execute_with_resilience(
+            operation="io-call",
+            callback=lambda: "ok",
+            retry=retry,
+            timeout=timeout,
+            circuit_breaker=breaker,
+            circuit_state=state,
+        )


### PR DESCRIPTION
### Motivation
- Provide consistent operational primitives at boundary layers (`app`, `data`, `execution`) so incidents are traceable and secrets are never leaked.  
- Apply retry/timeout/circuit-breaker only at external I/O boundaries to keep domain/backtest logic deterministic.  
- Surface a small, auditable event schema for key lifecycle events (order creation/rejection/fill, risk rejects, exceptions) to standardize logging and triage.  
- Capture runbook guidance in-repo so operators have a first-response checklist for common failure modes.

### Description
- Added a shared operations module `src/trading_system/core/ops.py` implementing structured logging (JSON/key-value), correlation-id propagation (`correlation_scope`), payload redaction for sensitive keys, event dataclasses, and resilience primitives (`RetryPolicy`, `TimeoutPolicy`, `CircuitBreakerPolicy`, `execute_with_resilience`).
- Instrumented the backtest orchestration in `src/trading_system/backtest/engine.py` to emit structured events for `order.created`, `order.rejected`, `order.filled`, `risk.rejected`, and `exception`, and to propagate a logger via `BacktestContext`.
- Applied resilience at adapters only: `CsvMarketDataProvider` now wraps CSV loads with `execute_with_resilience` and optional `data.load.success` logging, and `ResilientBroker` (new wrapper in `src/trading_system/execution/broker.py`) applies retry/timeout/circuit-breaker around broker submits.
- Updated application wiring in `src/trading_system/app/services.py` to initialize `StructuredLogger`, run the backtest inside a `correlation_scope()`, and load live credentials only from environment via `EnvSecretProvider` (no secrets in code or logs).
- Added operational documentation `docs/runbooks/incident-response.md` and updated `README.md` with the operations baseline and `TRADING_SYSTEM_API_KEY` guidance.
- Tests and small test updates: added `tests/unit/test_core_ops.py` (redaction, structured logger, circuit-breaker behavior) and extended `tests/unit/test_backtest_engine.py` to assert event emission; updated imports and small formatting fixes.

### Testing
- Ran targeted unit tests: `python -m pytest tests/unit/test_core_ops.py tests/unit/test_backtest_engine.py tests/unit/test_execution_adapters_and_broker.py tests/unit/test_data_provider.py tests/unit/test_app_main.py` which passed (`19 passed`).
- Ran style checks with `ruff check src tests` and fixed issues; final `ruff` run passed.
- Attempted full test run `python -m pytest` which failed at collection due to the environment missing the `PyYAML` dependency required by existing configuration tests (`ModuleNotFoundError: No module named 'yaml'`), so full CI should pass once `PyYAML` is available (it is declared in `pyproject.toml`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b371ffd0048333aacc885e017e4d93)