### PR TITLE
Add integration backtests, config loader tests, and CI smoke/extended split

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  smoke-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run smoke test set
+        run: pytest -m smoke -q
+
+  extended-tests:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'push' || github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Run extended test set
+        run: pytest -m "not smoke" -q

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ pytest
 
 ## Run commands
 
+### Test suites (CI split)
+
+- Fast smoke set: `pytest -m smoke -q`
+- Extended set: `pytest -m "not smoke" -q`
+
+The smoke set is intended for quick CI feedback. The extended set covers broader integration and failure-path scenarios.
+
+
 Backtest mode:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ where = ["src"]
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]
+markers = [
+  "smoke: fast CI smoke tests",
+  "extended: broader integration and failure-path tests",
+]
 
 [tool.ruff]
 line-length = 100

--- a/tests/integration/test_backtest_orchestration_integration.py
+++ b/tests/integration/test_backtest_orchestration_integration.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from trading_system.app.services import AppServices
+from trading_system.app.settings import AppMode
+from trading_system.core.ops import (
+    CircuitBreakerPolicy,
+    RetryPolicy,
+    StructuredLogFormat,
+    StructuredLogger,
+    TimeoutPolicy,
+)
+from trading_system.core.types import MarketBar
+from trading_system.data.provider import InMemoryMarketDataProvider
+from trading_system.execution.broker import (
+    BpsCommissionPolicy,
+    BpsSlippagePolicy,
+    FillEvent,
+    FillStatus,
+    FixedRatioFillPolicy,
+    PolicyBrokerSimulator,
+    ResilientBroker,
+)
+from trading_system.execution.orders import OrderRequest
+from trading_system.portfolio.book import PortfolioBook
+from trading_system.risk.limits import RiskLimits
+from trading_system.strategy.base import SignalSide, StrategySignal
+
+
+@dataclass(slots=True)
+class SequenceStrategy:
+    signals: list[StrategySignal]
+    name: str = "sequence"
+    _index: int = 0
+
+    def evaluate(self, bar: MarketBar) -> StrategySignal:
+        del bar
+        signal = self.signals[self._index]
+        self._index += 1
+        return signal
+
+
+@dataclass(slots=True)
+class FailingProvider:
+    error: Exception
+
+    def load_bars(self, symbol: str):
+        del symbol
+        raise self.error
+
+
+@dataclass(slots=True)
+class OSErrorBroker:
+    def submit_order(self, order: OrderRequest, bar: MarketBar) -> FillEvent:
+        del order, bar
+        raise OSError("broker transport unavailable")
+
+
+@dataclass(slots=True)
+class DelayedBroker:
+    delay_seconds: float
+
+    def submit_order(self, order: OrderRequest, bar: MarketBar) -> FillEvent:
+        time.sleep(self.delay_seconds)
+        return FillEvent(
+            symbol=order.symbol,
+            side=order.side,
+            requested_quantity=order.quantity,
+            filled_quantity=order.quantity,
+            fill_price=bar.close,
+            fee=Decimal("0"),
+            status=FillStatus.FILLED,
+        )
+
+
+@pytest.mark.smoke
+def test_backtest_orchestration_pipeline_happy_path_and_determinism() -> None:
+    result_a = _run_happy_path_backtest()
+    result_b = _run_happy_path_backtest()
+
+    assert result_a.processed_bars == 3
+    assert result_a.executed_trades == 2
+    assert result_a.rejected_signals == 0
+    assert result_a.final_portfolio.cash == Decimal("990")
+    assert result_a.final_portfolio.positions == {}
+    assert result_a.equity_curve == [Decimal("1000"), Decimal("1010"), Decimal("990")]
+    assert result_a.total_return == Decimal("-0.01")
+
+    assert _snapshot(result_a) == _snapshot(result_b)
+
+
+def test_backtest_orchestration_rejects_signal_when_risk_disallows_order() -> None:
+    services = _build_services(
+        strategy=SequenceStrategy(
+            signals=[StrategySignal(side=SignalSide.BUY, quantity=Decimal("2"), reason="entry")]
+        ),
+        risk_limits=RiskLimits(
+            max_position=Decimal("1"),
+            max_notional=Decimal("100000"),
+            max_order_size=Decimal("1"),
+        ),
+        bars=[_bar(Decimal("100"), 0)],
+    )
+
+    result = services.run()
+
+    assert result.executed_trades == 0
+    assert result.rejected_signals == 1
+    assert result.final_portfolio.cash == Decimal("1000")
+    assert result.final_portfolio.positions == {}
+
+
+@pytest.mark.extended
+def test_backtest_orchestration_propagates_provider_error() -> None:
+    services = AppServices(
+        mode=AppMode.BACKTEST,
+        strategy=SequenceStrategy([]),
+        data_provider=FailingProvider(ValueError("provider disconnected")),
+        risk_limits=RiskLimits(
+            max_position=Decimal("10"),
+            max_notional=Decimal("100000"),
+            max_order_size=Decimal("10"),
+        ),
+        broker_simulator=ResilientBroker(
+            delegate=PolicyBrokerSimulator(
+                fill_quantity_policy=FixedRatioFillPolicy(),
+                slippage_policy=BpsSlippagePolicy(),
+                commission_policy=BpsCommissionPolicy(),
+            )
+        ),
+        portfolio=PortfolioBook(cash=Decimal("1000")),
+        symbols=("BTCUSDT",),
+        logger=StructuredLogger("test", log_format=StructuredLogFormat.JSON),
+    )
+
+    with pytest.raises(ValueError, match="provider disconnected"):
+        services.run()
+
+
+@pytest.mark.extended
+@pytest.mark.parametrize(
+    ("delegate", "timeout_seconds", "cause_type"),
+    [
+        (OSErrorBroker(), 0.1, OSError),
+        (DelayedBroker(delay_seconds=0.01), 0.001, TimeoutError),
+    ],
+)
+def test_backtest_orchestration_fails_on_broker_errors(
+    delegate,
+    timeout_seconds: float,
+    cause_type: type[Exception],
+) -> None:
+    services = _build_services(
+        strategy=SequenceStrategy(
+            signals=[StrategySignal(side=SignalSide.BUY, quantity=Decimal("1"), reason="entry")]
+        ),
+        risk_limits=RiskLimits(
+            max_position=Decimal("10"),
+            max_notional=Decimal("100000"),
+            max_order_size=Decimal("10"),
+        ),
+        bars=[_bar(Decimal("100"), 0)],
+        broker=ResilientBroker(
+            delegate=delegate,
+            retry_policy=RetryPolicy(max_attempts=1, backoff_seconds=0),
+            timeout_policy=TimeoutPolicy(timeout_seconds=timeout_seconds),
+            circuit_breaker_policy=CircuitBreakerPolicy(
+                failure_threshold=1,
+                reset_timeout_seconds=1,
+            ),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="failed after 1 attempts") as exc_info:
+        services.run()
+
+    assert isinstance(exc_info.value.__cause__, cause_type)
+
+
+def _run_happy_path_backtest():
+    services = _build_services(
+        strategy=SequenceStrategy(
+            signals=[
+                StrategySignal(side=SignalSide.BUY, quantity=Decimal("1"), reason="entry"),
+                StrategySignal(side=SignalSide.HOLD, quantity=Decimal("0"), reason="hold"),
+                StrategySignal(side=SignalSide.SELL, quantity=Decimal("1"), reason="exit"),
+            ]
+        ),
+        risk_limits=RiskLimits(
+            max_position=Decimal("10"),
+            max_notional=Decimal("100000"),
+            max_order_size=Decimal("10"),
+        ),
+        bars=[_bar(Decimal("100"), 0), _bar(Decimal("110"), 1), _bar(Decimal("90"), 2)],
+    )
+    return services.run()
+
+
+def _build_services(
+    strategy: SequenceStrategy,
+    risk_limits: RiskLimits,
+    bars: list[MarketBar],
+    broker: ResilientBroker | None = None,
+) -> AppServices:
+    return AppServices(
+        mode=AppMode.BACKTEST,
+        strategy=strategy,
+        data_provider=InMemoryMarketDataProvider(bars_by_symbol={"BTCUSDT": bars}),
+        risk_limits=risk_limits,
+        broker_simulator=broker
+        or ResilientBroker(
+            delegate=PolicyBrokerSimulator(
+                fill_quantity_policy=FixedRatioFillPolicy(),
+                slippage_policy=BpsSlippagePolicy(),
+                commission_policy=BpsCommissionPolicy(),
+            )
+        ),
+        portfolio=PortfolioBook(cash=Decimal("1000")),
+        symbols=("BTCUSDT",),
+        logger=StructuredLogger("test", log_format=StructuredLogFormat.JSON),
+    )
+
+
+def _snapshot(result) -> tuple[Decimal, dict[str, Decimal], list[Decimal], Decimal]:
+    return (
+        result.final_portfolio.cash,
+        dict(result.final_portfolio.positions),
+        list(result.equity_curve),
+        result.total_return,
+    )
+
+
+def _bar(close: Decimal, minute: int) -> MarketBar:
+    return MarketBar(
+        symbol="BTCUSDT",
+        timestamp=datetime(2024, 1, 1, 0, minute, tzinfo=timezone.utc),
+        open=close,
+        high=close,
+        low=close,
+        close=close,
+        volume=Decimal("1"),
+    )

--- a/tests/integration/test_config_loader_integration.py
+++ b/tests/integration/test_config_loader_integration.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import pytest
+
+from trading_system.config.settings import SettingsValidationError, load_settings
+
+
+@pytest.mark.smoke
+def test_load_settings_fails_when_nested_schema_key_is_missing(tmp_path: Path) -> None:
+    config_path = tmp_path / "settings.yaml"
+    config_path.write_text(
+        """
+app:
+  environment: local
+  timezone: Asia/Seoul
+  mode: backtest
+market_data:
+  provider: mock
+  symbols:
+    - BTCUSDT
+risk:
+  max_position: 1.0
+  max_notional: 100000.0
+  max_order_size: 0.25
+backtest:
+  starting_cash: 10000.0
+  fee_bps: 5.0
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        SettingsValidationError,
+        match="Missing required key: 'backtest.trade_quantity'",
+    ):
+        load_settings(config_path)
+
+
+@pytest.mark.extended
+def test_load_settings_fails_when_nested_schema_type_is_invalid(tmp_path: Path) -> None:
+    config_path = tmp_path / "settings.yaml"
+    config_path.write_text(
+        """
+app:
+  environment: local
+  timezone: Asia/Seoul
+  mode: backtest
+market_data:
+  provider: mock
+  symbols:
+    - BTCUSDT
+risk:
+  max_position: 1.0
+  max_notional: 100000.0
+  max_order_size: 0.25
+backtest:
+  starting_cash: 10000.0
+  fee_bps: 5.0
+  trade_quantity:
+    amount: 0.1
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        SettingsValidationError,
+        match="Invalid type for 'backtest.trade_quantity'",
+    ):
+        load_settings(config_path)


### PR DESCRIPTION
### Motivation

- Provide deterministic integration coverage for the full backtest orchestration pipeline (data → strategy → risk → execution → portfolio → analytics). 
- Ensure critical failure paths are exercised (risk rejections, provider exceptions, broker transport failures and timeouts). 
- Separate a fast CI smoke set from a broader extended suite so quick feedback is available while retaining deeper checks.

### Description

- Added `tests/integration/test_backtest_orchestration_integration.py` with a happy-path backtest, a determinism snapshot test, and failure-path tests for risk rejection, provider exceptions, broker OSError, and broker timeout behavior. 
- Added `tests/integration/test_config_loader_integration.py` to validate YAML loader failures for a missing nested key and an invalid nested type. 
- Registered `smoke` and `extended` pytest markers in `pyproject.toml` and updated `README.md` with the smoke/extended test commands. 
- Added a GitHub Actions workflow `.github/workflows/tests.yml` that runs `pytest -m smoke -q` for fast feedback and `pytest -m "not smoke" -q` for the extended set.

### Testing

- Ran the new integration test set with `pytest tests/integration/test_backtest_orchestration_integration.py tests/integration/test_config_loader_integration.py -q` and observed all tests passing. 
- Verified the smoke suite with `pytest -m smoke -q` which passed (`2 passed, 39 deselected`). 
- Verified the extended set with `pytest -m "not smoke" -q` which passed (`39 passed, 2 deselected`). 
- Ran the full test suite with `pytest -q` which passed (`41 passed`). 
- Ran `ruff` checks on the new integration files which passed, and noted existing repo-wide `ruff` issues outside the change remain pre-existing and were intentionally left untouched.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b3845faa1c8333a5fa08f552d2f30c)