### PR TITLE
Add safe live preflight mode with API key enforcement; update CLI, services, tests, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,24 +47,22 @@ pytest
 - Fast smoke set: `pytest -m smoke -q`
 - Extended set: `pytest -m "not smoke" -q`
 
-The smoke set is intended for quick CI feedback. The extended set covers broader integration and failure-path scenarios.
-
-
-Backtest mode:
+### Backtest mode
 
 ```bash
 PYTHONPATH=src TRADING_SYSTEM_ENV=local TRADING_SYSTEM_TIMEZONE=Asia/Seoul \
 python -m trading_system.app.main --mode backtest --symbols BTCUSDT
 ```
 
-Operational (live placeholder) mode validation:
+### Live preflight mode (no order submission)
 
 ```bash
 PYTHONPATH=src TRADING_SYSTEM_ENV=local TRADING_SYSTEM_TIMEZONE=Asia/Seoul \
+TRADING_SYSTEM_API_KEY=dummy-key \
 python -m trading_system.app.main --mode live --symbols BTCUSDT
 ```
 
-The built-in smoke backtest module is still available and now routes through the app layer:
+The built-in smoke backtest module is still available and routes through the app layer:
 
 ```bash
 PYTHONPATH=src python -m trading_system.backtest.example
@@ -74,9 +72,7 @@ PYTHONPATH=src python -m trading_system.backtest.example
 
 - `TRADING_SYSTEM_ENV`: logical runtime environment name (for example `local`, `staging`, `prod`).
 - `TRADING_SYSTEM_TIMEZONE`: operator timezone used for runtime context (for example `Asia/Seoul`).
-
-- `TRADING_SYSTEM_API_KEY`: live execution adapter credential injected from environment/secret manager only.
-
+- `TRADING_SYSTEM_API_KEY`: live adapter credential injected from environment/secret manager only.
 
 ## Configuration schema
 
@@ -97,34 +93,15 @@ Required top-level sections:
 
 All amount/quantity/fee fields are parsed as `Decimal`. Validation errors return human-friendly messages for missing keys, invalid types, and out-of-range values.
 
-## Current status
-
-This repository currently provides a clean package skeleton, a small risk-rule example, a deterministic single-symbol backtest loop, and repository-level skills for planning, implementation, review, and documentation work.
-
 ## Analysis docs
 
 - Architecture overview: `docs/architecture/overview.md`
 - Current workspace analysis: `docs/architecture/workspace-analysis.md`
-
-## Try a simple example
-
-The repository includes a deterministic smoke example:
-
-```bash
-PYTHONPATH=src python -m trading_system.backtest.example
-```
-
-It runs a small single-symbol bar sequence through the v1 backtest loop with:
-
-- a built-in stateful `MomentumStrategy`
-- close-price immediate fills
-- fee-aware cash updates
-- a printed equity curve and return summary
-
+- Incident runbook: `docs/runbooks/incident-response.md`
+- Release gates: `docs/runbooks/release-gate-checklist.md`
 
 ## Operations baseline
 
 - Boundary layers (`app`, `data`, `execution`) emit structured logs with a propagated `correlation_id`.
 - Key events use fixed schema names: `order.created`, `order.rejected`, `order.filled`, `risk.rejected`, `exception`.
 - Retry/timeout/circuit-breaker policies are applied only at external I/O boundaries.
-- Runbook for outage response: `docs/runbooks/incident-response.md`.

--- a/docs/architecture/workspace-analysis.md
+++ b/docs/architecture/workspace-analysis.md
@@ -1,110 +1,116 @@
 # Workspace Analysis
 
-This document captures the current implementation state of the trading-system workspace as of March 12, 2026.
+This document captures the current implementation state of the trading-system workspace as of March 13, 2026.
 
 ## Repository state
 
-The repository is still at scaffold stage. The package layout under `src/trading_system/` matches the intended layered design, but most modules currently define contracts or small value objects rather than full workflows.
+The repository is no longer only a scaffold. It now includes a deterministic end-to-end backtest path, a CLI app entrypoint, typed configuration loading with validation, and both unit/integration tests for core orchestration.
 
 Implemented behavior today:
 
-- `risk.limits.RiskLimits` enforces order size, projected position, and projected notional checks.
-- `portfolio.book.PortfolioBook` updates cash and positions from fills.
-- `analytics.metrics.cumulative_return` computes a simple equity-curve return.
-- Unit coverage exists only for `RiskLimits`.
-
-Scaffolded but not orchestrated yet:
-
-- `data.provider.MarketDataProvider` defines the historical/live bar contract.
-- `strategy.base.Strategy` and `StrategySignal` define signal generation contracts.
-- `execution.orders.OrderRequest` models order intent.
-- `backtest.engine.BacktestContext` groups a portfolio, risk limits, and fees but does not execute a backtest loop.
+- `app.main` provides CLI entrypoints for `backtest` and a safe `live` preflight mode.
+- `app.services` composes strategy, provider, risk, broker simulator, and portfolio services.
+- `backtest.engine.run_backtest` orchestrates signal -> risk -> broker fill -> portfolio updates -> equity curve.
+- `execution.adapters` maps strategy signals to order requests.
+- `execution.broker` provides deterministic fill/fee/slippage policies and a resilient broker wrapper (retry/timeout/circuit-breaker).
+- `config.settings.load_settings` loads YAML into typed settings with human-friendly validation errors.
+- `core.ops` provides structured logging, redaction, correlation IDs, and reusable resilience helpers.
 
 ## Layer analysis
 
+### App
+
+The app layer now exists and separates CLI argument handling (`app.main`) from service wiring (`app.services`).
+
+- `--mode backtest` executes the deterministic backtest path.
+- `--mode live` currently performs preflight validation only (including required secret checks) and does not submit orders.
+
+This keeps live mode safe while allowing operators to validate runtime inputs.
+
 ### Data
 
-`MarketDataProvider.load_bars()` returns `Iterable[MarketBar]`, which is flexible enough for both backtest and streaming-like adapters. The interface is minimal and clean, but it does not yet capture timeframe, range selection, or multi-symbol loading. Those omissions are reasonable for a scaffold, but they will matter as soon as the backtest engine is implemented.
+`MarketDataProvider` has an `InMemoryMarketDataProvider` implementation suitable for deterministic tests and smoke runs.
+
+Current limitation:
+- No external historical/live provider adapter is implemented yet.
 
 ### Strategy
 
-The strategy layer exposes a single-bar `evaluate(bar)` contract and returns a `StrategySignal` with side, quantity, and reason. This keeps hidden state out of the interface, but it also means any stateful strategy will need explicit internal state management or a richer context object. That design decision should be made before adding a real strategy implementation.
+`MomentumStrategy` provides a deterministic stateful example strategy based on consecutive closes.
+
+Current limitation:
+- No strategy registry/plugin mechanism yet; selection is currently fixed in service composition.
 
 ### Risk
 
-`RiskLimits.allows_order()` is the only domain rule with tests and real decision logic. It currently uses projected position notional as the notional check. That is internally consistent, but it assumes a single-symbol perspective and does not distinguish between gross exposure, net exposure, or per-order notional. Future risk work should keep those concepts explicit to avoid backtest/live drift.
+`RiskLimits` enforces max order size, projected position, and projected notional checks.
+
+Current limitation:
+- Exposure semantics are still single-portfolio and simple (no gross/net portfolio-level policies).
 
 ### Execution
 
-The execution layer stops at `OrderRequest`. There is no broker protocol, no order-to-fill lifecycle, and no mapping from `StrategySignal` to `OrderRequest`. This is the main missing boundary between intent generation and state mutation.
+Execution now has explicit boundaries:
+
+- signal-to-order adapter
+- broker simulator interface
+- policy-based fill/fee/slippage simulation
+- resilience wrapper for external-I/O-like failure handling
+
+Current limitation:
+- No real broker adapter or persistent order lifecycle state machine yet.
 
 ### Portfolio
 
-`PortfolioBook.apply_fill()` correctly moves signed quantity into positions and adjusts cash by `signed_quantity * fill_price`. The model is intentionally small, but it currently has no fee handling, average price tracking, realized/unrealized PnL, or zero-position cleanup. Those gaps are acceptable at this stage, but they limit analytics and backtest realism.
+`PortfolioBook` supports cash/position updates with fee-aware fill application and deterministic behavior.
+
+Current limitation:
+- No average price, realized/unrealized PnL decomposition, or storage persistence yet.
 
 ### Backtest
 
-`BacktestContext` exists only as a container. There is no orchestration loop joining data, strategy, risk, execution, portfolio, and analytics into a deterministic simulation. This is the largest functional gap in the workspace.
+Backtest orchestration is implemented and deterministic for identical inputs.
+
+Current limitation:
+- Multi-symbol portfolio accounting is supported for marking existing positions, but the default app path intentionally restricts runtime to one symbol for safety/simplicity.
 
 ### Analytics
 
-`cumulative_return()` provides one safe, deterministic metric with edge-case handling for empty curves and zero starting equity. No drawdown, trade statistics, turnover, or fee-aware performance metrics exist yet.
+`cumulative_return` is available and integrated into `BacktestResult.total_return`.
 
-## Current flow and missing links
+Current limitation:
+- Drawdown/trade stats/turnover metrics are not yet part of the default report.
 
-The intended flow is visible from the package boundaries:
+## Configuration and examples
 
-1. `MarketDataProvider` yields `MarketBar`.
-2. `Strategy.evaluate()` produces `StrategySignal`.
-3. Risk checks determine whether the desired quantity is allowed.
-4. Execution should convert the signal into `OrderRequest`.
-5. Portfolio should update from fills.
-6. Analytics should consume the resulting equity curve.
+Configuration shape is now aligned for executable baseline fields:
 
-The missing links are:
+- `configs/base.yaml` includes `app`, `market_data`, `risk`, and `backtest` sections compatible with typed settings.
+- `examples/sample_backtest.yaml` includes required risk/backtest fields and remains an operator-facing scenario reference.
 
-- No adapter converts `StrategySignal` into `OrderRequest`.
-- No broker or fill model exists between execution and portfolio.
-- No backtest loop coordinates iteration, state transitions, and fee application.
-- No portfolio-to-analytics bridge produces an equity curve.
+Notes:
+- The example still contains additional strategy metadata that is not yet consumed by the current CLI app composition.
 
-## Config and example consistency
+## Test coverage snapshot
 
-The configuration surface is only partially aligned.
+Coverage includes:
 
-- `config/settings.py` defines `RiskSettings` and `BacktestSettings`, but there is no loader or top-level application settings model.
-- `configs/base.yaml` contains `app` and `market_data` sections that are not represented in typed settings.
-- `examples/sample_backtest.yaml` contains strategy metadata and a `risk.max_order_size`, but omits `risk.max_notional`, which is required by `RiskLimits`.
-- The example file therefore describes a scenario that cannot yet be materialized into the current typed models without extra defaults or translation logic.
+- Unit tests: strategy/risk/portfolio/analytics/config/app/execution adapters and broker behavior.
+- Integration tests: orchestration happy path, deterministic replay, risk rejection, provider failure, broker failure/timeout paths, config loader invalid schema/type paths.
 
-Before implementing config loading, the repository should decide whether examples are intentionally aspirational or expected to be executable fixtures.
+This gives a solid regression baseline for the current deterministic backtest architecture.
 
-## Test coverage assessment
+## Remaining gaps before true live execution
 
-Current test coverage is narrow and focused on one happy path and one rejection case for `RiskLimits`.
-
-Highest-priority missing tests:
-
-1. Risk boundary cases for projected position and projected notional.
-2. Portfolio regression tests covering buys, sells, sign handling, and flatting a position.
-3. Analytics tests for empty, single-point, zero-start, and positive/negative return curves.
-4. Contract-level tests for strategy and execution adapters once those components exist.
-5. A minimal integration test for the future backtest loop.
+1. **Real adapters**: implement external market data and broker adapters behind existing protocols.
+2. **Live orchestration**: add runtime loop, heartbeat, and durable state transitions for order lifecycle.
+3. **Persistence/recovery**: add checkpointing/event storage for restart-safe operation.
+4. **Operational gates**: formalize pre-production checks (runbook drills, key rotation, alert routing).
+5. **Expanded analytics**: add drawdown and trade-level metrics for operational monitoring.
 
 ## Recommended next backlog
 
-### 1. Add a deterministic backtest loop
-
-Implement a small engine that iterates bars, calls a strategy, enforces `RiskLimits`, applies fills to `PortfolioBook`, and records an equity curve. Keep all time progression driven by input bars.
-
-### 2. Introduce execution and fill contracts
-
-Add explicit broker or simulator interfaces plus a fill model so the transition from desired action to portfolio mutation is not implicit.
-
-### 3. Normalize configuration models
-
-Create a typed top-level settings model and align `configs/base.yaml`, `examples/sample_backtest.yaml`, and the settings dataclasses so example configs can be loaded without hidden defaults.
-
-### 4. Expand foundational tests
-
-Add unit tests around portfolio behavior and analytics, then add one integration-style backtest smoke test to lock the orchestration path before strategy complexity grows.
+1. Introduce a real data-provider adapter with strict timeout/retry configuration.
+2. Add a broker adapter contract test suite (happy path + failure path) using fakes.
+3. Extend `live` mode from preflight to paper-trade loop with explicit dry-run guard.
+4. Add release-gate documentation with pass/fail checklist before enabling live order submission.

--- a/docs/runbooks/release-gate-checklist.md
+++ b/docs/runbooks/release-gate-checklist.md
@@ -1,0 +1,41 @@
+# Release gate checklist
+
+## Purpose
+
+라이브 주문 전환 전에 필수 운영 게이트를 동일한 기준으로 점검한다.
+현재 저장소 기준으로 `--mode live`는 preflight만 수행하며 주문을 제출하지 않는다.
+
+## Gate 1: Test baseline
+
+- [ ] `pytest -m smoke -q` 통과
+- [ ] `pytest -m "not smoke" -q` 통과
+- [ ] 최근 변경 영역(설정/리스크/실행 경계)에 대한 신규 회귀 테스트 포함
+
+## Gate 2: Config and secret baseline
+
+- [ ] `configs/base.yaml`이 최신 스키마와 일치
+- [ ] 운영 환경의 `TRADING_SYSTEM_API_KEY` 주입 확인
+- [ ] 시크릿이 코드/로그/티켓에 노출되지 않음
+
+## Gate 3: Runtime preflight baseline
+
+- [ ] `python -m trading_system.app.main --mode live --symbols BTCUSDT` preflight 성공
+- [ ] 잘못된 설정 입력 시 명확한 사용자 오류 메시지 반환 확인
+- [ ] 다중 심볼 제한/현 스캐폴드 제약이 운영자에게 공유됨
+
+## Gate 4: Incident drill baseline
+
+- [ ] 데이터 끊김 시나리오 점검(incident-response 시나리오 A)
+- [ ] 주문 실패 시나리오 점검(incident-response 시나리오 B)
+- [ ] 시계열 지연 시나리오 점검(incident-response 시나리오 C)
+
+## Gate 5: Sign-off
+
+- [ ] 개발 책임자 승인
+- [ ] 운영 책임자 승인
+- [ ] 롤백 담당자 및 연락 채널 확인
+
+## Notes
+
+- 본 체크리스트 통과는 실제 라이브 주문 구현 완료를 의미하지 않는다.
+- 실제 주문 전환 전에는 브로커 어댑터/지속성/알림 체계를 추가해야 한다.

--- a/src/trading_system/app/main.py
+++ b/src/trading_system/app/main.py
@@ -3,7 +3,7 @@ import sys
 
 from trading_system.app.backtest_demo import format_result
 from trading_system.app.services import build_services
-from trading_system.app.settings import AppSettings, SettingsValidationError
+from trading_system.app.settings import AppMode, AppSettings, SettingsValidationError
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -41,6 +41,10 @@ def run(argv: list[str] | None = None) -> int:
         settings.validate()
 
         services = build_services(settings)
+        if settings.mode == AppMode.LIVE:
+            print(services.preflight_live())
+            return 0
+
         result = services.run()
         print(format_result(result))
         return 0

--- a/src/trading_system/app/services.py
+++ b/src/trading_system/app/services.py
@@ -39,7 +39,7 @@ class AppServices:
         if self.mode != AppMode.BACKTEST:
             raise RuntimeError(f"Unsupported mode '{self.mode}'.")
 
-        symbol = self._single_symbol()
+        symbol = self._single_symbol(mode_name="backtest")
         with correlation_scope():
             bars = self.data_provider.load_bars(symbol)
             context = BacktestContext(
@@ -50,19 +50,27 @@ class AppServices:
             )
             return run_backtest(bars=bars, strategy=self.strategy, context=context)
 
-    def _single_symbol(self) -> str:
+    def preflight_live(self) -> str:
+        if self.mode != AppMode.LIVE:
+            raise RuntimeError(f"Unsupported mode '{self.mode}'.")
+
+        self._single_symbol(mode_name="live")
+        return "Live mode preflight passed (no orders were submitted)."
+
+    def _single_symbol(self, mode_name: str) -> str:
         if len(self.symbols) != 1:
-            raise RuntimeError("Current scaffold supports exactly one symbol for backtest mode.")
+            raise RuntimeError(
+                f"Current scaffold supports exactly one symbol for {mode_name} mode."
+            )
         return self.symbols[0]
 
 
 def build_services(settings: AppSettings) -> AppServices:
-    if settings.mode != AppMode.BACKTEST:
-        raise RuntimeError(f"Mode '{settings.mode}' is not implemented yet.")
-
     ensure_logging()
     logger = StructuredLogger("trading_system", log_format=StructuredLogFormat.JSON)
-    _load_live_api_key_if_present()
+
+    if settings.mode == AppMode.LIVE:
+        _require_live_api_key()
 
     bars_by_symbol = {symbol: build_sample_bars(symbol=symbol) for symbol in settings.symbols}
     return AppServices(
@@ -87,9 +95,6 @@ def build_services(settings: AppSettings) -> AppServices:
     )
 
 
-def _load_live_api_key_if_present() -> None:
+def _require_live_api_key() -> None:
     provider = EnvSecretProvider()
-    try:
-        provider.get_secret("TRADING_SYSTEM_API_KEY")
-    except RuntimeError:
-        return
+    provider.get_secret("TRADING_SYSTEM_API_KEY")

--- a/tests/unit/test_app_main.py
+++ b/tests/unit/test_app_main.py
@@ -9,6 +9,27 @@ def test_cli_backtest_mode_runs_successfully(capsys) -> None:
     assert "Smoke backtest result" in captured.out
 
 
+def test_cli_live_mode_runs_preflight_when_api_key_is_present(capsys, monkeypatch) -> None:
+    monkeypatch.setenv("TRADING_SYSTEM_API_KEY", "dummy-key")
+
+    exit_code = run(["--mode", "live", "--symbols", "BTCUSDT"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Live mode preflight passed" in captured.out
+
+
+def test_cli_live_mode_fails_when_api_key_is_missing(capsys, monkeypatch) -> None:
+    monkeypatch.delenv("TRADING_SYSTEM_API_KEY", raising=False)
+
+    exit_code = run(["--mode", "live", "--symbols", "BTCUSDT"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 3
+    assert "Runtime error:" in captured.err
+    assert "Missing required secret: TRADING_SYSTEM_API_KEY" in captured.err
+
+
 def test_cli_returns_validation_error_for_invalid_fee_bps(capsys) -> None:
     exit_code = run(["--mode", "backtest", "--fee-bps", "-1"])
 


### PR DESCRIPTION
### Motivation

- Provide a safe `live` preflight that validates runtime inputs and secrets without submitting orders to brokers.
- Enforce presence of the live adapter API key for `--mode live` to avoid accidental live execution with missing credentials.
- Bring docs and runbooks in line with the implemented app behavior and add an explicit release gate checklist.

### Description

- Update `app.main` to recognize `AppMode` and short-circuit to a `preflight_live` path when `mode == AppMode.LIVE` that prints a safe confirmation message and exits.
- Add `AppServices.preflight_live()` and extend `_single_symbol()` to include a contextual `mode_name` parameter, and enforce single-symbol constraints with clearer error text.
- Change service composition in `build_services` to require the live API key when `settings.mode == AppMode.LIVE` by calling `_require_live_api_key()` which delegates to the environment secret provider.
- Add unit tests for the CLI live preflight behavior in `tests/unit/test_app_main.py` and update `README.md`, `docs/architecture/workspace-analysis.md`, and add `docs/runbooks/release-gate-checklist.md` to document the new behavior and operational guidance.

### Testing

- Ran unit tests in `tests/unit/test_app_main.py` via `pytest -q tests/unit/test_app_main.py` and the suite passed, covering backtest, live preflight present, and live preflight missing cases.
- Exercised the CLI backtest smoke run with `run([..."--mode","backtest"...])` as part of the unit tests and it returned the expected smoke output.
- No automated integration or external broker tests were added in this change set and live mode remains a non-order-submitting preflight by design.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b3672fc1b48333b6421f87d0fab7cf)