### PR TITLE
Add Python 3.10 compatibility shim for enum/timezone primitives

### DIFF
--- a/src/trading_system/app/settings.py
+++ b/src/trading_system/app/settings.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
-from enum import StrEnum
+from trading_system.core.compat import StrEnum
 
 
 class AppMode(StrEnum):

--- a/src/trading_system/config/settings.py
+++ b/src/trading_system/config/settings.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
-from enum import StrEnum
+from trading_system.core.compat import StrEnum
 from pathlib import Path
 from typing import Any
 

--- a/src/trading_system/core/compat.py
+++ b/src/trading_system/core/compat.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import timezone
+from enum import Enum
+
+try:
+    from enum import StrEnum as _StrEnum
+except ImportError:
+
+    class _StrEnum(str, Enum):
+        """Python 3.10-compatible fallback for enum.StrEnum."""
+
+
+try:
+    from datetime import UTC as _UTC
+except ImportError:
+    _UTC = timezone.utc
+
+
+StrEnum = _StrEnum
+UTC = _UTC
+
+__all__ = ["StrEnum", "UTC"]

--- a/src/trading_system/core/ops.py
+++ b/src/trading_system/core/ops.py
@@ -8,10 +8,11 @@ import uuid
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import asdict, dataclass
-from datetime import UTC, datetime
+from datetime import datetime
 from decimal import Decimal
-from enum import StrEnum
 from typing import Any, Protocol
+
+from trading_system.core.compat import UTC, StrEnum
 
 _CORRELATION_ID: ContextVar[str | None] = ContextVar("correlation_id", default=None)
 _SENSITIVE_KEYWORDS = ("secret", "token", "password", "api_key", "apikey")

--- a/src/trading_system/execution/broker.py
+++ b/src/trading_system/execution/broker.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from decimal import Decimal
-from enum import StrEnum
+from trading_system.core.compat import StrEnum
 from typing import Protocol
 
 from trading_system.core.ops import (

--- a/src/trading_system/execution/orders.py
+++ b/src/trading_system/execution/orders.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from decimal import Decimal
-from enum import StrEnum
+from trading_system.core.compat import StrEnum
 
 
 class OrderSide(StrEnum):

--- a/src/trading_system/strategy/base.py
+++ b/src/trading_system/strategy/base.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from decimal import Decimal
-from enum import StrEnum
+from trading_system.core.compat import StrEnum
 from typing import Protocol
 
 from trading_system.core.types import MarketBar

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timezone
+
+from trading_system.core.compat import StrEnum, UTC
+
+
+class _DemoMode(StrEnum):
+    PAPER = "paper"
+
+
+def test_str_enum_is_str_compatible() -> None:
+    assert isinstance(_DemoMode.PAPER, str)
+    assert _DemoMode("paper") == _DemoMode.PAPER
+
+
+def test_utc_alias_matches_standard_utc_timezone() -> None:
+    assert datetime(2024, 1, 1, tzinfo=UTC).utcoffset() == timezone.utc.utcoffset(None)


### PR DESCRIPTION
## Summary
- Added `src/trading_system/core/compat.py` to provide a safe fallback for `StrEnum` and `UTC` on Python versions earlier than 3.11.
- Updated enum and UTC imports in app/config/core/execution/strategy modules to consume the compatibility layer.
- Added regression tests in `tests/unit/test_compat.py` to guarantee str-compatible enums and UTC alias behavior.

## Problem 1-pager
- **Context**: The repository declares Python 3.12, but local/CI environments may execute tests with Python 3.10.
- **Problem**: Test collection failed immediately due to `ImportError` for `enum.StrEnum` and `datetime.UTC`, so the codebase was not runnable.
- **Goal**: Make code importable and testable in Python 3.10+ without changing business behavior.
- **Non-goals**: No strategy/risk/execution logic changes; no config schema changes.
- **Constraints**: Keep change small, deterministic, dependency-free, and backward compatible with Python 3.12.

## Options considered
1. **Option A: Raise runtime requirement to 3.12-only and enforce interpreter in tooling**
   - Pros: No code changes needed.
   - Cons: Fails in mixed environments and does not improve portability.
   - Risks: Continues immediate import failures where 3.12 is unavailable.
2. **Option B (chosen): Add small compatibility shim and keep call sites unchanged semantically**
   - Pros: Minimal code change, works on 3.10+, preserves behavior on 3.12.
   - Cons: Adds one module and import indirection.
   - Risks: Low; mitigated with dedicated compatibility tests.

## Impact note
- Affected symbols: `AppMode`, `SignalSide`, `OrderSide`, `FillStatus`, `StructuredLogFormat`, and structured log timestamp generation via `UTC`.
- Pre/postcondition remains the same (string-valued enums and UTC-aware timestamps); only import source changed.

## Validation
- `pytest -q tests/unit/test_compat.py tests/unit/test_core_ops.py tests/unit/test_config_settings.py`
- `pytest -q`

Both passed after installing `PyYAML` in this environment.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b9eddc9a708333976ac6620ebf1194)