### PR TITLE
Support explicit live-execution "paper" mode (preflight default) and add paper-run loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ TRADING_SYSTEM_CSV_DIR=data/market \
 python -m trading_system.app.main --mode backtest --provider csv --symbols 005930 --trade-quantity 1
 ```
 
-### 5.5 Live preflight mode (no order submission) / 라이브 프리플라이트 모드 (실주문 없음)
+### 5.5 Live preflight mode (default, no order submission) / 라이브 프리플라이트 모드 (기본값, 실주문 없음)
 
 ```bash
 PYTHONPATH=src TRADING_SYSTEM_ENV=local TRADING_SYSTEM_TIMEZONE=Asia/Seoul \
@@ -151,7 +151,15 @@ TRADING_SYSTEM_API_KEY=dummy-key \
 python -m trading_system.app.main --mode live --symbols BTCUSDT
 ```
 
-### 5.6 Built-in backtest example / 내장 백테스트 예시
+### 5.6 Live paper mode (explicit opt-in) / 라이브 페이퍼 모드 (명시적 활성화)
+
+```bash
+PYTHONPATH=src TRADING_SYSTEM_ENV=local TRADING_SYSTEM_TIMEZONE=Asia/Seoul \
+TRADING_SYSTEM_API_KEY=dummy-key \
+python -m trading_system.app.main --mode live --symbols BTCUSDT --live-execution paper
+```
+
+### 5.7 Built-in backtest example / 내장 백테스트 예시
 
 ```bash
 PYTHONPATH=src python -m trading_system.backtest.example
@@ -165,7 +173,7 @@ PYTHONPATH=src python -m trading_system.backtest.example
 This repository is not a fully live-trading product yet. It is a deterministic, test-centered platform that can:
 
 1. Execute end-to-end backtests through CLI.
-2. Run live-mode preflight checks without submitting real orders.
+2. Run live-mode preflight checks (default) or an explicit paper execution loop (`--live-execution paper`) without submitting real orders.
 3. Load market data via in-memory provider (`mock`) or CSV provider (`csv`).
 4. Enforce risk limits (`max_position`, `max_notional`, `max_order_size`).
 5. Simulate fills via fill ratio, slippage (bps), and commission (bps).
@@ -177,7 +185,7 @@ This repository is not a fully live-trading product yet. It is a deterministic, 
 이 저장소는 아직 “완전한 실주문 시스템”은 아니며, 결정성과 테스트 중심의 플랫폼으로 다음을 수행할 수 있습니다.
 
 1. CLI 기반 end-to-end 백테스트 실행.
-2. 실주문 없이 라이브 프리플라이트 검증 수행.
+2. 실주문 없이 라이브 프리플라이트(기본) 또는 명시적 페이퍼 실행 루프(`--live-execution paper`) 수행.
 3. 인메모리(`mock`) 또는 CSV(`csv`) 데이터 공급자 사용.
 4. 리스크 제한(`max_position`, `max_notional`, `max_order_size`) 적용.
 5. 체결 비율/슬리피지(bps)/수수료(bps) 기반 체결 시뮬레이션.
@@ -332,13 +340,13 @@ settings = load_settings("configs/base.yaml")
 ## 12) Operational cautions / 운영 시 주의사항
 
 ### EN
-1. **No real live order submission yet**: `live` mode is currently preflight-only.
+1. **No real live order submission yet**: `live` mode defaults to preflight, and supports paper simulation only when `--live-execution paper` is set.
 2. **Secret handling**: inject credentials via environment/secret manager only.
 3. **Current scaffold limitation**: app composition currently focuses on a single-symbol runtime path for simplicity/safety.
 4. **Determinism first**: any backtest logic change should ship with deterministic regression tests.
 
 ### KO
-1. **실주문 미지원**: 현재 `live` 모드는 preflight 전용입니다.
+1. **실주문 미지원**: 현재 `live` 모드는 기본 preflight이며, `--live-execution paper` 지정 시 페이퍼 시뮬레이션만 지원합니다.
 2. **시크릿 관리**: 인증정보는 환경변수/시크릿 매니저로만 주입하세요.
 3. **현재 스캐폴드 제약**: 단순성과 안전성을 위해 앱 조립 경로는 단일 심볼 중심입니다.
 4. **결정성 우선**: 백테스트 로직 변경 시 결정성 회귀 테스트를 함께 추가하세요.
@@ -397,8 +405,8 @@ PYTHONPATH=src python -m trading_system.patterns.example
 1. **CLI 기반 백테스트 실행**
    - 전략 신호 생성 → 주문 변환 → 리스크 검증 → 체결 시뮬레이션 → 포트폴리오 반영 → 성과 계산을 일괄 수행합니다.
 
-2. **라이브 프리플라이트(preflight) 실행**
-   - `--mode live`는 실제 주문을 보내지 않고 운영 필수 입력(예: API 키)만 사전 검증합니다.
+2. **라이브 실행(preflight/paper) 지원**
+   - `--mode live`는 기본적으로 preflight를 수행하며, `--live-execution paper`를 지정하면 실주문 없이 페이퍼 실행 루프를 수행합니다.
 
 3. **시장 데이터 공급 선택**
    - `mock` 인메모리 데이터(테스트/스모크용)
@@ -455,7 +463,7 @@ PYTHONPATH=src python -m trading_system.patterns.example
 
 ### 3) 아키텍처 레이어별 역할 요약
 
-- **app**: CLI 입력 처리, 서비스 조립, 모드 분기(backtest/live preflight)
+- **app**: CLI 입력 처리, 서비스 조립, 모드 분기(backtest/live preflight/paper)
 - **data**: 데이터 공급자 인터페이스 및 구현(mock/csv)
 - **strategy**: 전략 신호 생성
 - **risk**: 주문 가능 여부 검증
@@ -488,7 +496,7 @@ PYTHONPATH=src python -m trading_system.patterns.example
 ### 6) 운영 시 주의사항
 
 1. **실주문 미지원**
-   - 현재 `live`는 preflight 전용이며 실제 주문 제출은 구현되어 있지 않습니다.
+   - 현재 `live`는 기본 preflight이며, `--live-execution paper`로 페이퍼 실행만 가능합니다(실주문 제출 미구현).
 
 2. **시크릿 관리**
    - API 키는 반드시 환경변수/시크릿 매니저로 주입하고 코드/로그에 직접 남기지 마세요.

--- a/docs/architecture/workspace-analysis.md
+++ b/docs/architecture/workspace-analysis.md
@@ -1,6 +1,6 @@
 # Workspace Analysis
 
-This document captures the current implementation state of the trading-system workspace as of March 13, 2026.
+This document captures the current implementation state of the trading-system workspace as of March 18, 2026.
 
 ## Repository state
 
@@ -8,7 +8,7 @@ The repository is no longer only a scaffold. It now includes a deterministic end
 
 Implemented behavior today:
 
-- `app.main` provides CLI entrypoints for `backtest` and a safe `live` preflight mode.
+- `app.main` provides CLI entrypoints for `backtest` and a safe `live` mode with `preflight` (default) and explicit `paper` execution options.
 - `app.services` composes strategy, provider, risk, broker simulator, and portfolio services.
 - `backtest.engine.run_backtest` orchestrates signal -> risk -> broker fill -> portfolio updates -> equity curve.
 - `execution.adapters` maps strategy signals to order requests.
@@ -23,9 +23,9 @@ Implemented behavior today:
 The app layer now exists and separates CLI argument handling (`app.main`) from service wiring (`app.services`).
 
 - `--mode backtest` executes the deterministic backtest path.
-- `--mode live` currently performs preflight validation only (including required secret checks) and does not submit orders.
+- `--mode live` performs preflight validation by default (including required secret checks), and can run a deterministic paper loop when `--live-execution paper` is provided.
 
-This keeps live mode safe while allowing operators to validate runtime inputs.
+This keeps live mode safe by default while allowing operators to validate runtime flow without real order submission.
 
 ### Data
 
@@ -112,5 +112,5 @@ This gives a solid regression baseline for the current deterministic backtest ar
 
 1. Introduce a real data-provider adapter with strict timeout/retry configuration.
 2. Add a broker adapter contract test suite (happy path + failure path) using fakes.
-3. Extend `live` mode from preflight to paper-trade loop with explicit dry-run guard.
+3. Add a dedicated live formatter/status model for paper execution output (currently reuses backtest formatting).
 4. Add release-gate documentation with pass/fail checklist before enabling live order submission.

--- a/docs/runbooks/release-gate-checklist.md
+++ b/docs/runbooks/release-gate-checklist.md
@@ -3,7 +3,8 @@
 ## Purpose
 
 라이브 주문 전환 전에 필수 운영 게이트를 동일한 기준으로 점검한다.
-현재 저장소 기준으로 `--mode live`는 preflight만 수행하며 주문을 제출하지 않는다.
+현재 저장소 기준으로 `--mode live`는 기본 preflight를 수행하고,
+`--live-execution paper` 지정 시 실주문 없이 페이퍼 실행 루프를 수행한다.
 
 ## Gate 1: Test baseline
 
@@ -20,6 +21,7 @@
 ## Gate 3: Runtime preflight baseline
 
 - [ ] `python -m trading_system.app.main --mode live --symbols BTCUSDT` preflight 성공
+- [ ] `python -m trading_system.app.main --mode live --symbols BTCUSDT --live-execution paper` paper 실행 성공
 - [ ] 잘못된 설정 입력 시 명확한 사용자 오류 메시지 반환 확인
 - [ ] 다중 심볼 제한/현 스캐폴드 제약이 운영자에게 공유됨
 

--- a/src/trading_system/app/backtest_demo.py
+++ b/src/trading_system/app/backtest_demo.py
@@ -3,7 +3,13 @@ from decimal import Decimal
 
 from trading_system.app.sample_data import build_sample_bars as _build_sample_bars
 from trading_system.app.services import build_services
-from trading_system.app.settings import AppMode, AppSettings, BacktestSettings, RiskSettings
+from trading_system.app.settings import (
+    AppMode,
+    AppSettings,
+    BacktestSettings,
+    LiveExecutionMode,
+    RiskSettings,
+)
 from trading_system.backtest.engine import BacktestResult
 from trading_system.core.types import MarketBar
 
@@ -32,6 +38,7 @@ def run_smoke_backtest(config: SmokeBacktestConfig | None = None) -> BacktestRes
         symbols=(config.symbol,),
         provider="mock",
         broker="paper",
+        live_execution=LiveExecutionMode.PREFLIGHT,
         risk=RiskSettings(
             max_position=config.max_position,
             max_notional=config.max_notional,

--- a/src/trading_system/app/main.py
+++ b/src/trading_system/app/main.py
@@ -3,7 +3,12 @@ import sys
 
 from trading_system.app.backtest_demo import format_result
 from trading_system.app.services import build_services
-from trading_system.app.settings import AppMode, AppSettings, SettingsValidationError
+from trading_system.app.settings import (
+    AppMode,
+    AppSettings,
+    LiveExecutionMode,
+    SettingsValidationError,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -12,6 +17,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--symbols", default="BTCUSDT", help="Comma-separated symbols")
     parser.add_argument("--provider", default="mock", help="Market data provider")
     parser.add_argument("--broker", default="paper", help="Execution broker")
+    parser.add_argument(
+        "--live-execution",
+        default="preflight",
+        help="Live execution mode (preflight|paper)",
+    )
     parser.add_argument("--starting-cash", default="10000", help="Starting cash for backtest")
     parser.add_argument("--fee-bps", default="5", help="Fee in basis points")
     parser.add_argument("--trade-quantity", default="0.1", help="Per-trade quantity")
@@ -31,6 +41,7 @@ def run(argv: list[str] | None = None) -> int:
             symbols=args.symbols,
             provider=args.provider,
             broker=args.broker,
+            live_execution=args.live_execution,
             starting_cash=args.starting_cash,
             fee_bps=args.fee_bps,
             trade_quantity=args.trade_quantity,
@@ -43,6 +54,9 @@ def run(argv: list[str] | None = None) -> int:
         services = build_services(settings)
         if settings.mode == AppMode.LIVE:
             print(services.preflight_live())
+            if settings.live_execution == LiveExecutionMode.PAPER:
+                result = services.run_live_paper()
+                print(format_result(result))
             return 0
 
         result = services.run()

--- a/src/trading_system/app/services.py
+++ b/src/trading_system/app/services.py
@@ -63,6 +63,21 @@ class AppServices:
         self._single_symbol(mode_name="live")
         return "Live mode preflight passed (no orders were submitted)."
 
+    def run_live_paper(self) -> BacktestResult:
+        if self.mode != AppMode.LIVE:
+            raise RuntimeError(f"Unsupported mode '{self.mode}'.")
+
+        symbol = self._single_symbol(mode_name="live")
+        with correlation_scope():
+            bars = self.data_provider.load_bars(symbol)
+            context = BacktestContext(
+                portfolio=self.portfolio,
+                risk_limits=self.risk_limits,
+                broker=self.broker_simulator,
+                logger=self.logger,
+            )
+            return run_backtest(bars=bars, strategy=self.strategy, context=context)
+
     def _single_symbol(self, mode_name: str) -> str:
         if len(self.symbols) != 1:
             raise RuntimeError(

--- a/src/trading_system/app/settings.py
+++ b/src/trading_system/app/settings.py
@@ -9,6 +9,11 @@ class AppMode(StrEnum):
     LIVE = "live"
 
 
+class LiveExecutionMode(StrEnum):
+    PREFLIGHT = "preflight"
+    PAPER = "paper"
+
+
 class SettingsValidationError(ValueError):
     """Raised when user-provided application settings are invalid."""
 
@@ -33,6 +38,7 @@ class AppSettings:
     symbols: tuple[str, ...]
     provider: str
     broker: str
+    live_execution: LiveExecutionMode
     risk: RiskSettings
     backtest: BacktestSettings
 
@@ -43,6 +49,7 @@ class AppSettings:
         symbols: str,
         provider: str,
         broker: str,
+        live_execution: str,
         starting_cash: str,
         fee_bps: str,
         trade_quantity: str,
@@ -67,6 +74,7 @@ class AppSettings:
             symbols=parsed_symbols,
             provider=provider.strip().lower(),
             broker=broker.strip().lower(),
+            live_execution=_parse_live_execution_mode(live_execution),
             risk=RiskSettings(
                 max_position=_to_decimal(max_position, "max_position"),
                 max_notional=_to_decimal(max_notional, "max_notional"),
@@ -88,6 +96,11 @@ class AppSettings:
 
         if self.broker not in {"paper"}:
             raise SettingsValidationError("--broker must be 'paper' for this scaffold.")
+
+        if self.live_execution not in {LiveExecutionMode.PREFLIGHT, LiveExecutionMode.PAPER}:
+            raise SettingsValidationError(
+                "--live-execution must be one of: 'preflight', 'paper'."
+            )
 
         if self.backtest.starting_cash <= 0:
             raise SettingsValidationError("--starting-cash must be greater than 0.")
@@ -116,3 +129,13 @@ def _to_decimal(value: str, field_name: str) -> Decimal:
         return Decimal(value)
     except InvalidOperation as exc:
         raise SettingsValidationError(f"{field_name} must be a valid decimal value.") from exc
+
+
+def _parse_live_execution_mode(value: str) -> LiveExecutionMode:
+    normalized = value.strip().lower()
+    try:
+        return LiveExecutionMode(normalized)
+    except ValueError as exc:
+        raise SettingsValidationError(
+            "--live-execution must be one of: 'preflight', 'paper'."
+        ) from exc

--- a/tests/unit/test_app_main.py
+++ b/tests/unit/test_app_main.py
@@ -19,6 +19,26 @@ def test_cli_live_mode_runs_preflight_when_api_key_is_present(capsys, monkeypatc
     assert "Live mode preflight passed" in captured.out
 
 
+def test_cli_live_mode_runs_paper_loop_when_requested(capsys, monkeypatch) -> None:
+    monkeypatch.setenv("TRADING_SYSTEM_API_KEY", "dummy-key")
+
+    exit_code = run(
+        [
+            "--mode",
+            "live",
+            "--symbols",
+            "BTCUSDT",
+            "--live-execution",
+            "paper",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Live mode preflight passed" in captured.out
+    assert "Smoke backtest result" in captured.out
+
+
 def test_cli_live_mode_fails_when_api_key_is_missing(capsys, monkeypatch) -> None:
     monkeypatch.delenv("TRADING_SYSTEM_API_KEY", raising=False)
 
@@ -55,3 +75,12 @@ def test_cli_returns_validation_error_for_unsupported_provider(capsys) -> None:
     assert exit_code == 2
     assert "Configuration error:" in captured.err
     assert "--provider must be one of: 'mock', 'csv'." in captured.err
+
+
+def test_cli_returns_validation_error_for_invalid_live_execution_mode(capsys) -> None:
+    exit_code = run(["--mode", "live", "--live-execution", "invalid"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "Configuration error:" in captured.err
+    assert "--live-execution must be one of: 'preflight', 'paper'." in captured.err

--- a/tests/unit/test_app_services.py
+++ b/tests/unit/test_app_services.py
@@ -21,6 +21,7 @@ def test_build_services_uses_csv_provider_for_domestic_symbol(tmp_path, monkeypa
         symbols="005930",
         provider="csv",
         broker="paper",
+        live_execution="preflight",
         starting_cash="1000000",
         fee_bps="5",
         trade_quantity="1",
@@ -46,6 +47,7 @@ def test_build_services_raises_clear_error_when_csv_file_missing(tmp_path, monke
         symbols="005930",
         provider="csv",
         broker="paper",
+        live_execution="preflight",
         starting_cash="1000000",
         fee_bps="5",
         trade_quantity="1",
@@ -57,3 +59,27 @@ def test_build_services_raises_clear_error_when_csv_file_missing(tmp_path, monke
 
     with pytest.raises(RuntimeError, match="missing: 005930"):
         build_services(settings)
+
+
+def test_live_mode_paper_execution_runs_without_order_submission_error(monkeypatch) -> None:
+    monkeypatch.setenv("TRADING_SYSTEM_API_KEY", "dummy-key")
+
+    settings = AppSettings.from_cli(
+        mode="live",
+        symbols="BTCUSDT",
+        provider="mock",
+        broker="paper",
+        live_execution="paper",
+        starting_cash="10000",
+        fee_bps="5",
+        trade_quantity="0.1",
+        max_position="1",
+        max_notional="100000",
+        max_order_size="0.25",
+    )
+    settings.validate()
+
+    services = build_services(settings)
+    result = services.run_live_paper()
+
+    assert result.processed_bars > 0


### PR DESCRIPTION
### Motivation
- Make the `live` runtime safer by keeping preflight as the default while allowing an explicit paper simulation loop for operators to validate runtime flow without submitting real orders.
- Surface the new behavior in documentation and runbooks so operators know how to opt into paper execution via CLI.
- Provide typed settings/validation and programmatic service support so tests and examples can exercise the paper loop deterministically.

### Description
- Introduced `LiveExecutionMode` and added a `live_execution` field to `AppSettings`, with parsing and validation via `_parse_live_execution_mode` and related checks in `validate`.
- Added `--live-execution` CLI flag to `app.main`, wired `live_execution` into `AppSettings.from_cli`, and conditionally run `services.run_live_paper()` when `LiveExecutionMode.PAPER` is selected. 
- Implemented `AppServices.run_live_paper()` which reuses the deterministic backtest orchestration to run a paper simulation loop without submitting real orders.
- Updated docs (`README.md`, `docs/architecture/workspace-analysis.md`, `docs/runbooks/release-gate-checklist.md`) and examples (`backtest_demo.py`) to document default preflight behavior and the explicit `--live-execution paper` opt-in.

### Testing
- Ran unit test suite covering CLI and service behavior with `pytest tests/unit -q`, including new tests `test_cli_live_mode_runs_paper_loop_when_requested`, `test_live_mode_paper_execution_runs_without_order_submission_error`, and `test_cli_returns_validation_error_for_invalid_live_execution_mode`, and all tests passed.
- Existing integration/regression tests around backtest orchestration and CSV provider were exercised via unit tests and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b9fed1b0108333bf392aa4d5983d4a)