### PR TITLE
Add thin FastAPI HTTP API for backtest and live preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,56 @@ python -m trading_system.app.main --mode live --symbols BTCUSDT --live-execution
 PYTHONPATH=src python -m trading_system.backtest.example
 ```
 
+### 5.8 HTTP API mode / HTTP API 모드
+
+### EN
+Run API server:
+
+```bash
+PYTHONPATH=src uvicorn trading_system.api.server:create_app --factory --host 0.0.0.0 --port 8000
+```
+
+Request examples:
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/v1/backtests \
+  -H "Content-Type: application/json" \
+  -d '{"mode":"backtest","symbols":["BTCUSDT"],"provider":"mock","broker":"paper","live_execution":"preflight","risk":{"max_position":"1","max_notional":"100000","max_order_size":"0.25"},"backtest":{"starting_cash":"10000","fee_bps":"5","trade_quantity":"0.1"}}'
+
+curl http://127.0.0.1:8000/api/v1/backtests/<run_id>
+
+TRADING_SYSTEM_API_KEY=dummy-key \
+curl -X POST http://127.0.0.1:8000/api/v1/live/preflight \
+  -H "Content-Type: application/json" \
+  -d '{"mode":"live","symbols":["BTCUSDT"],"provider":"mock","broker":"paper","live_execution":"preflight","risk":{"max_position":"1","max_notional":"100000","max_order_size":"0.25"},"backtest":{"starting_cash":"10000","fee_bps":"5","trade_quantity":"0.1"}}'
+```
+
+Validation failures are returned as 4xx (`settings_validation_error`), and runtime failures are returned as a structured 5xx body (`runtime_error` or `internal_server_error`).
+
+### KO
+API 서버 실행:
+
+```bash
+PYTHONPATH=src uvicorn trading_system.api.server:create_app --factory --host 0.0.0.0 --port 8000
+```
+
+호출 예시:
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/v1/backtests \
+  -H "Content-Type: application/json" \
+  -d '{"mode":"backtest","symbols":["BTCUSDT"],"provider":"mock","broker":"paper","live_execution":"preflight","risk":{"max_position":"1","max_notional":"100000","max_order_size":"0.25"},"backtest":{"starting_cash":"10000","fee_bps":"5","trade_quantity":"0.1"}}'
+
+curl http://127.0.0.1:8000/api/v1/backtests/<run_id>
+
+TRADING_SYSTEM_API_KEY=dummy-key \
+curl -X POST http://127.0.0.1:8000/api/v1/live/preflight \
+  -H "Content-Type: application/json" \
+  -d '{"mode":"live","symbols":["BTCUSDT"],"provider":"mock","broker":"paper","live_execution":"preflight","risk":{"max_position":"1","max_notional":"100000","max_order_size":"0.25"},"backtest":{"starting_cash":"10000","fee_bps":"5","trade_quantity":"0.1"}}'
+```
+
+입력 검증 실패는 4xx(`settings_validation_error`)로, 실행 중 오류는 구조화된 5xx(`runtime_error` 또는 `internal_server_error`)로 반환합니다.
+
 ---
 
 ## 6) What this system can do now / 현재 시스템으로 할 수 있는 것

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,14 @@ description = "Starter scaffold for a modular Python trading system"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+  "fastapi>=0.116",
   "PyYAML>=6.0",
+  "uvicorn>=0.34",
 ]
 
 [project.optional-dependencies]
 dev = [
+  "httpx>=0.28",
   "pytest>=8.0",
   "ruff>=0.6",
 ]

--- a/src/trading_system/api/__init__.py
+++ b/src/trading_system/api/__init__.py
@@ -1,0 +1,5 @@
+"""HTTP API layer for trading_system."""
+
+from trading_system.api.server import create_app
+
+__all__ = ["create_app"]

--- a/src/trading_system/api/routes/__init__.py
+++ b/src/trading_system/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""API route modules."""

--- a/src/trading_system/api/routes/backtest.py
+++ b/src/trading_system/api/routes/backtest.py
@@ -1,0 +1,108 @@
+from dataclasses import dataclass
+from uuid import uuid4
+
+from fastapi import APIRouter, HTTPException, status
+
+from trading_system.api.schemas import (
+    BacktestResultDTO,
+    BacktestRunAcceptedDTO,
+    BacktestRunRequestDTO,
+    BacktestRunStatusDTO,
+    LivePreflightRequestDTO,
+    LivePreflightResponseDTO,
+)
+from trading_system.app.services import build_services
+from trading_system.app.settings import (
+    AppMode,
+    AppSettings,
+    BacktestSettings,
+    LiveExecutionMode,
+    RiskSettings,
+)
+from trading_system.backtest.engine import BacktestResult
+
+router = APIRouter(prefix="/api/v1", tags=["runtime"])
+
+
+@dataclass(slots=True)
+class StoredRun:
+    status: str
+    result: BacktestResult | None = None
+    error: str | None = None
+
+
+_RUNS: dict[str, StoredRun] = {}
+
+
+def _to_app_settings(payload: BacktestRunRequestDTO | LivePreflightRequestDTO) -> AppSettings:
+    settings = AppSettings(
+        mode=AppMode(payload.mode),
+        symbols=tuple(symbol.strip().upper() for symbol in payload.symbols if symbol.strip()),
+        provider=payload.provider,
+        broker=payload.broker,
+        live_execution=LiveExecutionMode(payload.live_execution),
+        risk=RiskSettings(
+            max_position=payload.risk.max_position,
+            max_notional=payload.risk.max_notional,
+            max_order_size=payload.risk.max_order_size,
+        ),
+        backtest=BacktestSettings(
+            starting_cash=payload.backtest.starting_cash,
+            fee_bps=payload.backtest.fee_bps,
+            trade_quantity=payload.backtest.trade_quantity,
+        ),
+    )
+    settings.validate()
+    return settings
+
+
+def _to_result_dto(result: BacktestResult) -> BacktestResultDTO:
+    return BacktestResultDTO(
+        processed_bars=result.processed_bars,
+        executed_trades=result.executed_trades,
+        rejected_signals=result.rejected_signals,
+        cash=result.final_portfolio.cash,
+        positions=dict(result.final_portfolio.positions),
+        total_return=result.total_return,
+        equity_curve=result.equity_curve,
+    )
+
+
+@router.post(
+    "/backtests",
+    response_model=BacktestRunAcceptedDTO,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_backtest_run(payload: BacktestRunRequestDTO) -> BacktestRunAcceptedDTO:
+    settings = _to_app_settings(payload)
+    run_id = str(uuid4())
+    services = build_services(settings)
+    result = services.run()
+    _RUNS[run_id] = StoredRun(status="succeeded", result=result)
+    return BacktestRunAcceptedDTO(run_id=run_id, status="succeeded")
+
+
+@router.get("/backtests/{run_id}", response_model=BacktestRunStatusDTO)
+def get_backtest_run(run_id: str) -> BacktestRunStatusDTO:
+    run = _RUNS.get(run_id)
+    if run is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Backtest run not found")
+
+    result_dto = _to_result_dto(run.result) if run.result is not None else None
+    return BacktestRunStatusDTO(
+        run_id=run_id,
+        status=run.status,
+        result=result_dto,
+        error=run.error,
+    )
+
+
+@router.post("/live/preflight", response_model=LivePreflightResponseDTO)
+def run_live_preflight(payload: LivePreflightRequestDTO) -> LivePreflightResponseDTO:
+    settings = _to_app_settings(payload)
+    services = build_services(settings)
+    message = services.preflight_live()
+    paper_result = None
+    if settings.live_execution == LiveExecutionMode.PAPER:
+        paper_result = _to_result_dto(services.run_live_paper())
+    return LivePreflightResponseDTO(message=message, paper_result=paper_result)

--- a/src/trading_system/api/schemas.py
+++ b/src/trading_system/api/schemas.py
@@ -1,0 +1,71 @@
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RiskSettingsDTO(BaseModel):
+    max_position: Decimal
+    max_notional: Decimal
+    max_order_size: Decimal
+
+
+class BacktestSettingsDTO(BaseModel):
+    starting_cash: Decimal
+    fee_bps: Decimal
+    trade_quantity: Decimal
+
+
+class BacktestRunRequestDTO(BaseModel):
+    mode: Literal["backtest"] = "backtest"
+    symbols: list[str] = Field(min_length=1)
+    provider: Literal["mock", "csv"] = "mock"
+    broker: Literal["paper"] = "paper"
+    live_execution: Literal["preflight", "paper"] = "preflight"
+    risk: RiskSettingsDTO
+    backtest: BacktestSettingsDTO
+
+
+class LivePreflightRequestDTO(BaseModel):
+    mode: Literal["live"] = "live"
+    symbols: list[str] = Field(min_length=1)
+    provider: Literal["mock", "csv"] = "mock"
+    broker: Literal["paper"] = "paper"
+    live_execution: Literal["preflight", "paper"] = "preflight"
+    risk: RiskSettingsDTO
+    backtest: BacktestSettingsDTO
+
+
+class BacktestResultDTO(BaseModel):
+    processed_bars: int
+    executed_trades: int
+    rejected_signals: int
+    cash: Decimal
+    positions: dict[str, Decimal]
+    total_return: Decimal
+    equity_curve: list[Decimal]
+
+
+class BacktestRunAcceptedDTO(BaseModel):
+    run_id: str
+    status: Literal["succeeded", "failed"]
+
+
+class BacktestRunStatusDTO(BaseModel):
+    run_id: str
+    status: Literal["running", "succeeded", "failed"]
+    result: BacktestResultDTO | None = None
+    error: str | None = None
+
+
+class LivePreflightResponseDTO(BaseModel):
+    status: Literal["ok"] = "ok"
+    message: str
+    paper_result: BacktestResultDTO | None = None
+
+
+class ErrorResponseDTO(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    error_code: str
+    message: str

--- a/src/trading_system/api/server.py
+++ b/src/trading_system/api/server.py
@@ -1,0 +1,45 @@
+from fastapi import FastAPI, Request, status
+from fastapi.responses import JSONResponse
+
+from trading_system.api.routes.backtest import router as backtest_router
+from trading_system.api.schemas import ErrorResponseDTO
+from trading_system.app.settings import SettingsValidationError as AppSettingsValidationError
+from trading_system.config.settings import SettingsValidationError as ConfigSettingsValidationError
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="trading_system API", version="1.0.0")
+    app.include_router(backtest_router)
+
+    @app.exception_handler(AppSettingsValidationError)
+    @app.exception_handler(ConfigSettingsValidationError)
+    async def handle_settings_validation(
+        _request: Request,
+        exc: AppSettingsValidationError | ConfigSettingsValidationError,
+    ) -> JSONResponse:
+        body = ErrorResponseDTO(error_code="settings_validation_error", message=str(exc))
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            content=body.model_dump(),
+        )
+
+    @app.exception_handler(RuntimeError)
+    async def handle_runtime_error(_request: Request, exc: RuntimeError) -> JSONResponse:
+        body = ErrorResponseDTO(error_code="runtime_error", message=str(exc))
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content=body.model_dump(),
+        )
+
+    @app.exception_handler(Exception)
+    async def handle_unexpected_error(_request: Request, _exc: Exception) -> JSONResponse:
+        body = ErrorResponseDTO(
+            error_code="internal_server_error",
+            message="An internal error occurred.",
+        )
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content=body.model_dump(),
+        )
+
+    return app

--- a/tests/unit/test_api_server.py
+++ b/tests/unit/test_api_server.py
@@ -1,0 +1,82 @@
+from fastapi.testclient import TestClient
+
+from trading_system.api.routes import backtest as backtest_routes
+from trading_system.api.server import create_app
+
+
+def _build_client() -> TestClient:
+    backtest_routes._RUNS.clear()
+    return TestClient(create_app())
+
+
+def _base_payload(mode: str) -> dict:
+    return {
+        "mode": mode,
+        "symbols": ["BTCUSDT"],
+        "provider": "mock",
+        "broker": "paper",
+        "live_execution": "preflight",
+        "risk": {
+            "max_position": "1",
+            "max_notional": "100000",
+            "max_order_size": "0.25",
+        },
+        "backtest": {
+            "starting_cash": "10000",
+            "fee_bps": "5",
+            "trade_quantity": "0.1",
+        },
+    }
+
+
+def test_post_backtests_and_get_run_result() -> None:
+    client = _build_client()
+    response = client.post("/api/v1/backtests", json=_base_payload(mode="backtest"))
+
+    assert response.status_code == 201
+    run_id = response.json()["run_id"]
+
+    run_response = client.get(f"/api/v1/backtests/{run_id}")
+
+    assert run_response.status_code == 200
+    body = run_response.json()
+    assert body["status"] == "succeeded"
+    assert body["result"]["processed_bars"] > 0
+
+
+def test_live_preflight_returns_ok_message(monkeypatch) -> None:
+    monkeypatch.setenv("TRADING_SYSTEM_API_KEY", "dummy-key")
+    client = _build_client()
+    response = client.post("/api/v1/live/preflight", json=_base_payload(mode="live"))
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    assert "preflight passed" in response.json()["message"]
+
+
+def test_settings_validation_errors_return_422() -> None:
+    client = _build_client()
+    payload = _base_payload(mode="backtest")
+    payload["risk"]["max_order_size"] = "2"
+
+    response = client.post("/api/v1/backtests", json=payload)
+
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error_code"] == "settings_validation_error"
+    assert "--max-order-size cannot exceed --max-position." in body["message"]
+
+
+def test_runtime_errors_return_structured_500() -> None:
+    client = _build_client()
+    payload = _base_payload(mode="backtest")
+    payload["symbols"] = ["BTCUSDT", "ETHUSDT"]
+
+    response = client.post("/api/v1/backtests", json=payload)
+
+    assert response.status_code == 500
+    body = response.json()
+    assert body == {
+        "error_code": "runtime_error",
+        "message": "Current scaffold supports exactly one symbol for backtest mode.",
+    }


### PR DESCRIPTION
### Motivation
- Provide a small HTTP surface so backtests and live preflight flows can be invoked programmatically rather than only via CLI. 
- Keep domain orchestration and business logic in `app/services.py` and expose it through a thin API layer that directly calls `build_services`, `run`, `preflight_live`, and `run_live_paper`.
- Unify error semantics so settings validation maps to 4xx and runtime/unexpected failures map to structured 5xx responses for easier client handling.
- Assumed an in-memory, process-local run store is acceptable for this minimal API surface.

### Description
- Added new API package `src/trading_system/api/` with `server.py` (app factory + exception handlers), `schemas.py` (Pydantic request/response DTOs), and `routes/backtest.py` (handlers and small in-memory run registry). 
- Implemented endpoints `POST /api/v1/backtests`, `GET /api/v1/backtests/{run_id}`, and `POST /api/v1/live/preflight` which perform thin orchestration by translating DTOs to `AppSettings`, calling `build_services`, and invoking the existing service methods. 
- Centralized exception mapping in the app factory so `SettingsValidationError` (app/config) returns 422 with `settings_validation_error`, `RuntimeError` returns 500 with `runtime_error`, and other exceptions return a structured `internal_server_error` 500 body using `ErrorResponseDTO`. 
- Added unit tests exercising happy and failure paths for the API, updated bilingual README with API server and curl examples, and added runtime/dev dependencies (`fastapi`, `uvicorn`, `httpx`) to `pyproject.toml`.

### Testing
- Installed editable package with dev extras via `python -m pip install -e .[dev]` and the installation completed successfully. 
- Linted code with `ruff check src tests` and the check passed. 
- Ran API and related unit tests with `pytest tests/unit/test_api_server.py tests/unit/test_app_main.py tests/unit/test_app_services.py -q` and all tests passed (`15 passed`). 
- Also ran the focused API test set `pytest tests/unit/test_api_server.py -q` and it passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ba07e95d748333b65fc51c7eb8da1d)