### PR TITLE
Persist backtest runs with repository and DTOs; add GET /api/v1/backtests/{run_id}

### DIFF
--- a/src/trading_system/api/routes/backtest.py
+++ b/src/trading_system/api/routes/backtest.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from datetime import UTC, datetime
 from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, status
@@ -19,19 +19,14 @@ from trading_system.app.settings import (
     LiveExecutionMode,
     RiskSettings,
 )
+from trading_system.backtest.dto import BacktestResultDTO as SerializedBacktestResultDTO
+from trading_system.backtest.dto import BacktestRunDTO
 from trading_system.backtest.engine import BacktestResult
+from trading_system.backtest.repository import InMemoryBacktestRunRepository
 
 router = APIRouter(prefix="/api/v1", tags=["runtime"])
 
-
-@dataclass(slots=True)
-class StoredRun:
-    status: str
-    result: BacktestResult | None = None
-    error: str | None = None
-
-
-_RUNS: dict[str, StoredRun] = {}
+_RUN_REPOSITORY = InMemoryBacktestRunRepository()
 
 
 def _to_app_settings(payload: BacktestRunRequestDTO | LivePreflightRequestDTO) -> AppSettings:
@@ -56,13 +51,17 @@ def _to_app_settings(payload: BacktestRunRequestDTO | LivePreflightRequestDTO) -
     return settings
 
 
-def _to_result_dto(result: BacktestResult) -> BacktestResultDTO:
+def _to_serialized_result(result: BacktestResult) -> SerializedBacktestResultDTO:
+    return SerializedBacktestResultDTO.from_result(result)
+
+
+def _to_api_result_dto(result: SerializedBacktestResultDTO) -> BacktestResultDTO:
     return BacktestResultDTO(
         processed_bars=result.processed_bars,
         executed_trades=result.executed_trades,
         rejected_signals=result.rejected_signals,
-        cash=result.final_portfolio.cash,
-        positions=dict(result.final_portfolio.positions),
+        cash=result.cash,
+        positions=result.positions,
         total_return=result.total_return,
         equity_curve=result.equity_curve,
     )
@@ -76,23 +75,37 @@ def _to_result_dto(result: BacktestResult) -> BacktestResultDTO:
 def create_backtest_run(payload: BacktestRunRequestDTO) -> BacktestRunAcceptedDTO:
     settings = _to_app_settings(payload)
     run_id = str(uuid4())
+    started_at = datetime.now(UTC)
     services = build_services(settings)
     result = services.run()
-    _RUNS[run_id] = StoredRun(status="succeeded", result=result)
+    finished_at = datetime.now(UTC)
+
+    stored_run = BacktestRunDTO.succeeded(
+        run_id=run_id,
+        started_at=started_at,
+        finished_at=finished_at,
+        input_symbols=settings.symbols,
+        mode=settings.mode.value,
+        result=result,
+    )
+    _RUN_REPOSITORY.save(stored_run)
     return BacktestRunAcceptedDTO(run_id=run_id, status="succeeded")
 
 
 @router.get("/backtests/{run_id}", response_model=BacktestRunStatusDTO)
 def get_backtest_run(run_id: str) -> BacktestRunStatusDTO:
-    run = _RUNS.get(run_id)
+    run = _RUN_REPOSITORY.get(run_id)
     if run is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Backtest run not found")
 
-    result_dto = _to_result_dto(run.result) if run.result is not None else None
     return BacktestRunStatusDTO(
-        run_id=run_id,
+        run_id=run.run_id,
         status=run.status,
-        result=result_dto,
+        started_at=run.started_at,
+        finished_at=run.finished_at,
+        input_symbols=run.input_symbols,
+        mode=run.mode,
+        result=_to_api_result_dto(run.result) if run.result is not None else None,
         error=run.error,
     )
 
@@ -104,5 +117,5 @@ def run_live_preflight(payload: LivePreflightRequestDTO) -> LivePreflightRespons
     message = services.preflight_live()
     paper_result = None
     if settings.live_execution == LiveExecutionMode.PAPER:
-        paper_result = _to_result_dto(services.run_live_paper())
+        paper_result = _to_api_result_dto(_to_serialized_result(services.run_live_paper()))
     return LivePreflightResponseDTO(message=message, paper_result=paper_result)

--- a/src/trading_system/api/schemas.py
+++ b/src/trading_system/api/schemas.py
@@ -40,10 +40,10 @@ class BacktestResultDTO(BaseModel):
     processed_bars: int
     executed_trades: int
     rejected_signals: int
-    cash: Decimal
-    positions: dict[str, Decimal]
-    total_return: Decimal
-    equity_curve: list[Decimal]
+    cash: str
+    positions: dict[str, str]
+    total_return: str
+    equity_curve: list[str]
 
 
 class BacktestRunAcceptedDTO(BaseModel):
@@ -54,6 +54,10 @@ class BacktestRunAcceptedDTO(BaseModel):
 class BacktestRunStatusDTO(BaseModel):
     run_id: str
     status: Literal["running", "succeeded", "failed"]
+    started_at: str
+    finished_at: str
+    input_symbols: list[str]
+    mode: Literal["backtest", "live"]
     result: BacktestResultDTO | None = None
     error: str | None = None
 

--- a/src/trading_system/backtest/dto.py
+++ b/src/trading_system/backtest/dto.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from trading_system.backtest.engine import BacktestResult
+
+
+@dataclass(slots=True, frozen=True)
+class BacktestResultDTO:
+    processed_bars: int
+    executed_trades: int
+    rejected_signals: int
+    cash: str
+    positions: dict[str, str]
+    total_return: str
+    equity_curve: list[str]
+
+    @classmethod
+    def from_result(cls, result: BacktestResult) -> "BacktestResultDTO":
+        return cls(
+            processed_bars=result.processed_bars,
+            executed_trades=result.executed_trades,
+            rejected_signals=result.rejected_signals,
+            cash=_decimal_to_json(result.final_portfolio.cash),
+            positions={
+                symbol: _decimal_to_json(quantity)
+                for symbol, quantity in result.final_portfolio.positions.items()
+            },
+            total_return=_decimal_to_json(result.total_return),
+            equity_curve=[_decimal_to_json(point) for point in result.equity_curve],
+        )
+
+
+@dataclass(slots=True, frozen=True)
+class BacktestRunDTO:
+    run_id: str
+    status: str
+    started_at: str
+    finished_at: str
+    input_symbols: list[str]
+    mode: str
+    result: BacktestResultDTO | None = None
+    error: str | None = None
+
+    @classmethod
+    def succeeded(
+        cls,
+        *,
+        run_id: str,
+        started_at: datetime,
+        finished_at: datetime,
+        input_symbols: tuple[str, ...],
+        mode: str,
+        result: BacktestResult,
+    ) -> "BacktestRunDTO":
+        return cls(
+            run_id=run_id,
+            status="succeeded",
+            started_at=_datetime_to_json(started_at),
+            finished_at=_datetime_to_json(finished_at),
+            input_symbols=list(input_symbols),
+            mode=mode,
+            result=BacktestResultDTO.from_result(result),
+        )
+
+
+def _decimal_to_json(value: Decimal) -> str:
+    return format(value, "f")
+
+
+def _datetime_to_json(value: datetime) -> str:
+    normalized = value.astimezone(UTC)
+    return normalized.isoformat().replace("+00:00", "Z")

--- a/src/trading_system/backtest/repository.py
+++ b/src/trading_system/backtest/repository.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from trading_system.backtest.dto import BacktestRunDTO
+
+
+class BacktestRunRepository(Protocol):
+    def save(self, run: BacktestRunDTO) -> None:
+        ...
+
+    def get(self, run_id: str) -> BacktestRunDTO | None:
+        ...
+
+    def clear(self) -> None:
+        ...
+
+
+@dataclass(slots=True)
+class InMemoryBacktestRunRepository(BacktestRunRepository):
+    _runs: dict[str, BacktestRunDTO] = field(default_factory=dict)
+
+    def save(self, run: BacktestRunDTO) -> None:
+        self._runs[run.run_id] = run
+
+    def get(self, run_id: str) -> BacktestRunDTO | None:
+        return self._runs.get(run_id)
+
+    def clear(self) -> None:
+        self._runs.clear()

--- a/tests/integration/test_backtest_run_api_integration.py
+++ b/tests/integration/test_backtest_run_api_integration.py
@@ -1,0 +1,60 @@
+from fastapi.testclient import TestClient
+
+from trading_system.api.routes import backtest as backtest_routes
+from trading_system.api.server import create_app
+
+
+def _base_payload() -> dict:
+    return {
+        "mode": "backtest",
+        "symbols": ["BTCUSDT"],
+        "provider": "mock",
+        "broker": "paper",
+        "live_execution": "preflight",
+        "risk": {
+            "max_position": "1",
+            "max_notional": "100000",
+            "max_order_size": "0.25",
+        },
+        "backtest": {
+            "starting_cash": "10000",
+            "fee_bps": "5",
+            "trade_quantity": "0.1",
+        },
+    }
+
+
+def test_create_then_get_backtest_run_returns_serialized_result_and_metadata() -> None:
+    backtest_routes._RUN_REPOSITORY.clear()
+    client = TestClient(create_app())
+
+    create_response = client.post("/api/v1/backtests", json=_base_payload())
+
+    assert create_response.status_code == 201
+    run_id = create_response.json()["run_id"]
+
+    get_response = client.get(f"/api/v1/backtests/{run_id}")
+
+    assert get_response.status_code == 200
+    body = get_response.json()
+    assert body["run_id"] == run_id
+    assert body["status"] == "succeeded"
+    assert body["mode"] == "backtest"
+    assert body["input_symbols"] == ["BTCUSDT"]
+    assert body["started_at"].endswith("Z")
+    assert body["finished_at"].endswith("Z")
+
+    result = body["result"]
+    assert isinstance(result["cash"], str)
+    assert isinstance(result["total_return"], str)
+    assert all(isinstance(point, str) for point in result["equity_curve"])
+
+
+def test_get_backtest_run_returns_404_for_unknown_run_id() -> None:
+    backtest_routes._RUN_REPOSITORY.clear()
+    client = TestClient(create_app())
+
+    response = client.get("/api/v1/backtests/does-not-exist")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Backtest run not found"}

--- a/tests/unit/test_api_server.py
+++ b/tests/unit/test_api_server.py
@@ -5,7 +5,7 @@ from trading_system.api.server import create_app
 
 
 def _build_client() -> TestClient:
-    backtest_routes._RUNS.clear()
+    backtest_routes._RUN_REPOSITORY.clear()
     return TestClient(create_app())
 
 
@@ -41,6 +41,8 @@ def test_post_backtests_and_get_run_result() -> None:
     assert run_response.status_code == 200
     body = run_response.json()
     assert body["status"] == "succeeded"
+    assert body["mode"] == "backtest"
+    assert body["input_symbols"] == ["BTCUSDT"]
     assert body["result"]["processed_bars"] > 0
 
 


### PR DESCRIPTION
### Motivation
- Provide a clear persistence boundary for backtest runs instead of an ad-hoc module dict and make serialized results JSON-safe for API consumption.
- Ensure run metadata (start/finish times, input symbols, mode) and results are storable and retrievable by `run_id`.

### Description
- Added a `BacktestRunRepository` protocol and an in-memory implementation `InMemoryBacktestRunRepository` with `save/get/clear` in `src/trading_system/backtest/repository.py`.
- Introduced serialization DTOs `BacktestResultDTO` and `BacktestRunDTO` in `src/trading_system/backtest/dto.py` that convert `Decimal` to string and `datetime` to UTC ISO-8601 `Z` for JSON safety.
- Wired the API to generate a `run_id`, capture `started_at`/`finished_at`/`input_symbols`/`mode`, persist the serialized run via the repository on execution, and serve stored runs from `GET /api/v1/backtests/{run_id}` returning 404 when missing (changes in `src/trading_system/api/routes/backtest.py`).
- Updated API pydantic schemas (`src/trading_system/api/schemas.py`) and tests: updated `tests/unit/test_api_server.py` and added integration tests `tests/integration/test_backtest_run_api_integration.py` covering create→get and unknown `run_id` 404.

### Testing
- Installed package and test deps with `python -m pip install -e .` and `python -m pip install httpx`, both completed successfully.
- Ran `pytest tests/integration/test_backtest_run_api_integration.py tests/unit/test_api_server.py` and observed all tests pass (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ba09ced6a88333b8627de62d75787e)