### PR TITLE
Add fixed analytics API DTO and persist backtest events

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,41 @@ curl -X POST http://127.0.0.1:8000/api/v1/live/preflight \
 
 Validation failures are returned as 4xx (`settings_validation_error`), and runtime failures are returned as a structured 5xx body (`runtime_error` or `internal_server_error`).
 
+Visualization response example (fixed schema):
+
+```json
+{
+  "result": {
+    "summary": {
+      "return": "0.0125",
+      "max_drawdown": "-0.0340",
+      "volatility": "0.0217",
+      "win_rate": "0.5714"
+    },
+    "equity_curve": [
+      {"timestamp": "2024-01-01T00:00:00Z", "equity": "10000"},
+      {"timestamp": "2024-01-02T00:00:00Z", "equity": "10125"}
+    ],
+    "drawdown_curve": [
+      {"timestamp": "2024-01-01T00:00:00Z", "drawdown": "0"},
+      {"timestamp": "2024-01-02T00:00:00Z", "drawdown": "0"}
+    ],
+    "orders": [
+      {
+        "event": "order.filled",
+        "payload": {"symbol": "BTCUSDT", "filled_quantity": "0.1", "status": "filled"}
+      }
+    ],
+    "risk_rejections": [
+      {
+        "event": "risk.rejected",
+        "payload": {"symbol": "BTCUSDT", "requested_quantity": "0.5"}
+      }
+    ]
+  }
+}
+```
+
 ### KO
 API 서버 실행:
 
@@ -214,6 +249,41 @@ curl -X POST http://127.0.0.1:8000/api/v1/live/preflight \
 ```
 
 입력 검증 실패는 4xx(`settings_validation_error`)로, 실행 중 오류는 구조화된 5xx(`runtime_error` 또는 `internal_server_error`)로 반환합니다.
+
+시각화 응답 예시(고정 스키마):
+
+```json
+{
+  "result": {
+    "summary": {
+      "return": "0.0125",
+      "max_drawdown": "-0.0340",
+      "volatility": "0.0217",
+      "win_rate": "0.5714"
+    },
+    "equity_curve": [
+      {"timestamp": "2024-01-01T00:00:00Z", "equity": "10000"},
+      {"timestamp": "2024-01-02T00:00:00Z", "equity": "10125"}
+    ],
+    "drawdown_curve": [
+      {"timestamp": "2024-01-01T00:00:00Z", "drawdown": "0"},
+      {"timestamp": "2024-01-02T00:00:00Z", "drawdown": "0"}
+    ],
+    "orders": [
+      {
+        "event": "order.filled",
+        "payload": {"symbol": "BTCUSDT", "filled_quantity": "0.1", "status": "filled"}
+      }
+    ],
+    "risk_rejections": [
+      {
+        "event": "risk.rejected",
+        "payload": {"symbol": "BTCUSDT", "requested_quantity": "0.5"}
+      }
+    ]
+  }
+}
+```
 
 ---
 

--- a/src/trading_system/analytics/view_models.py
+++ b/src/trading_system/analytics/view_models.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from trading_system.analytics.metrics import drawdown_series, performance_metrics
+
+
+@dataclass(slots=True, frozen=True)
+class SummaryViewModel:
+    return_value: Decimal
+    max_drawdown: Decimal
+    volatility: Decimal
+    win_rate: Decimal
+
+
+@dataclass(slots=True, frozen=True)
+class EquityPointViewModel:
+    timestamp: str
+    equity: Decimal
+
+
+@dataclass(slots=True, frozen=True)
+class DrawdownPointViewModel:
+    timestamp: str
+    drawdown: Decimal
+
+
+@dataclass(slots=True, frozen=True)
+class EventViewModel:
+    event: str
+    payload: dict[str, Decimal | str]
+
+
+@dataclass(slots=True, frozen=True)
+class BacktestAnalyticsViewModel:
+    summary: SummaryViewModel
+    equity_curve: list[EquityPointViewModel]
+    drawdown_curve: list[DrawdownPointViewModel]
+    orders: list[EventViewModel]
+    risk_rejections: list[EventViewModel]
+
+
+def build_backtest_analytics_view_model(
+    *,
+    timestamps: list[datetime],
+    equity_curve: list[Decimal],
+    orders: list[EventViewModel],
+    risk_rejections: list[EventViewModel],
+) -> BacktestAnalyticsViewModel:
+    metrics = performance_metrics(equity_curve)
+    drawdowns = drawdown_series(equity_curve)
+    equity_points = [
+        EquityPointViewModel(timestamp=_to_iso8601(timestamp), equity=equity)
+        for timestamp, equity in zip(timestamps, equity_curve, strict=True)
+    ]
+    drawdown_points = [
+        DrawdownPointViewModel(timestamp=point.timestamp, drawdown=drawdown)
+        for point, drawdown in zip(equity_points, drawdowns, strict=True)
+    ]
+    return BacktestAnalyticsViewModel(
+        summary=SummaryViewModel(
+            return_value=metrics.cumulative_return,
+            max_drawdown=metrics.max_drawdown,
+            volatility=metrics.volatility,
+            win_rate=metrics.win_rate,
+        ),
+        equity_curve=equity_points,
+        drawdown_curve=drawdown_points,
+        orders=orders,
+        risk_rejections=risk_rejections,
+    )
+
+
+def _to_iso8601(value: datetime) -> str:
+    normalized = value.astimezone(UTC)
+    return normalized.isoformat().replace("+00:00", "Z")

--- a/src/trading_system/api/routes/backtest.py
+++ b/src/trading_system/api/routes/backtest.py
@@ -57,13 +57,16 @@ def _to_serialized_result(result: BacktestResult) -> SerializedBacktestResultDTO
 
 def _to_api_result_dto(result: SerializedBacktestResultDTO) -> BacktestResultDTO:
     return BacktestResultDTO(
-        processed_bars=result.processed_bars,
-        executed_trades=result.executed_trades,
-        rejected_signals=result.rejected_signals,
-        cash=result.cash,
-        positions=result.positions,
-        total_return=result.total_return,
+        summary={
+            "return": result.summary.return_value,
+            "max_drawdown": result.summary.max_drawdown,
+            "volatility": result.summary.volatility,
+            "win_rate": result.summary.win_rate,
+        },
         equity_curve=result.equity_curve,
+        drawdown_curve=result.drawdown_curve,
+        orders=result.orders,
+        risk_rejections=result.risk_rejections,
     )
 
 

--- a/src/trading_system/api/schemas.py
+++ b/src/trading_system/api/schemas.py
@@ -37,13 +37,31 @@ class LivePreflightRequestDTO(BaseModel):
 
 
 class BacktestResultDTO(BaseModel):
-    processed_bars: int
-    executed_trades: int
-    rejected_signals: int
-    cash: str
-    positions: dict[str, str]
-    total_return: str
-    equity_curve: list[str]
+    class SummaryDTO(BaseModel):
+        return_value: str = Field(alias="return")
+        max_drawdown: str
+        volatility: str
+        win_rate: str
+
+        model_config = ConfigDict(populate_by_name=True)
+
+    class EquityPointDTO(BaseModel):
+        timestamp: str
+        equity: str
+
+    class DrawdownPointDTO(BaseModel):
+        timestamp: str
+        drawdown: str
+
+    class EventDTO(BaseModel):
+        event: str
+        payload: dict[str, str]
+
+    summary: SummaryDTO
+    equity_curve: list[EquityPointDTO]
+    drawdown_curve: list[DrawdownPointDTO]
+    orders: list[EventDTO]
+    risk_rejections: list[EventDTO]
 
 
 class BacktestRunAcceptedDTO(BaseModel):

--- a/src/trading_system/backtest/dto.py
+++ b/src/trading_system/backtest/dto.py
@@ -1,35 +1,76 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal
 
+from trading_system.analytics.view_models import EventViewModel, build_backtest_analytics_view_model
 from trading_system.backtest.engine import BacktestResult
 
 
 @dataclass(slots=True, frozen=True)
+class SummaryDTO:
+    return_value: str
+    max_drawdown: str
+    volatility: str
+    win_rate: str
+
+
+@dataclass(slots=True, frozen=True)
+class EquityPointDTO:
+    timestamp: str
+    equity: str
+
+
+@dataclass(slots=True, frozen=True)
+class DrawdownPointDTO:
+    timestamp: str
+    drawdown: str
+
+
+@dataclass(slots=True, frozen=True)
+class EventDTO:
+    event: str
+    payload: dict[str, str]
+
+
+@dataclass(slots=True, frozen=True)
 class BacktestResultDTO:
-    processed_bars: int
-    executed_trades: int
-    rejected_signals: int
-    cash: str
-    positions: dict[str, str]
-    total_return: str
-    equity_curve: list[str]
+    summary: SummaryDTO
+    equity_curve: list[EquityPointDTO]
+    drawdown_curve: list[DrawdownPointDTO]
+    orders: list[EventDTO]
+    risk_rejections: list[EventDTO]
 
     @classmethod
     def from_result(cls, result: BacktestResult) -> "BacktestResultDTO":
+        analytics = build_backtest_analytics_view_model(
+            timestamps=result.equity_timestamps,
+            equity_curve=result.equity_curve,
+            orders=[_event_to_view_model(event) for event in result.orders],
+            risk_rejections=[_event_to_view_model(event) for event in result.risk_rejections],
+        )
         return cls(
-            processed_bars=result.processed_bars,
-            executed_trades=result.executed_trades,
-            rejected_signals=result.rejected_signals,
-            cash=_decimal_to_json(result.final_portfolio.cash),
-            positions={
-                symbol: _decimal_to_json(quantity)
-                for symbol, quantity in result.final_portfolio.positions.items()
-            },
-            total_return=_decimal_to_json(result.total_return),
-            equity_curve=[_decimal_to_json(point) for point in result.equity_curve],
+            summary=SummaryDTO(
+                return_value=_decimal_to_json(analytics.summary.return_value),
+                max_drawdown=_decimal_to_json(analytics.summary.max_drawdown),
+                volatility=_decimal_to_json(analytics.summary.volatility),
+                win_rate=_decimal_to_json(analytics.summary.win_rate),
+            ),
+            equity_curve=[
+                EquityPointDTO(timestamp=point.timestamp, equity=_decimal_to_json(point.equity))
+                for point in analytics.equity_curve
+            ],
+            drawdown_curve=[
+                DrawdownPointDTO(
+                    timestamp=point.timestamp,
+                    drawdown=_decimal_to_json(point.drawdown),
+                )
+                for point in analytics.drawdown_curve
+            ],
+            orders=[_event_to_dto(event) for event in analytics.orders],
+            risk_rejections=[_event_to_dto(event) for event in analytics.risk_rejections],
         )
 
 
@@ -68,6 +109,29 @@ class BacktestRunDTO:
 
 def _decimal_to_json(value: Decimal) -> str:
     return format(value, "f")
+
+
+def _event_to_view_model(event: dict[str, object]) -> EventViewModel:
+    raw_payload = event.get("payload", {})
+    if not isinstance(raw_payload, Mapping):
+        raw_payload = {}
+    return EventViewModel(
+        event=str(event["event"]),
+        payload={str(key): value for key, value in raw_payload.items()},
+    )
+
+
+def _event_to_dto(event: EventViewModel) -> EventDTO:
+    return EventDTO(
+        event=event.event,
+        payload={key: _value_to_json(value) for key, value in event.payload.items()},
+    )
+
+
+def _value_to_json(value: object) -> str:
+    if isinstance(value, Decimal):
+        return _decimal_to_json(value)
+    return str(value)
 
 
 def _datetime_to_json(value: datetime) -> str:

--- a/src/trading_system/backtest/engine.py
+++ b/src/trading_system/backtest/engine.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterable
 from dataclasses import dataclass
+from datetime import datetime
 from decimal import Decimal
 from typing import Any
 
@@ -32,10 +33,13 @@ class BacktestContext:
 @dataclass(slots=True)
 class BacktestResult:
     final_portfolio: PortfolioBook
+    equity_timestamps: list[datetime]
     equity_curve: list[Decimal]
     processed_bars: int
     executed_trades: int
     rejected_signals: int
+    orders: list[dict[str, Any]]
+    risk_rejections: list[dict[str, Any]]
 
     @property
     def total_return(self) -> Decimal:
@@ -47,11 +51,14 @@ def run_backtest(
     strategy: Strategy,
     context: BacktestContext,
 ) -> BacktestResult:
+    equity_timestamps: list[datetime] = []
     equity_curve: list[Decimal] = []
     processed_bars = 0
     executed_trades = 0
     rejected_signals = 0
     last_prices: dict[str, Decimal] = {}
+    orders: list[dict[str, Any]] = []
+    risk_rejections: list[dict[str, Any]] = []
 
     for bar in bars:
         processed_bars += 1
@@ -59,17 +66,19 @@ def run_backtest(
         order = signal_to_order_request(bar.symbol, signal)
 
         if order is not None:
+            order_created_payload = event_payload(
+                OrderCreatedEvent(
+                    symbol=order.symbol,
+                    side=order.side.value,
+                    quantity=order.quantity,
+                )
+            )
             _emit_event(
                 context.logger,
                 "order.created",
-                event_payload(
-                    OrderCreatedEvent(
-                        symbol=order.symbol,
-                        side=order.side.value,
-                        quantity=order.quantity,
-                    )
-                ),
+                order_created_payload,
             )
+            _record_event(orders, "order.created", order_created_payload)
             signed_quantity = order.quantity if order.side == OrderSide.BUY else -order.quantity
             current_position = context.portfolio.positions.get(bar.symbol, Decimal("0"))
             if context.risk_limits.allows_order(current_position, signed_quantity, bar.close):
@@ -97,9 +106,36 @@ def run_backtest(
                             )
                         ),
                     )
+                    _record_event(
+                        orders,
+                        "order.filled",
+                        event_payload(
+                            OrderFilledEvent(
+                                symbol=fill.symbol,
+                                side=fill.side.value,
+                                requested_quantity=fill.requested_quantity,
+                                filled_quantity=fill.filled_quantity,
+                                fill_price=fill.fill_price,
+                                fee=fill.fee,
+                                status=fill.status.value,
+                            )
+                        ),
+                    )
                 else:
                     _emit_event(
                         context.logger,
+                        "order.rejected",
+                        event_payload(
+                            OrderRejectedEvent(
+                                symbol=order.symbol,
+                                side=order.side.value,
+                                quantity=order.quantity,
+                                reason="unfilled",
+                            )
+                        ),
+                    )
+                    _record_event(
+                        orders,
                         "order.rejected",
                         event_payload(
                             OrderRejectedEvent(
@@ -124,16 +160,32 @@ def run_backtest(
                         )
                     ),
                 )
+                _record_event(
+                    risk_rejections,
+                    "risk.rejected",
+                    event_payload(
+                        RiskRejectedEvent(
+                            symbol=order.symbol,
+                            requested_quantity=signed_quantity,
+                            current_position=current_position,
+                            price=bar.close,
+                        )
+                    ),
+                )
 
         last_prices[bar.symbol] = bar.close
+        equity_timestamps.append(bar.timestamp)
         equity_curve.append(_equity_for_portfolio(context.portfolio, last_prices))
 
     return BacktestResult(
         final_portfolio=context.portfolio,
+        equity_timestamps=equity_timestamps,
         equity_curve=equity_curve,
         processed_bars=processed_bars,
         executed_trades=executed_trades,
         rejected_signals=rejected_signals,
+        orders=orders,
+        risk_rejections=risk_rejections,
     )
 
 
@@ -155,3 +207,7 @@ def _emit_event(
     if logger is None:
         return
     logger.emit(event_name, severity=20, payload=payload)
+
+
+def _record_event(target: list[dict[str, Any]], event_name: str, payload: dict[str, Any]) -> None:
+    target.append({"event": event_name, "payload": payload})

--- a/tests/integration/test_backtest_run_api_integration.py
+++ b/tests/integration/test_backtest_run_api_integration.py
@@ -45,9 +45,21 @@ def test_create_then_get_backtest_run_returns_serialized_result_and_metadata() -
     assert body["finished_at"].endswith("Z")
 
     result = body["result"]
-    assert isinstance(result["cash"], str)
-    assert isinstance(result["total_return"], str)
-    assert all(isinstance(point, str) for point in result["equity_curve"])
+    assert set(result.keys()) == {
+        "summary",
+        "equity_curve",
+        "drawdown_curve",
+        "orders",
+        "risk_rejections",
+    }
+    assert isinstance(result["summary"]["return"], str)
+    assert isinstance(result["summary"]["max_drawdown"], str)
+    assert isinstance(result["summary"]["volatility"], str)
+    assert isinstance(result["summary"]["win_rate"], str)
+    assert all(isinstance(point["timestamp"], str) for point in result["equity_curve"])
+    assert all(isinstance(point["equity"], str) for point in result["equity_curve"])
+    assert all(isinstance(point["timestamp"], str) for point in result["drawdown_curve"])
+    assert all(isinstance(point["drawdown"], str) for point in result["drawdown_curve"])
 
 
 def test_get_backtest_run_returns_404_for_unknown_run_id() -> None:

--- a/tests/unit/test_analytics_metrics.py
+++ b/tests/unit/test_analytics_metrics.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from decimal import Decimal
 
 from trading_system.analytics.metrics import (
@@ -8,6 +9,7 @@ from trading_system.analytics.metrics import (
     volatility,
     win_rate,
 )
+from trading_system.analytics.view_models import EventViewModel, build_backtest_analytics_view_model
 
 
 def test_metrics_for_standard_equity_curve() -> None:
@@ -57,3 +59,42 @@ def test_metrics_handle_zero_or_negative_starting_equity_deterministically() -> 
     assert max_drawdown(negative_curve) == Decimal("-0.2222222222222222222222222222")
     assert volatility(negative_curve) == Decimal("0.1611111111111111111111111111")
     assert win_rate(negative_curve) == Decimal("0.5")
+
+
+def test_view_model_includes_metrics_and_drawdown_curves_for_api_schema() -> None:
+    timestamps = [
+        datetime(2024, 1, 1, tzinfo=UTC),
+        datetime(2024, 1, 2, tzinfo=UTC),
+        datetime(2024, 1, 3, tzinfo=UTC),
+    ]
+    equity_curve = [Decimal("100"), Decimal("120"), Decimal("90")]
+
+    view_model = build_backtest_analytics_view_model(
+        timestamps=timestamps,
+        equity_curve=equity_curve,
+        orders=[
+            EventViewModel(
+                event="order.created",
+                payload={"symbol": "BTCUSDT", "quantity": Decimal("1")},
+            )
+        ],
+        risk_rejections=[
+            EventViewModel(
+                event="risk.rejected",
+                payload={"symbol": "BTCUSDT", "requested_quantity": Decimal("2")},
+            )
+        ],
+    )
+
+    assert view_model.summary.return_value == Decimal("-0.1")
+    assert view_model.summary.max_drawdown == Decimal("-0.25")
+    assert view_model.summary.volatility == Decimal("0.225")
+    assert view_model.summary.win_rate == Decimal("0.5")
+    assert view_model.equity_curve[0].timestamp == "2024-01-01T00:00:00Z"
+    assert [point.drawdown for point in view_model.drawdown_curve] == [
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("-0.25"),
+    ]
+    assert [event.event for event in view_model.orders] == ["order.created"]
+    assert [event.event for event in view_model.risk_rejections] == ["risk.rejected"]

--- a/tests/unit/test_api_backtest_schema.py
+++ b/tests/unit/test_api_backtest_schema.py
@@ -1,0 +1,62 @@
+from fastapi.testclient import TestClient
+
+from trading_system.api.routes import backtest as backtest_routes
+from trading_system.api.server import create_app
+
+
+def _base_payload() -> dict:
+    return {
+        "mode": "backtest",
+        "symbols": ["BTCUSDT"],
+        "provider": "mock",
+        "broker": "paper",
+        "live_execution": "preflight",
+        "risk": {
+            "max_position": "1",
+            "max_notional": "100000",
+            "max_order_size": "0.25",
+        },
+        "backtest": {
+            "starting_cash": "10000",
+            "fee_bps": "5",
+            "trade_quantity": "0.1",
+        },
+    }
+
+
+def test_backtest_result_schema_is_stable_for_visualization_clients() -> None:
+    backtest_routes._RUN_REPOSITORY.clear()
+    client = TestClient(create_app())
+
+    create_response = client.post("/api/v1/backtests", json=_base_payload())
+    run_id = create_response.json()["run_id"]
+    get_response = client.get(f"/api/v1/backtests/{run_id}")
+
+    assert get_response.status_code == 200
+    result = get_response.json()["result"]
+    assert set(result.keys()) == {
+        "summary",
+        "equity_curve",
+        "drawdown_curve",
+        "orders",
+        "risk_rejections",
+    }
+    assert set(result["summary"].keys()) == {"return", "max_drawdown", "volatility", "win_rate"}
+    assert all(set(point.keys()) == {"timestamp", "equity"} for point in result["equity_curve"])
+    assert all(
+        set(point.keys()) == {"timestamp", "drawdown"} for point in result["drawdown_curve"]
+    )
+    assert all(set(event.keys()) == {"event", "payload"} for event in result["orders"])
+    assert all(set(event.keys()) == {"event", "payload"} for event in result["risk_rejections"])
+
+
+def test_backtest_result_schema_has_matching_curve_lengths() -> None:
+    backtest_routes._RUN_REPOSITORY.clear()
+    client = TestClient(create_app())
+
+    create_response = client.post("/api/v1/backtests", json=_base_payload())
+    run_id = create_response.json()["run_id"]
+    get_response = client.get(f"/api/v1/backtests/{run_id}")
+
+    result = get_response.json()["result"]
+    assert len(result["equity_curve"]) == len(result["drawdown_curve"])

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -51,7 +51,10 @@ def test_run_backtest_executes_buy_at_close_and_records_return() -> None:
     assert result.rejected_signals == 0
     assert result.final_portfolio.positions["BTCUSDT"] == Decimal("2")
     assert result.final_portfolio.cash == Decimal("800")
+    assert len(result.equity_timestamps) == 2
     assert result.equity_curve == [Decimal("1000"), Decimal("1020")]
+    assert [event["event"] for event in result.orders] == ["order.created", "order.filled"]
+    assert result.risk_rejections == []
     assert result.total_return == Decimal("0.02")
 
 
@@ -74,6 +77,7 @@ def test_run_backtest_executes_sell_using_negative_signed_quantity() -> None:
     assert result.final_portfolio.positions["BTCUSDT"] == Decimal("0.5")
     assert result.final_portfolio.cash == Decimal("650")
     assert result.equity_curve == [Decimal("700")]
+    assert [event["event"] for event in result.orders] == ["order.created", "order.filled"]
 
 
 def test_run_backtest_rejects_signal_when_risk_limits_fail() -> None:
@@ -97,6 +101,8 @@ def test_run_backtest_rejects_signal_when_risk_limits_fail() -> None:
     assert result.final_portfolio.positions == {}
     assert result.final_portfolio.cash == Decimal("1000")
     assert result.equity_curve == [Decimal("1000")]
+    assert [event["event"] for event in result.orders] == ["order.created"]
+    assert [event["event"] for event in result.risk_rejections] == ["risk.rejected"]
 
 
 def test_run_backtest_applies_commission_fee() -> None:
@@ -133,6 +139,7 @@ def test_run_backtest_supports_partial_fill_and_unfilled_order() -> None:
     assert partial_result.executed_trades == 1
     assert partial_result.final_portfolio.positions["BTCUSDT"] == Decimal("1")
     assert partial_result.final_portfolio.cash == Decimal("900")
+    assert [event["event"] for event in partial_result.orders] == ["order.created", "order.filled"]
 
     unfilled_context = BacktestContext(
         portfolio=PortfolioBook(cash=Decimal("1000")),
@@ -150,6 +157,7 @@ def test_run_backtest_supports_partial_fill_and_unfilled_order() -> None:
     assert unfilled_result.executed_trades == 0
     assert unfilled_result.final_portfolio.positions == {}
     assert unfilled_result.final_portfolio.cash == Decimal("1000")
+    assert [event["event"] for event in unfilled_result.orders] == ["order.created", "order.rejected"]
 
 
 def test_run_backtest_applies_slippage_to_fill_price() -> None:


### PR DESCRIPTION
### Motivation
- Stabilize the backtest API response into a fixed visualization-oriented schema containing `summary`, `equity_curve`, `drawdown_curve`, `orders`, and `risk_rejections` so downstream visualizers have a predictable DTO. 
- Expose existing analytics (`performance_metrics`, `drawdown_series`) in an API-friendly form and ensure event history from the backtest engine is preserved (not only logged). 
- Add tests and docs to lock the schema shape and protect regressions.

### Description
- Added `src/trading_system/analytics/view_models.py` which builds API-facing analytics payloads from `performance_metrics` and `drawdown_series` and normalizes timestamps to UTC ISO-8601. 
- Extended `BacktestResult` and `run_backtest` in `src/trading_system/backtest/engine.py` to accumulate `equity_timestamps`, `orders`, and `risk_rejections` (records for `order.created`, `order.filled`, `order.rejected`, and `risk.rejected`) in the returned result independently of structured logging. 
- Reworked serialization in `src/trading_system/backtest/dto.py` to produce the fixed visualization DTO (`summary`, `equity_curve`, `drawdown_curve`, `orders`, `risk_rejections`) and added safe conversion helpers for event payloads. 
- Updated API Pydantic schemas in `src/trading_system/api/schemas.py` and the backtest route mapping in `src/trading_system/api/routes/backtest.py` to return the new fixed structure (including `summary.return` alias). 
- Updated and added tests: extended `tests/unit/test_backtest_engine.py`, extended `tests/unit/test_analytics_metrics.py`, added `tests/unit/test_api_backtest_schema.py`, and updated `tests/integration/test_backtest_run_api_integration.py` to validate the new schema shape. 
- Added English/Korean visualization response examples to `README.md` demonstrating the fixed schema.

### Testing
- Ran targeted unit test set with `pytest tests/unit/test_analytics_metrics.py tests/unit/test_backtest_engine.py` and both files passed (`11 passed`).
- Ran broader test selection including API/integration tests with `pytest tests/unit/test_api_backtest_schema.py tests/integration/test_backtest_run_api_integration.py` and collection failed due to missing runtime dependency `fastapi` in the test environment (module import error during collection).
- Notes: unit-focused validations for metrics, view-model composition, and engine event persistence succeeded; full API integration requires `fastapi` available in the environment to validate end-to-end serialization.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ba0fe58c8c8333b5577c70d6a4dea7)