### PR TITLE
Add minimal static frontend for backtest run creation, listing, and result visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,84 @@ curl -X POST http://127.0.0.1:8000/api/v1/live/preflight \
 }
 ```
 
+### 5.9 Frontend + backend local development / 프론트엔드 + 백엔드 로컬 개발
+
+### EN
+The repository now includes a minimal static frontend under `frontend/` with three pages:
+
+- `frontend/index.html`: backtest run form (symbol/risk/fee inputs)
+- `frontend/runs.html`: run list and status refresh
+- `frontend/run.html?run_id=<id>`: result details with equity/drawdown time-series charts and fill/rejection event table
+
+Run backend and frontend together in two terminals:
+
+```bash
+# Terminal A: backend API
+PYTHONPATH=src uvicorn trading_system.api.server:create_app --factory --host 0.0.0.0 --port 8000
+
+# Terminal B: static frontend
+python -m http.server 5173 -d frontend
+```
+
+Open `http://127.0.0.1:5173/index.html`.
+
+Local development flow:
+
+1. Start backend API server.
+2. Start frontend static server.
+3. Submit a run from `index.html`.
+4. Check run status in `runs.html`.
+5. Inspect charts/events in `run.html?run_id=<id>`.
+
+API endpoint contract used by frontend client:
+
+- `POST /api/v1/backtests` → create run
+- `GET /api/v1/backtests/{run_id}` → fetch run status/result
+
+Frontend error handling is separated by path:
+
+- Network failure: backend not reachable
+- 4xx failure: validation/input issue from API
+- 5xx failure: runtime/internal server issue
+
+### KO
+저장소에는 `frontend/` 경로에 최소 정적 프론트엔드가 포함되어 있으며, 다음 3개 페이지를 제공합니다.
+
+- `frontend/index.html`: 백테스트 실행 폼 (심볼/리스크/수수료 입력)
+- `frontend/runs.html`: 실행 목록 및 상태 갱신
+- `frontend/run.html?run_id=<id>`: Equity/Drawdown 시계열 차트 + 체결/거절 이벤트 테이블 상세
+
+백엔드와 프론트를 각각 다른 터미널에서 실행하세요:
+
+```bash
+# 터미널 A: 백엔드 API
+PYTHONPATH=src uvicorn trading_system.api.server:create_app --factory --host 0.0.0.0 --port 8000
+
+# 터미널 B: 정적 프론트엔드 서버
+python -m http.server 5173 -d frontend
+```
+
+브라우저에서 `http://127.0.0.1:5173/index.html`를 열면 됩니다.
+
+로컬 개발 흐름:
+
+1. 백엔드 API 서버 실행
+2. 프론트 정적 서버 실행
+3. `index.html`에서 실행 요청 제출
+4. `runs.html`에서 상태 확인
+5. `run.html?run_id=<id>`에서 차트/이벤트 상세 확인
+
+프론트 클라이언트가 사용하는 API 계약:
+
+- `POST /api/v1/backtests` → 실행 생성
+- `GET /api/v1/backtests/{run_id}` → 실행 상태/결과 조회
+
+프론트 오류 메시지는 다음 경로로 구분해 표시합니다.
+
+- 네트워크 오류: 백엔드 미접속
+- 4xx 오류: API 입력/검증 문제
+- 5xx 오류: 런타임/서버 내부 문제
+
 ---
 
 ## 6) What this system can do now / 현재 시스템으로 할 수 있는 것

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Backtest Runner</title>
+    <link rel="stylesheet" href="./src/styles.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>Backtest Runner</h1>
+      <nav>
+        <a href="./index.html">Run Form</a>
+        <a href="./runs.html">Runs</a>
+      </nav>
+    </header>
+
+    <main class="container">
+      <section class="card">
+        <h2>Create Run</h2>
+        <form id="backtest-form" class="form-grid">
+          <label>
+            Symbol
+            <input id="symbol" name="symbol" value="BTCUSDT" required />
+          </label>
+          <label>
+            Max position
+            <input id="max-position" name="maxPosition" type="number" step="0.0001" min="0.0001" value="1" required />
+          </label>
+          <label>
+            Max notional
+            <input id="max-notional" name="maxNotional" type="number" step="0.01" min="0.01" value="100000" required />
+          </label>
+          <label>
+            Max order size
+            <input id="max-order-size" name="maxOrderSize" type="number" step="0.0001" min="0.0001" value="0.25" required />
+          </label>
+          <label>
+            Trade quantity
+            <input id="trade-quantity" name="tradeQuantity" type="number" step="0.0001" min="0.0001" value="0.1" required />
+          </label>
+          <label>
+            Fee (bps)
+            <input id="fee-bps" name="feeBps" type="number" step="0.01" min="0" value="5" required />
+          </label>
+          <button id="submit-button" type="submit">Start Backtest</button>
+        </form>
+        <p id="form-message" class="message" role="status" aria-live="polite"></p>
+      </section>
+    </main>
+
+    <script type="module" src="./src/pages/createRunPage.js"></script>
+  </body>
+</html>

--- a/frontend/run.html
+++ b/frontend/run.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Backtest Run Detail</title>
+    <link rel="stylesheet" href="./src/styles.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>Backtest Detail</h1>
+      <nav>
+        <a href="./index.html">Run Form</a>
+        <a href="./runs.html">Runs</a>
+      </nav>
+    </header>
+
+    <main class="container">
+      <section class="card">
+        <div class="row-between">
+          <h2 id="run-title">Run</h2>
+          <button id="refresh-detail" type="button">Refresh</button>
+        </div>
+        <p id="detail-message" class="message" role="status" aria-live="polite"></p>
+        <div id="summary"></div>
+      </section>
+
+      <section class="card">
+        <h3>Equity Curve (time axis)</h3>
+        <div id="equity-chart"></div>
+      </section>
+
+      <section class="card">
+        <h3>Drawdown Curve (time axis)</h3>
+        <div id="drawdown-chart"></div>
+      </section>
+
+      <section class="card">
+        <h3>Fill / Rejection Events</h3>
+        <table>
+          <thead>
+            <tr>
+              <th>Type</th>
+              <th>Event</th>
+              <th>Symbol</th>
+              <th>Quantity</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody id="events-table-body"></tbody>
+        </table>
+      </section>
+    </main>
+
+    <script type="module" src="./src/pages/runDetailPage.js"></script>
+  </body>
+</html>

--- a/frontend/runs.html
+++ b/frontend/runs.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Backtest Runs</title>
+    <link rel="stylesheet" href="./src/styles.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>Backtest Runs</h1>
+      <nav>
+        <a href="./index.html">Run Form</a>
+        <a href="./runs.html">Runs</a>
+      </nav>
+    </header>
+
+    <main class="container">
+      <section class="card">
+        <div class="row-between">
+          <h2>Run List / Status</h2>
+          <button id="refresh-runs" type="button">Refresh</button>
+        </div>
+        <p id="runs-message" class="message" role="status" aria-live="polite"></p>
+        <table>
+          <thead>
+            <tr>
+              <th>Run ID</th>
+              <th>Symbol</th>
+              <th>Status</th>
+              <th>Created (UTC)</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody id="runs-table-body"></tbody>
+        </table>
+      </section>
+    </main>
+
+    <script type="module" src="./src/pages/runsPage.js"></script>
+  </body>
+</html>

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,0 +1,92 @@
+const DEFAULT_BASE_URL = "http://127.0.0.1:8000/api/v1";
+
+export class ApiError extends Error {
+  constructor(kind, message, status = null, payload = null) {
+    super(message);
+    this.name = "ApiError";
+    this.kind = kind;
+    this.status = status;
+    this.payload = payload;
+  }
+}
+
+function resolveBaseUrl() {
+  const configured = window.localStorage.getItem("ts_api_base_url");
+  return configured || DEFAULT_BASE_URL;
+}
+
+async function requestJson(path, options = {}) {
+  const url = `${resolveBaseUrl()}${path}`;
+  let response;
+
+  try {
+    response = await fetch(url, {
+      headers: { "Content-Type": "application/json" },
+      ...options,
+    });
+  } catch (_networkError) {
+    throw new ApiError("network", "Cannot reach backend API. Check host/port.");
+  }
+
+  const rawBody = await response.text();
+  let parsed = null;
+  if (rawBody) {
+    try {
+      parsed = JSON.parse(rawBody);
+    } catch (_syntaxError) {
+      parsed = null;
+    }
+  }
+
+  if (response.ok) {
+    return parsed;
+  }
+
+  if (response.status >= 400 && response.status < 500) {
+    throw new ApiError(
+      "validation",
+      parsed?.message || parsed?.detail || "Validation error from backend.",
+      response.status,
+      parsed,
+    );
+  }
+
+  if (response.status >= 500) {
+    throw new ApiError(
+      "server",
+      parsed?.message || "Server error while handling request.",
+      response.status,
+      parsed,
+    );
+  }
+
+  throw new ApiError("http", `Unexpected HTTP status: ${response.status}`, response.status, parsed);
+}
+
+export async function createBacktestRun(payload) {
+  return requestJson("/backtests", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function getBacktestRun(runId) {
+  return requestJson(`/backtests/${encodeURIComponent(runId)}`);
+}
+
+export function userMessageForError(error) {
+  if (!(error instanceof ApiError)) {
+    return "Unexpected error occurred in client.";
+  }
+
+  if (error.kind === "network") {
+    return "네트워크 오류: 백엔드 서버에 연결할 수 없습니다. 서버 실행 상태를 확인하세요.";
+  }
+  if (error.kind === "validation") {
+    return `요청 검증 오류(4xx): ${error.message}`;
+  }
+  if (error.kind === "server") {
+    return `서버 오류(5xx): ${error.message}`;
+  }
+  return `HTTP 오류: ${error.message}`;
+}

--- a/frontend/src/pages/createRunPage.js
+++ b/frontend/src/pages/createRunPage.js
@@ -1,0 +1,56 @@
+import { createBacktestRun, userMessageForError } from "../api/client.js";
+import { saveRun } from "../state/runStore.js";
+
+const form = document.getElementById("backtest-form");
+const message = document.getElementById("form-message");
+const submitButton = document.getElementById("submit-button");
+
+function setMessage(text, isError = false) {
+  message.textContent = text;
+  message.classList.toggle("error", isError);
+}
+
+function buildPayload(formData) {
+  return {
+    mode: "backtest",
+    symbols: [String(formData.get("symbol")).trim().toUpperCase()],
+    provider: "mock",
+    broker: "paper",
+    live_execution: "preflight",
+    risk: {
+      max_position: String(formData.get("maxPosition")),
+      max_notional: String(formData.get("maxNotional")),
+      max_order_size: String(formData.get("maxOrderSize")),
+    },
+    backtest: {
+      starting_cash: "10000",
+      fee_bps: String(formData.get("feeBps")),
+      trade_quantity: String(formData.get("tradeQuantity")),
+    },
+  };
+}
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  submitButton.disabled = true;
+  setMessage("Submitting...", false);
+
+  const formData = new FormData(form);
+  const payload = buildPayload(formData);
+
+  try {
+    const created = await createBacktestRun(payload);
+    saveRun({
+      runId: created.run_id,
+      status: created.status,
+      symbol: payload.symbols[0],
+      createdAt: new Date().toISOString(),
+    });
+    setMessage(`Run created: ${created.run_id}`, false);
+    window.location.href = `./run.html?run_id=${encodeURIComponent(created.run_id)}`;
+  } catch (error) {
+    setMessage(userMessageForError(error), true);
+  } finally {
+    submitButton.disabled = false;
+  }
+});

--- a/frontend/src/pages/runDetailPage.js
+++ b/frontend/src/pages/runDetailPage.js
@@ -1,0 +1,125 @@
+import { getBacktestRun, userMessageForError } from "../api/client.js";
+import { renderTimeSeriesChart } from "../utils/charts.js";
+import {
+  formatDecimal,
+  formatPercentFromRatio,
+  formatUtcTimestamp,
+} from "../utils/formatters.js";
+
+const title = document.getElementById("run-title");
+const message = document.getElementById("detail-message");
+const summary = document.getElementById("summary");
+const equityChart = document.getElementById("equity-chart");
+const drawdownChart = document.getElementById("drawdown-chart");
+const eventsBody = document.getElementById("events-table-body");
+const refreshButton = document.getElementById("refresh-detail");
+
+function setMessage(text, isError = false) {
+  message.textContent = text;
+  message.classList.toggle("error", isError);
+}
+
+function renderSummary(detail) {
+  const stats = detail.result?.summary;
+  if (!stats) {
+    summary.textContent = "Result is not ready.";
+    return;
+  }
+
+  const items = [
+    ["Return", formatPercentFromRatio(stats.return)],
+    ["Max Drawdown", formatPercentFromRatio(stats.max_drawdown)],
+    ["Volatility", formatPercentFromRatio(stats.volatility)],
+    ["Win Rate", formatPercentFromRatio(stats.win_rate)],
+    ["Started (UTC)", formatUtcTimestamp(detail.started_at)],
+    ["Finished (UTC)", formatUtcTimestamp(detail.finished_at)],
+  ];
+  summary.innerHTML = "";
+  const grid = document.createElement("div");
+  grid.className = "summary-grid";
+  for (const [labelText, valueText] of items) {
+    const wrapper = document.createElement("div");
+    wrapper.className = "summary-item";
+    const label = document.createElement("div");
+    label.className = "label";
+    label.textContent = labelText;
+    const value = document.createElement("div");
+    value.className = "value";
+    value.textContent = valueText;
+    wrapper.append(label, value);
+    grid.append(wrapper);
+  }
+  summary.append(grid);
+}
+
+function renderEvents(detail) {
+  const orders = detail.result?.orders ?? [];
+  const rejections = detail.result?.risk_rejections ?? [];
+  const rows = [
+    ...orders.map((event) => ({ type: "fill", ...event })),
+    ...rejections.map((event) => ({ type: "rejection", ...event })),
+  ];
+
+  eventsBody.innerHTML = "";
+  for (const row of rows) {
+    const tr = document.createElement("tr");
+    const symbol = row.payload.symbol ?? "-";
+    const qty = row.payload.filled_quantity ?? row.payload.requested_quantity ?? "-";
+    const qtyText = formatDecimal(qty);
+    const status = row.payload.status ?? (row.type === "rejection" ? "rejected" : "-");
+    const cells = [row.type, row.event, symbol, qtyText, status];
+    for (const value of cells) {
+      const td = document.createElement("td");
+      td.textContent = value;
+      tr.append(td);
+    }
+    eventsBody.append(tr);
+  }
+
+  if (rows.length === 0) {
+    const tr = document.createElement("tr");
+    tr.innerHTML = '<td colspan="5">No fill/rejection events.</td>';
+    eventsBody.append(tr);
+  }
+}
+
+function renderCharts(detail) {
+  const result = detail.result;
+  if (!result) {
+    equityChart.textContent = "No equity data.";
+    drawdownChart.textContent = "No drawdown data.";
+    return;
+  }
+
+  renderTimeSeriesChart(equityChart, result.equity_curve, "equity", "#2563eb");
+  renderTimeSeriesChart(drawdownChart, result.drawdown_curve, "drawdown", "#dc2626");
+}
+
+function getRunId() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get("run_id")?.trim() || "";
+}
+
+async function loadDetail() {
+  const runId = getRunId();
+  if (!runId) {
+    setMessage("run_id query parameter is required.", true);
+    return;
+  }
+
+  title.textContent = `Run ${runId}`;
+  setMessage("Loading...", false);
+
+  try {
+    const detail = await getBacktestRun(runId);
+    setMessage(`Status: ${detail.status}`, false);
+    renderSummary(detail);
+    renderCharts(detail);
+    renderEvents(detail);
+  } catch (error) {
+    setMessage(userMessageForError(error), true);
+  }
+}
+
+refreshButton.addEventListener("click", loadDetail);
+loadDetail();

--- a/frontend/src/pages/runsPage.js
+++ b/frontend/src/pages/runsPage.js
@@ -1,0 +1,60 @@
+import { getBacktestRun, userMessageForError } from "../api/client.js";
+import { formatUtcTimestamp } from "../utils/formatters.js";
+import { listRuns, updateRunStatus } from "../state/runStore.js";
+
+const tableBody = document.getElementById("runs-table-body");
+const message = document.getElementById("runs-message");
+const refreshButton = document.getElementById("refresh-runs");
+
+function setMessage(text, isError = false) {
+  message.textContent = text;
+  message.classList.toggle("error", isError);
+}
+
+function renderRows(runs) {
+  tableBody.innerHTML = "";
+  for (const run of runs) {
+    const tr = document.createElement("tr");
+    const runId = document.createElement("td");
+    runId.textContent = run.runId;
+    const symbol = document.createElement("td");
+    symbol.textContent = run.symbol ?? "-";
+    const status = document.createElement("td");
+    status.textContent = run.status;
+    const createdAt = document.createElement("td");
+    createdAt.textContent = formatUtcTimestamp(run.createdAt);
+    const action = document.createElement("td");
+    const link = document.createElement("a");
+    link.href = `./run.html?run_id=${encodeURIComponent(run.runId)}`;
+    link.textContent = "Open";
+    action.append(link);
+    tr.append(runId, symbol, status, createdAt, action);
+    tableBody.append(tr);
+  }
+}
+
+async function refreshStatuses() {
+  const runs = listRuns();
+  renderRows(runs);
+  if (runs.length === 0) {
+    setMessage("No runs saved yet.", false);
+    return;
+  }
+
+  setMessage("Refreshing run statuses...", false);
+  try {
+    await Promise.all(
+      runs.map(async (run) => {
+        const detail = await getBacktestRun(run.runId);
+        updateRunStatus(run.runId, detail.status);
+      }),
+    );
+    renderRows(listRuns());
+    setMessage("Status refresh completed.", false);
+  } catch (error) {
+    setMessage(userMessageForError(error), true);
+  }
+}
+
+refreshButton.addEventListener("click", refreshStatuses);
+refreshStatuses();

--- a/frontend/src/state/runStore.js
+++ b/frontend/src/state/runStore.js
@@ -1,0 +1,25 @@
+const STORAGE_KEY = "ts_backtest_runs";
+
+export function listRuns() {
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (_syntaxError) {
+    return [];
+  }
+}
+
+export function saveRun(run) {
+  const runs = listRuns().filter((item) => item.runId !== run.runId);
+  runs.unshift(run);
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(runs.slice(0, 100)));
+}
+
+export function updateRunStatus(runId, status) {
+  const runs = listRuns().map((run) => (run.runId === runId ? { ...run, status } : run));
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(runs));
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,137 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  background: #f6f7fb;
+  color: #1f2937;
+}
+
+.page-header {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 1rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.page-header nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.page-header a {
+  color: #bae6fd;
+  text-decoration: none;
+}
+
+.container {
+  max-width: 1000px;
+  margin: 1.5rem auto;
+  padding: 0 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.6rem;
+  padding: 1rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.8rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+input,
+button {
+  border-radius: 0.4rem;
+  border: 1px solid #cbd5e1;
+  padding: 0.45rem 0.65rem;
+  font-size: 0.95rem;
+}
+
+button {
+  background: #0ea5e9;
+  color: white;
+  border-color: #0284c7;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.message {
+  min-height: 1.25rem;
+  margin-top: 0.6rem;
+  color: #0f766e;
+}
+
+.message.error {
+  color: #b91c1c;
+}
+
+.row-between {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.6rem;
+}
+
+th,
+td {
+  border-bottom: 1px solid #e5e7eb;
+  text-align: left;
+  padding: 0.45rem;
+  font-size: 0.88rem;
+}
+
+svg {
+  width: 100%;
+  height: 260px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.4rem;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 0.6rem;
+}
+
+.summary-item {
+  border: 1px solid #e2e8f0;
+  border-radius: 0.4rem;
+  padding: 0.6rem;
+}
+
+.summary-item .label {
+  font-size: 0.76rem;
+  color: #475569;
+}
+
+.summary-item .value {
+  font-weight: 700;
+  margin-top: 0.3rem;
+}

--- a/frontend/src/utils/charts.js
+++ b/frontend/src/utils/charts.js
@@ -1,0 +1,68 @@
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+function createSvg(width, height) {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+  return svg;
+}
+
+function scale(value, min, max, outMin, outMax) {
+  if (max <= min) {
+    return (outMin + outMax) / 2;
+  }
+  const ratio = (value - min) / (max - min);
+  return outMin + ratio * (outMax - outMin);
+}
+
+function makePoints(curve, valueKey, width, height, padding) {
+  const valid = curve
+    .map((p) => ({ x: Date.parse(p.timestamp), y: Number(p[valueKey]) }))
+    .filter((p) => Number.isFinite(p.x) && Number.isFinite(p.y));
+
+  if (valid.length === 0) {
+    return [];
+  }
+
+  const xMin = Math.min(...valid.map((p) => p.x));
+  const xMax = Math.max(...valid.map((p) => p.x));
+  const yMin = Math.min(...valid.map((p) => p.y));
+  const yMax = Math.max(...valid.map((p) => p.y));
+
+  return valid.map((p) => {
+    const sx = scale(p.x, xMin, xMax, padding, width - padding);
+    const sy = scale(p.y, yMin, yMax, height - padding, padding);
+    return `${sx},${sy}`;
+  });
+}
+
+export function renderTimeSeriesChart(container, curve, valueKey, color) {
+  container.innerHTML = "";
+  const width = 900;
+  const height = 260;
+  const padding = 26;
+
+  const svg = createSvg(width, height);
+  const points = makePoints(curve, valueKey, width, height, padding);
+
+  if (points.length === 0) {
+    container.textContent = "No chart data.";
+    return;
+  }
+
+  const axis = document.createElementNS(SVG_NS, "line");
+  axis.setAttribute("x1", String(padding));
+  axis.setAttribute("y1", String(height - padding));
+  axis.setAttribute("x2", String(width - padding));
+  axis.setAttribute("y2", String(height - padding));
+  axis.setAttribute("stroke", "#94a3b8");
+  axis.setAttribute("stroke-width", "1");
+
+  const polyline = document.createElementNS(SVG_NS, "polyline");
+  polyline.setAttribute("points", points.join(" "));
+  polyline.setAttribute("fill", "none");
+  polyline.setAttribute("stroke", color);
+  polyline.setAttribute("stroke-width", "2");
+
+  svg.append(axis, polyline);
+  container.append(svg);
+}

--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -1,0 +1,43 @@
+const numberFmt = new Intl.NumberFormat("en-US", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const currencyFmt = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const percentFmt = new Intl.NumberFormat("en-US", {
+  style: "percent",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const dateFmt = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "short",
+  timeStyle: "short",
+  timeZone: "UTC",
+});
+
+export function formatDecimal(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? numberFmt.format(n) : "-";
+}
+
+export function formatCurrency(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? currencyFmt.format(n) : "-";
+}
+
+export function formatPercentFromRatio(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? percentFmt.format(n) : "-";
+}
+
+export function formatUtcTimestamp(timestamp) {
+  const t = Date.parse(timestamp);
+  return Number.isFinite(t) ? dateFmt.format(new Date(t)) : "-";
+}


### PR DESCRIPTION
### Motivation

- Provide a minimal local UI so operators can create backtest runs, inspect run status, and view result visualizations without introducing a heavy frontend stack. 
- Keep the backend API contract unchanged and implement a zero-dependency static client that consumes `POST /api/v1/backtests` and `GET /api/v1/backtests/{run_id}`. 
- Make failure paths explicit in the UI (network / 4xx validation / 5xx server) and surface time-series charts with simple, deterministic rendering logic.

### Description

- Added a static frontend under `frontend/` with three pages: `index.html` (run form), `runs.html` (run list/status), and `run.html` (detailed result view with charts and events). 
- Implemented an API client at `frontend/src/api/client.js` that performs `POST /backtests` and `GET /backtests/{run_id}`, classifies errors as `network` / `validation` / `server` / `http`, and exposes `userMessageForError` for localized UI messages. 
- Added utility modules: `frontend/src/utils/formatters.js` for decimal/currency/percent/UTC formatting and `frontend/src/utils/charts.js` for simple time-axis SVG chart rendering of equity and drawdown curves. 
- Implemented page logic and local run state storage: `createRunPage.js` (submit + save run), `runsPage.js` (list + refresh status), `runDetailPage.js` (summary, charts, events), and `runStore.js` (localStorage persistence); also added styles in `frontend/src/styles.css`. 
- Documented local developer flow and concurrent backend/frontend run commands (EN/KO) in `README.md` and explicitly described the API contract and UI error branches.

### Testing

- Ran `pytest tests/unit/test_api_server.py tests/unit/test_api_backtest_schema.py -q`, which failed during test collection with `ModuleNotFoundError: No module named 'fastapi'` because the runtime environment used for automated tests here does not have `fastapi` installed. 
- No frontend automated tests were added in this change and no other automated build/lint steps were executed in this environment. 
- The change is intentionally dependency-free for the frontend (vanilla ES modules) to simplify local manual validation using a static server as described in the updated `README.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ba138a221c8333a80acf281b645e27)