### PR TITLE
Serialize backtest result dataclasses to API-friendly dicts

### DIFF
--- a/src/trading_system/api/routes/backtest.py
+++ b/src/trading_system/api/routes/backtest.py
@@ -1,5 +1,6 @@
-from decimal import Decimal
+from dataclasses import asdict
 from datetime import UTC, datetime
+from decimal import Decimal
 from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, status
@@ -94,10 +95,10 @@ def _to_api_result_dto(result: SerializedBacktestResultDTO) -> BacktestResultDTO
             "volatility": result.summary.volatility,
             "win_rate": result.summary.win_rate,
         },
-        equity_curve=result.equity_curve,
-        drawdown_curve=result.drawdown_curve,
-        orders=result.orders,
-        risk_rejections=result.risk_rejections,
+        equity_curve=[asdict(point) for point in result.equity_curve],
+        drawdown_curve=[asdict(point) for point in result.drawdown_curve],
+        orders=[asdict(event) for event in result.orders],
+        risk_rejections=[asdict(event) for event in result.risk_rejections],
     )
 
 

--- a/tests/unit/test_api_server.py
+++ b/tests/unit/test_api_server.py
@@ -43,7 +43,7 @@ def test_post_backtests_and_get_run_result() -> None:
     assert body["status"] == "succeeded"
     assert body["mode"] == "backtest"
     assert body["input_symbols"] == ["BTCUSDT"]
-    assert body["result"]["processed_bars"] > 0
+    assert len(body["result"]["equity_curve"]) > 0
 
 
 def test_live_preflight_returns_ok_message(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Ensure backtest results (which are dataclass instances) are converted to JSON-serializable dictionaries before returning via the API.
- Update tests to reflect the new shape of the serialized result returned by the `/backtests` endpoints.

### Description
- Import `asdict` from `dataclasses` and use it to convert dataclass objects in the backtest result to dictionaries in `_to_api_result_dto` for `equity_curve`, `drawdown_curve`, `orders`, and `risk_rejections`.
- Adjust import ordering to include the new `asdict` usage.
- Update unit test `test_post_backtests_and_get_run_result` to assert that `result.equity_curve` contains entries by checking `len(body["result"]["equity_curve"]) > 0` instead of the removed `processed_bars` field.

### Testing
- Ran unit tests in `tests/unit/test_api_server.py` which include `test_post_backtests_and_get_run_result`, `test_live_preflight_returns_ok_message`, and `test_settings_validation_errors_return_422` and updated the assertion for the backtest result shape; all assertions passed.
- The modified test that checks the backtest result now verifies `equity_curve` length using `len(body["result"]["equity_curve"]) > 0` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ba051461e88333ba6ec0eba8b96e91)