### PR TITLE
Add KIS broker adapter, KIS order support, and wire broker selection

### DIFF
--- a/src/trading_system/app/services.py
+++ b/src/trading_system/app/services.py
@@ -21,10 +21,12 @@ from trading_system.data.provider import (
 from trading_system.execution.broker import (
     BpsCommissionPolicy,
     BpsSlippagePolicy,
+    BrokerSimulator,
     FixedRatioFillPolicy,
     PolicyBrokerSimulator,
     ResilientBroker,
 )
+from trading_system.execution.kis_adapter import KisBrokerAdapter
 from trading_system.portfolio.book import PortfolioBook
 from trading_system.risk.limits import RiskLimits
 from trading_system.strategy.base import Strategy
@@ -107,11 +109,7 @@ def build_services(settings: AppSettings) -> AppServices:
             max_order_size=settings.risk.max_order_size,
         ),
         broker_simulator=ResilientBroker(
-            delegate=PolicyBrokerSimulator(
-                fill_quantity_policy=FixedRatioFillPolicy(),
-                slippage_policy=BpsSlippagePolicy(),
-                commission_policy=BpsCommissionPolicy(bps=settings.backtest.fee_bps),
-            )
+            delegate=_build_broker(settings, kis_client=kis_client),
         ),
         portfolio=PortfolioBook(cash=settings.backtest.starting_cash),
         symbols=settings.symbols,
@@ -160,6 +158,21 @@ def _build_data_provider(
         )
 
     return CsvMarketDataProvider(csv_by_symbol=csv_by_symbol)
+def _build_broker(
+    settings: AppSettings,
+    *,
+    kis_client: KisApiClient | None,
+) -> BrokerSimulator:
+    if settings.broker == "kis":
+        if kis_client is None:
+            raise RuntimeError("KIS broker requires KIS API credentials.")
+        return KisBrokerAdapter(client=kis_client)
+
+    return PolicyBrokerSimulator(
+        fill_quantity_policy=FixedRatioFillPolicy(),
+        slippage_policy=BpsSlippagePolicy(),
+        commission_policy=BpsCommissionPolicy(bps=settings.backtest.fee_bps),
+    )
 
 
 def _build_kis_client_if_needed(settings: AppSettings) -> KisApiClient | None:

--- a/src/trading_system/execution/__init__.py
+++ b/src/trading_system/execution/__init__.py
@@ -11,6 +11,7 @@ from trading_system.execution.broker import (
     PolicyBrokerSimulator,
     ResilientBroker,
 )
+from trading_system.execution.kis_adapter import KisBrokerAdapter
 from trading_system.execution.orders import OrderRequest, OrderSide
 
 __all__ = [
@@ -20,6 +21,7 @@ __all__ = [
     "FillEvent",
     "FillStatus",
     "FixedRatioFillPolicy",
+    "KisBrokerAdapter",
     "OrderRequest",
     "OrderSide",
     "PolicyBrokerSimulator",

--- a/src/trading_system/execution/kis_adapter.py
+++ b/src/trading_system/execution/kis_adapter.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+from decimal import Decimal
+
+from trading_system.core.types import MarketBar
+from trading_system.execution.broker import FillEvent, FillStatus
+from trading_system.execution.orders import OrderRequest
+from trading_system.integrations.kis import KisApiClient, KisOrderResult
+
+
+@dataclass(slots=True)
+class KisBrokerAdapter:
+    client: KisApiClient
+
+    def submit_order(self, order: OrderRequest, bar: MarketBar) -> FillEvent:
+        result = self.client.submit_order(order)
+        return _to_fill_event(result=result, order=order, fallback_price=bar.close)
+
+
+def _to_fill_event(
+    *,
+    result: KisOrderResult,
+    order: OrderRequest,
+    fallback_price: Decimal,
+) -> FillEvent:
+    filled_quantity = max(result.filled_quantity, Decimal("0"))
+    fill_price = result.fill_price if result.fill_price > 0 else fallback_price
+    status = _resolve_status(requested=order.quantity, filled=filled_quantity)
+    return FillEvent(
+        symbol=order.symbol,
+        side=order.side,
+        requested_quantity=order.quantity,
+        filled_quantity=filled_quantity,
+        fill_price=fill_price,
+        fee=result.fee,
+        status=status,
+    )
+
+
+def _resolve_status(*, requested: Decimal, filled: Decimal) -> FillStatus:
+    if filled <= 0:
+        return FillStatus.UNFILLED
+    if filled >= requested:
+        return FillStatus.FILLED
+    return FillStatus.PARTIALLY_FILLED

--- a/src/trading_system/integrations/kis.py
+++ b/src/trading_system/integrations/kis.py
@@ -12,6 +12,7 @@ from urllib.request import Request, urlopen
 
 from trading_system.core.compat import UTC
 from trading_system.core.ops import EnvSecretProvider, SecretProvider
+from trading_system.execution.orders import OrderRequest, OrderSide
 
 
 @dataclass(slots=True)
@@ -31,9 +32,36 @@ class KisQuote:
 
 
 @dataclass(slots=True)
+class KisOrderResult:
+    order_id: str
+    symbol: str
+    side: OrderSide
+    requested_quantity: Decimal
+    filled_quantity: Decimal
+    fill_price: Decimal
+    fee: Decimal
+
+
+@dataclass(slots=True)
 class HttpResponse:
     status_code: int
     body: dict[str, Any]
+
+
+class KisApiError(RuntimeError):
+    """Base error for KIS API failures."""
+
+
+class KisTransportError(KisApiError):
+    """Raised when the transport layer cannot reach KIS."""
+
+
+class KisHttpError(KisApiError):
+    """Raised when KIS returns a non-success HTTP status."""
+
+
+class KisResponseError(KisApiError):
+    """Raised when KIS returns an invalid or failed payload."""
 
 
 class HttpTransport(Protocol):
@@ -77,16 +105,18 @@ class UrllibHttpTransport:
         except HTTPError as exc:
             payload = exc.read().decode("utf-8")
             parsed = json.loads(payload) if payload else {}
-            raise RuntimeError(
+            raise KisHttpError(
                 f"KIS HTTP error {exc.code}: {parsed.get('msg1', exc.reason)}"
             ) from exc
         except URLError as exc:
-            raise OSError(f"KIS transport unavailable: {exc.reason}") from exc
+            raise KisTransportError(f"KIS transport unavailable: {exc.reason}") from exc
 
 
 class KisApiClient:
     _PROD_BASE_URL = "https://openapi.koreainvestment.com:9443"
     _MOCK_BASE_URL = "https://openapivts.koreainvestment.com:29443"
+    _PRICE_PATH = "/uapi/domestic-stock/v1/quotations/inquire-price"
+    _ORDER_PATH = "/uapi/domestic-stock/v1/trading/order-cash"
 
     def __init__(
         self,
@@ -124,7 +154,7 @@ class KisApiClient:
         return cls(credentials=credentials, transport=transport, base_url=default_base_url)
 
     def preflight_symbol(self, symbol: str) -> KisQuote:
-        access_token = self._issue_access_token()
+        access_token = self.issue_access_token()
         return self.inquire_price(symbol=symbol, access_token=access_token)
 
     def inquire_price(self, symbol: str, *, access_token: str) -> KisQuote:
@@ -136,12 +166,12 @@ class KisApiClient:
         )
         response = self._transport.request(
             "GET",
-            f"{self._base_url}/uapi/domestic-stock/v1/quotations/inquire-price?{params}",
+            f"{self._base_url}{self._PRICE_PATH}?{params}",
             headers={
                 "authorization": f"Bearer {access_token}",
                 "appkey": self._credentials.app_key,
                 "appsecret": self._credentials.app_secret,
-                "tr_id": os.getenv("TRADING_SYSTEM_KIS_PRICE_TR_ID", "FHKST01010100"),
+                "tr_id": self._price_tr_id(),
             },
         )
         output = _as_dict(response.body.get("output"), "output")
@@ -154,7 +184,17 @@ class KisApiClient:
             as_of=datetime.now(tz=UTC),
         )
 
-    def _issue_access_token(self) -> str:
+    def submit_order(self, order: OrderRequest) -> KisOrderResult:
+        access_token = self.issue_access_token()
+        response = self._transport.request(
+            "POST",
+            f"{self._base_url}{self._ORDER_PATH}",
+            headers=self._order_headers(access_token=access_token, side=order.side),
+            body=self._order_payload(order),
+        )
+        return self._parse_order_response(order=order, response=response)
+
+    def issue_access_token(self) -> str:
         response = self._transport.request(
             "POST",
             f"{self._base_url}/oauth2/tokenP",
@@ -167,13 +207,74 @@ class KisApiClient:
         )
         access_token = response.body.get("access_token")
         if not isinstance(access_token, str) or not access_token.strip():
-            raise RuntimeError("KIS token response did not include a usable access_token.")
+            raise KisResponseError("KIS token response did not include a usable access_token.")
         return access_token
+
+    def _price_tr_id(self) -> str:
+        return os.getenv("TRADING_SYSTEM_KIS_PRICE_TR_ID", "FHKST01010100")
+
+    def _order_tr_id(self, side: OrderSide) -> str:
+        default = "TTTC0802U" if side == OrderSide.BUY else "TTTC0801U"
+        return os.getenv("TRADING_SYSTEM_KIS_ORDER_TR_ID", default)
+
+    def _order_headers(self, *, access_token: str, side: OrderSide) -> dict[str, str]:
+        return {
+            "authorization": f"Bearer {access_token}",
+            "appkey": self._credentials.app_key,
+            "appsecret": self._credentials.app_secret,
+            "tr_id": self._order_tr_id(side),
+            "custtype": "P",
+            "content-type": "application/json",
+        }
+
+    def _order_payload(self, order: OrderRequest) -> dict[str, str]:
+        return {
+            "CANO": self._credentials.account_number,
+            "ACNT_PRDT_CD": self._credentials.product_code,
+            "PDNO": order.symbol,
+            "ORD_DVSN": "00",
+            "ORD_QTY": str(order.quantity),
+            "ORD_UNPR": str(order.limit_price or Decimal("0")),
+        }
+
+    def _parse_order_response(self, *, order: OrderRequest, response: HttpResponse) -> KisOrderResult:
+        result_code = str(response.body.get("rt_cd", ""))
+        message = str(response.body.get("msg1", "unknown error"))
+        if response.status_code >= 400:
+            raise KisHttpError(
+                f"KIS order request failed with status={response.status_code}: {message}"
+            )
+        if result_code and result_code != "0":
+            raise KisResponseError(
+                "KIS order rejected "
+                f"(rt_cd={result_code}, msg_cd={response.body.get('msg_cd', '')}, msg1={message})."
+            )
+
+        output = _as_dict(response.body.get("output"), "output")
+        order_id = str(output.get("ODNO") or "")
+        if not order_id:
+            raise KisResponseError("KIS order response field 'ODNO' was missing.")
+
+        filled_quantity = _as_decimal(output.get("ORD_QTY"), "ORD_QTY", default=Decimal("0"))
+        fill_price = _as_decimal(
+            output.get("ORD_UNPR") or order.limit_price,
+            "ORD_UNPR",
+            default=Decimal("0"),
+        )
+        return KisOrderResult(
+            order_id=order_id,
+            symbol=order.symbol,
+            side=order.side,
+            requested_quantity=order.quantity,
+            filled_quantity=filled_quantity,
+            fill_price=fill_price,
+            fee=Decimal("0"),
+        )
 
 
 def _as_dict(value: Any, field_name: str) -> dict[str, Any]:
     if not isinstance(value, dict):
-        raise RuntimeError(f"KIS response field '{field_name}' was missing or invalid.")
+        raise KisResponseError(f"KIS response field '{field_name}' was missing or invalid.")
     return value
 
 
@@ -181,8 +282,8 @@ def _as_decimal(value: Any, field_name: str, *, default: Decimal | None = None) 
     if value in (None, ""):
         if default is not None:
             return default
-        raise RuntimeError(f"KIS response field '{field_name}' was missing.")
+        raise KisResponseError(f"KIS response field '{field_name}' was missing.")
     try:
         return Decimal(str(value))
     except Exception as exc:  # pragma: no cover - defensive parser path
-        raise RuntimeError(f"KIS response field '{field_name}' was not numeric.") from exc
+        raise KisResponseError(f"KIS response field '{field_name}' was not numeric.") from exc

--- a/tests/unit/test_app_services.py
+++ b/tests/unit/test_app_services.py
@@ -5,6 +5,7 @@ import pytest
 
 from trading_system.app.services import build_services
 from trading_system.app.settings import AppSettings
+from trading_system.execution.kis_adapter import KisBrokerAdapter
 
 
 def test_build_services_uses_csv_provider_for_domestic_symbol(tmp_path, monkeypatch) -> None:
@@ -112,6 +113,33 @@ def test_live_mode_kis_preflight_uses_kis_quote(monkeypatch) -> None:
         "KIS live preflight passed (symbol=005930, price=70200, volume=1200). "
         "No orders were submitted."
     )
+
+
+def test_build_services_uses_kis_broker_adapter_when_broker_is_kis(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "trading_system.app.services.KisApiClient.from_env",
+        lambda: _StubKisClient(),
+    )
+
+    settings = AppSettings.from_cli(
+        mode="live",
+        symbols="005930",
+        provider="mock",
+        broker="kis",
+        live_execution="preflight",
+        starting_cash="1000000",
+        fee_bps="5",
+        trade_quantity="1",
+        max_position="10",
+        max_notional="100000000",
+        max_order_size="5",
+    )
+    settings.validate()
+
+    services = build_services(settings)
+
+    assert isinstance(services.broker_simulator.delegate, KisBrokerAdapter)
+
 
 
 class _StubKisClient:

--- a/tests/unit/test_kis_integration.py
+++ b/tests/unit/test_kis_integration.py
@@ -1,8 +1,16 @@
+from datetime import datetime, timezone
 from decimal import Decimal
 
 import pytest
 
-from trading_system.integrations.kis import HttpResponse, KisApiClient
+from trading_system.core.types import MarketBar
+from trading_system.execution.kis_adapter import KisBrokerAdapter
+from trading_system.execution.orders import OrderRequest, OrderSide
+from trading_system.integrations.kis import (
+    HttpResponse,
+    KisApiClient,
+    KisResponseError,
+)
 
 
 def test_kis_api_client_preflight_symbol_fetches_token_and_quote() -> None:
@@ -24,8 +32,55 @@ def test_kis_api_client_requires_access_token_in_response() -> None:
         transport=_MissingTokenTransport(),
     )
 
-    with pytest.raises(RuntimeError, match="access_token"):
+    with pytest.raises(KisResponseError, match="access_token"):
         client.preflight_symbol("005930")
+
+
+def test_kis_broker_adapter_maps_successful_order_to_fill_event() -> None:
+    client = KisApiClient.from_env(
+        secret_provider=_StubSecretProvider(),
+        transport=_OrderSuccessTransport(),
+    )
+    adapter = KisBrokerAdapter(client=client)
+
+    fill = adapter.submit_order(
+        OrderRequest(symbol="005930", side=OrderSide.BUY, quantity=Decimal("3")),
+        _bar(),
+    )
+
+    assert fill.symbol == "005930"
+    assert fill.requested_quantity == Decimal("3")
+    assert fill.filled_quantity == Decimal("3")
+    assert fill.fill_price == Decimal("70100")
+    assert fill.status.value == "filled"
+
+
+def test_kis_broker_adapter_maps_partial_fill_status() -> None:
+    client = KisApiClient.from_env(
+        secret_provider=_StubSecretProvider(),
+        transport=_OrderPartialFillTransport(),
+    )
+    adapter = KisBrokerAdapter(client=client)
+
+    fill = adapter.submit_order(
+        OrderRequest(symbol="005930", side=OrderSide.SELL, quantity=Decimal("5")),
+        _bar(),
+    )
+
+    assert fill.filled_quantity == Decimal("2")
+    assert fill.status.value == "partially_filled"
+
+
+def test_kis_api_client_submit_order_raises_response_error_on_rejection() -> None:
+    client = KisApiClient.from_env(
+        secret_provider=_StubSecretProvider(),
+        transport=_OrderRejectedTransport(),
+    )
+
+    with pytest.raises(KisResponseError, match="order rejected"):
+        client.submit_order(
+            OrderRequest(symbol="005930", side=OrderSide.BUY, quantity=Decimal("1"))
+        )
 
 
 class _StubSecretProvider:
@@ -62,3 +117,61 @@ class _MissingTokenTransport:
     def request(self, method: str, url: str, *, headers: dict[str, str], body=None) -> HttpResponse:
         del method, url, headers, body
         return HttpResponse(status_code=200, body={})
+
+
+class _OrderSuccessTransport:
+    def request(self, method: str, url: str, *, headers: dict[str, str], body=None) -> HttpResponse:
+        if method == "POST" and url.endswith("/oauth2/tokenP"):
+            return HttpResponse(status_code=200, body={"access_token": "kis-access-token"})
+
+        assert method == "POST"
+        assert url.endswith("/uapi/domestic-stock/v1/trading/order-cash")
+        assert headers["tr_id"] == "TTTC0802U"
+        assert body["PDNO"] == "005930"
+        return HttpResponse(
+            status_code=200,
+            body={
+                "rt_cd": "0",
+                "msg_cd": "APBK0013",
+                "msg1": "정상처리",
+                "output": {"ODNO": "12345", "ORD_QTY": "3", "ORD_UNPR": "70100"},
+            },
+        )
+
+
+class _OrderPartialFillTransport:
+    def request(self, method: str, url: str, *, headers: dict[str, str], body=None) -> HttpResponse:
+        if method == "POST" and url.endswith("/oauth2/tokenP"):
+            return HttpResponse(status_code=200, body={"access_token": "kis-access-token"})
+
+        assert headers["tr_id"] == "TTTC0801U"
+        return HttpResponse(
+            status_code=200,
+            body={
+                "rt_cd": "0",
+                "output": {"ODNO": "12346", "ORD_QTY": "2", "ORD_UNPR": "70000"},
+            },
+        )
+
+
+class _OrderRejectedTransport:
+    def request(self, method: str, url: str, *, headers: dict[str, str], body=None) -> HttpResponse:
+        if method == "POST" and url.endswith("/oauth2/tokenP"):
+            return HttpResponse(status_code=200, body={"access_token": "kis-access-token"})
+
+        return HttpResponse(
+            status_code=200,
+            body={"rt_cd": "1", "msg_cd": "ERROR", "msg1": "주문 가능 수량 부족"},
+        )
+
+
+def _bar() -> MarketBar:
+    return MarketBar(
+        symbol="005930",
+        timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        open=Decimal("70000"),
+        high=Decimal("70500"),
+        low=Decimal("69900"),
+        close=Decimal("70200"),
+        volume=Decimal("1000"),
+    )


### PR DESCRIPTION
### Motivation
- Ensure `broker="kis"` selects a real KIS execution adapter that implements the `BrokerSimulator` contract instead of always using the paper `PolicyBrokerSimulator` so live flows can exercise order submission mapping. 
- Provide explicit KIS order handling and clear error types so order submission failures are surfaced deterministically and testably.

### Description
- Add `KisBrokerAdapter` at `src/trading_system/execution/kis_adapter.py` that implements `submit_order(order, bar) -> FillEvent` and maps a KIS order result to `FillEvent` with a fallback to `bar.close` when response price is missing.
- Extend `src/trading_system/integrations/kis.py` with order submission support (`submit_order`), TR-ID/header/payload helpers, `KisOrderResult` dataclass, and explicit exceptions `KisApiError`, `KisTransportError`, `KisHttpError`, and `KisResponseError` for clearer failure semantics.
- Wire broker selection in `src/trading_system/app/services.py` by adding `_build_broker(...) -> BrokerSimulator` and injecting `KisBrokerAdapter` when `settings.broker == "kis"`, preserving the existing `PolicyBrokerSimulator` path for paper execution.
- Exported `KisBrokerAdapter` in `src/trading_system/execution/__init__.py` and added/expanded unit tests in `tests/unit/test_app_services.py` and `tests/unit/test_kis_integration.py` to cover the broker selection and order mapping (success, partial, rejection) cases.

### Testing
- Ran `pytest -q tests/unit/test_app_services.py tests/unit/test_kis_integration.py tests/unit/test_execution_adapters_and_broker.py` and observed all tests passed (`14 passed`).
- Ran the targeted combinations during development: `pytest -q tests/unit/test_app_services.py tests/unit/test_kis_integration.py` (`10 passed`) and `pytest -q tests/unit/test_execution_adapters_and_broker.py` (`4 passed`).
- No automated test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb58a6aae083338422ea714303ddd1)