### PR TITLE
Make KIS market division configurable and validate domestic symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ uv run --python .venv/bin/python --no-sync -m trading_system.app.main --mode liv
 ```bash
 TRADING_SYSTEM_ENV=local TRADING_SYSTEM_TIMEZONE=Asia/Seoul \
 TRADING_SYSTEM_KIS_ENV=prod \
+TRADING_SYSTEM_KIS_MARKET_DIV=J \
 TRADING_SYSTEM_KIS_APP_KEY=your-app-key \
 TRADING_SYSTEM_KIS_APP_SECRET=your-app-secret \
 TRADING_SYSTEM_KIS_CANO=12345678 \
@@ -496,6 +497,7 @@ This makes signal→risk→execution decisions inspectable, not just final PnL n
 - `TRADING_SYSTEM_KIS_CANO` / `TRADING_SYSTEM_KIS_ACNT_PRDT_CD`: KIS account number and product code
 - `TRADING_SYSTEM_KIS_BASE_URL` (optional): override KIS REST base URL
 - `TRADING_SYSTEM_KIS_PRICE_TR_ID` (optional): override domestic quote TR id for preflight quote checks
+- `TRADING_SYSTEM_KIS_MARKET_DIV` (optional): override quote market division code (`J` default for domestic stock)
 - `TRADING_SYSTEM_ALLOWED_API_KEYS`: comma-separated API keys accepted by HTTP middleware (`X-API-Key`)
 - `TRADING_SYSTEM_CORS_ALLOW_ORIGINS` (optional): comma-separated CORS origins; overrides config file value
 - `TRADING_SYSTEM_RATE_LIMIT_MAX_REQUESTS` / `TRADING_SYSTEM_RATE_LIMIT_WINDOW_SECONDS` (optional): simple per-path rate limit
@@ -510,6 +512,7 @@ This makes signal→risk→execution decisions inspectable, not just final PnL n
 - `TRADING_SYSTEM_KIS_CANO` / `TRADING_SYSTEM_KIS_ACNT_PRDT_CD`: 한국투자 계좌번호와 상품코드
 - `TRADING_SYSTEM_KIS_BASE_URL` (선택): 한국투자 REST 기본 URL 재정의
 - `TRADING_SYSTEM_KIS_PRICE_TR_ID` (선택): 프리플라이트 현재가 조회용 TR ID 재정의
+- `TRADING_SYSTEM_KIS_MARKET_DIV` (선택): 현재가 조회 시장 구분 코드 재정의 (기본값 `J`, 국내주식)
 - `TRADING_SYSTEM_ALLOWED_API_KEYS`: HTTP 미들웨어가 허용할 API 키 목록(쉼표 구분, `X-API-Key`)
 - `TRADING_SYSTEM_CORS_ALLOW_ORIGINS` (선택): CORS 허용 오리진 목록(쉼표 구분, 설정 파일 값보다 우선)
 - `TRADING_SYSTEM_RATE_LIMIT_MAX_REQUESTS` / `TRADING_SYSTEM_RATE_LIMIT_WINDOW_SECONDS` (선택): 경로 단위 단순 요청 제한

--- a/src/trading_system/integrations/kis.py
+++ b/src/trading_system/integrations/kis.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
@@ -117,6 +118,8 @@ class KisApiClient:
     _MOCK_BASE_URL = "https://openapivts.koreainvestment.com:29443"
     _PRICE_PATH = "/uapi/domestic-stock/v1/quotations/inquire-price"
     _ORDER_PATH = "/uapi/domestic-stock/v1/trading/order-cash"
+    _DEFAULT_MARKET_DIV = "J"
+    _SYMBOL_PATTERN = re.compile(r"^\d{6}$")
 
     def __init__(
         self,
@@ -158,10 +161,11 @@ class KisApiClient:
         return self.inquire_price(symbol=symbol, access_token=access_token)
 
     def inquire_price(self, symbol: str, *, access_token: str) -> KisQuote:
+        validated_symbol = _validate_domestic_symbol(symbol)
         params = urlencode(
             {
-                "FID_COND_MRKT_DIV_CODE": "J",
-                "FID_INPUT_ISCD": symbol,
+                "FID_COND_MRKT_DIV_CODE": self._market_div_code(),
+                "FID_INPUT_ISCD": validated_symbol,
             }
         )
         response = self._transport.request(
@@ -178,11 +182,15 @@ class KisApiClient:
         current_price = _as_decimal(output.get("stck_prpr"), "stck_prpr")
         volume = _as_decimal(output.get("acml_vol"), "acml_vol", default=Decimal("0"))
         return KisQuote(
-            symbol=symbol,
+            symbol=validated_symbol,
             price=current_price,
             volume=volume,
             as_of=datetime.now(tz=UTC),
         )
+
+    def _market_div_code(self) -> str:
+        configured = os.getenv("TRADING_SYSTEM_KIS_MARKET_DIV", self._DEFAULT_MARKET_DIV)
+        return configured.strip() or self._DEFAULT_MARKET_DIV
 
     def submit_order(self, order: OrderRequest) -> KisOrderResult:
         access_token = self.issue_access_token()
@@ -287,3 +295,13 @@ def _as_decimal(value: Any, field_name: str, *, default: Decimal | None = None) 
         return Decimal(str(value))
     except Exception as exc:  # pragma: no cover - defensive parser path
         raise KisResponseError(f"KIS response field '{field_name}' was not numeric.") from exc
+
+
+def _validate_domestic_symbol(symbol: str) -> str:
+    normalized_symbol = symbol.strip()
+    if KisApiClient._SYMBOL_PATTERN.match(normalized_symbol):
+        return normalized_symbol
+    raise KisResponseError(
+        "KIS domestic symbol format invalid "
+        f"(input={symbol!r}, expected='6-digit numeric code, e.g. 005930')."
+    )

--- a/tests/unit/test_kis_integration.py
+++ b/tests/unit/test_kis_integration.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from decimal import Decimal
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -24,6 +25,41 @@ def test_kis_api_client_preflight_symbol_fetches_token_and_quote() -> None:
     assert quote.symbol == "005930"
     assert quote.price == Decimal("70300")
     assert quote.volume == Decimal("123456")
+
+
+def test_kis_api_client_inquire_price_uses_default_market_div_code() -> None:
+    client = KisApiClient.from_env(
+        secret_provider=_StubSecretProvider(),
+        transport=_PriceTransport(expected_market_div="J"),
+    )
+
+    quote = client.preflight_symbol("005930")
+
+    assert quote.symbol == "005930"
+
+
+def test_kis_api_client_inquire_price_applies_custom_market_div_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TRADING_SYSTEM_KIS_MARKET_DIV", "W")
+    client = KisApiClient.from_env(
+        secret_provider=_StubSecretProvider(),
+        transport=_PriceTransport(expected_market_div="W"),
+    )
+
+    quote = client.preflight_symbol("005930")
+
+    assert quote.symbol == "005930"
+
+
+def test_kis_api_client_inquire_price_rejects_invalid_domestic_symbol() -> None:
+    client = KisApiClient.from_env(
+        secret_provider=_StubSecretProvider(),
+        transport=_StubTransport(),
+    )
+
+    with pytest.raises(KisResponseError, match="input='5930'.*6-digit numeric code"):
+        client.preflight_symbol("5930")
 
 
 def test_kis_api_client_requires_access_token_in_response() -> None:
@@ -107,6 +143,7 @@ class _StubTransport:
 
         assert headers["authorization"] == "Bearer kis-access-token"
         assert "FID_INPUT_ISCD=005930" in url
+        assert "FID_COND_MRKT_DIV_CODE=J" in url
         return HttpResponse(
             status_code=200,
             body={"output": {"stck_prpr": "70300", "acml_vol": "123456"}},
@@ -162,6 +199,25 @@ class _OrderRejectedTransport:
         return HttpResponse(
             status_code=200,
             body={"rt_cd": "1", "msg_cd": "ERROR", "msg1": "주문 가능 수량 부족"},
+        )
+
+
+class _PriceTransport:
+    def __init__(self, *, expected_market_div: str) -> None:
+        self.expected_market_div = expected_market_div
+
+    def request(self, method: str, url: str, *, headers: dict[str, str], body=None) -> HttpResponse:
+        if method == "POST" and url.endswith("/oauth2/tokenP"):
+            return HttpResponse(status_code=200, body={"access_token": "kis-access-token"})
+
+        assert method == "GET"
+        assert headers["authorization"] == "Bearer kis-access-token"
+        query = parse_qs(urlparse(url).query)
+        assert query["FID_COND_MRKT_DIV_CODE"] == [self.expected_market_div]
+        assert query["FID_INPUT_ISCD"] == ["005930"]
+        return HttpResponse(
+            status_code=200,
+            body={"output": {"stck_prpr": "70300", "acml_vol": "123456"}},
         )
 
 


### PR DESCRIPTION
### Motivation
- Remove the hardcoded KIS quote market division value and make it configurable at runtime to support different KIS market division codes. 
- Fail fast on invalid domestic stock symbols to avoid making unnecessary API calls and to provide clearer error messages. 
- Add tests and documentation for the new runtime option and symbol validation to keep behavior explicit and testable.

### Description
- Replaced the hardcoded `FID_COND_MRKT_DIV_CODE = "J"` in `KisApiClient.inquire_price` with a `_market_div_code()` method that reads `TRADING_SYSTEM_KIS_MARKET_DIV` and falls back to the default `"J"`.
- Added `_DEFAULT_MARKET_DIV` and `_SYMBOL_PATTERN` constants and implemented `_validate_domestic_symbol(symbol: str)` to enforce `^\d{6}$` domestic symbol format and include the input and expected format in the raised `KisResponseError` message.
- Updated `inquire_price` to validate the symbol before building the request and to pass the validated symbol into the request/returned `KisQuote`.
- Added unit tests in `tests/unit/test_kis_integration.py` covering the default market division behavior, a custom `TRADING_SYSTEM_KIS_MARKET_DIV` override, and the invalid domestic symbol regression case, using a `_PriceTransport` helper to assert query params.
- Updated `README.md` (EN/KO) to document the new `TRADING_SYSTEM_KIS_MARKET_DIV` environment variable and added it to the KIS live example.

### Testing
- Ran the targeted unit tests with `pytest tests/unit/test_kis_integration.py -q`, which completed successfully: `8 passed`.
- The changes were validated only via the added/updated unit tests for the KIS integration path and did not modify order submission logic or other integration flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb74d4f5dc8333904cc363f56bb0b9)