### PR TITLE
Add opt-in KIS live order execution mode (TRADING_SYSTEM_ENABLE_LIVE_ORDERS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,13 +174,27 @@ TRADING_SYSTEM_API_KEY=dummy-key \
 uv run --python .venv/bin/python --no-sync -m trading_system.app.main --mode live --symbols BTCUSDT --live-execution paper
 ```
 
-### 5.7 Built-in backtest example / 내장 백테스트 예시
+### 5.7 Live order mode (explicit opt-in + KIS only) / 라이브 실주문 모드 (명시적 활성화 + KIS 전용)
+
+```bash
+TRADING_SYSTEM_ENV=local TRADING_SYSTEM_TIMEZONE=Asia/Seoul \
+TRADING_SYSTEM_ENABLE_LIVE_ORDERS=true \
+TRADING_SYSTEM_KIS_ENV=prod \
+TRADING_SYSTEM_KIS_MARKET_DIV=J \
+TRADING_SYSTEM_KIS_APP_KEY=your-app-key \
+TRADING_SYSTEM_KIS_APP_SECRET=your-app-secret \
+TRADING_SYSTEM_KIS_CANO=12345678 \
+TRADING_SYSTEM_KIS_ACNT_PRDT_CD=01 \
+uv run --python .venv/bin/python --no-sync -m trading_system.app.main --mode live --provider kis --broker kis --symbols 005930 --live-execution live
+```
+
+### 5.8 Built-in backtest example / 내장 백테스트 예시
 
 ```bash
 uv run --python .venv/bin/python --no-sync -m trading_system.backtest.example
 ```
 
-### 5.8 HTTP API mode / HTTP API 모드
+### 5.9 HTTP API mode / HTTP API 모드
 
 ### EN
 Always run the API through `uv` against the project virtualenv. Avoid calling system `uvicorn` directly because it may use a different Python environment.
@@ -326,7 +340,7 @@ curl -X POST http://127.0.0.1:8000/api/v1/live/preflight \
 }
 ```
 
-### 5.9 Frontend + backend local development / 프론트엔드 + 백엔드 로컬 개발
+### 5.10 Frontend + backend local development / 프론트엔드 + 백엔드 로컬 개발
 
 ### EN
 The repository now includes a minimal static frontend under `frontend/` with three pages:
@@ -424,7 +438,7 @@ http://127.0.0.1:9000/api/v1
 This repository is not a fully live-trading product yet. It is a deterministic, test-centered platform that can:
 
 1. Execute end-to-end backtests through CLI.
-2. Run live-mode preflight checks (default) or an explicit paper execution loop (`--live-execution paper`) without submitting real orders.
+2. Run live-mode preflight checks (default), an explicit paper loop (`--live-execution paper`), or KIS-only live execution (`--live-execution live` + `TRADING_SYSTEM_ENABLE_LIVE_ORDERS=true`).
 3. Load market data via in-memory provider (`mock`) or CSV provider (`csv`).
 4. Enforce risk limits (`max_position`, `max_notional`, `max_order_size`).
 5. Simulate fills via fill ratio, slippage (bps), and commission (bps).
@@ -436,7 +450,7 @@ This repository is not a fully live-trading product yet. It is a deterministic, 
 이 저장소는 아직 “완전한 실주문 시스템”은 아니며, 결정성과 테스트 중심의 플랫폼으로 다음을 수행할 수 있습니다.
 
 1. CLI 기반 end-to-end 백테스트 실행.
-2. 실주문 없이 라이브 프리플라이트(기본) 또는 명시적 페이퍼 실행 루프(`--live-execution paper`) 수행.
+2. 라이브 프리플라이트(기본), 명시적 페이퍼 실행 루프(`--live-execution paper`), 또는 KIS 전용 실주문 실행(`--live-execution live` + `TRADING_SYSTEM_ENABLE_LIVE_ORDERS=true`) 수행.
 3. 인메모리(`mock`) 또는 CSV(`csv`) 데이터 공급자 사용.
 4. 리스크 제한(`max_position`, `max_notional`, `max_order_size`) 적용.
 5. 체결 비율/슬리피지(bps)/수수료(bps) 기반 체결 시뮬레이션.
@@ -492,6 +506,7 @@ This makes signal→risk→execution decisions inspectable, not just final PnL n
 - `TRADING_SYSTEM_ENV`: runtime environment label (`local`, `staging`, `prod`, ...)
 - `TRADING_SYSTEM_TIMEZONE`: operator timezone (`Asia/Seoul`, ...)
 - `TRADING_SYSTEM_API_KEY`: credential for live adapter preflight
+- `TRADING_SYSTEM_ENABLE_LIVE_ORDERS` (optional): set to `true` to allow `--live-execution live` order submission
 - `TRADING_SYSTEM_KIS_ENV` (optional): KIS environment selector (`prod` default, `mock` available)
 - `TRADING_SYSTEM_KIS_APP_KEY` / `TRADING_SYSTEM_KIS_APP_SECRET`: KIS Open API app credentials
 - `TRADING_SYSTEM_KIS_CANO` / `TRADING_SYSTEM_KIS_ACNT_PRDT_CD`: KIS account number and product code
@@ -507,6 +522,7 @@ This makes signal→risk→execution decisions inspectable, not just final PnL n
 - `TRADING_SYSTEM_ENV`: 런타임 환경 라벨 (`local`, `staging`, `prod` 등)
 - `TRADING_SYSTEM_TIMEZONE`: 운영 타임존 (`Asia/Seoul` 등)
 - `TRADING_SYSTEM_API_KEY`: 라이브 어댑터 프리플라이트용 인증 정보
+- `TRADING_SYSTEM_ENABLE_LIVE_ORDERS` (선택): `--live-execution live` 실주문 허용 시 `true`로 설정
 - `TRADING_SYSTEM_KIS_ENV` (선택): 한국투자 Open API 환경 선택 (`prod` 기본값, `mock` 가능)
 - `TRADING_SYSTEM_KIS_APP_KEY` / `TRADING_SYSTEM_KIS_APP_SECRET`: 한국투자 Open API 앱 인증정보
 - `TRADING_SYSTEM_KIS_CANO` / `TRADING_SYSTEM_KIS_ACNT_PRDT_CD`: 한국투자 계좌번호와 상품코드
@@ -613,13 +629,13 @@ settings = load_settings("configs/base.yaml")
 ## 12) Operational cautions / 운영 시 주의사항
 
 ### EN
-1. **No real live order submission yet**: `live` mode defaults to preflight, and supports paper simulation only when `--live-execution paper` is set.
+1. **Live order submission is opt-in and KIS-only**: `live` mode defaults to preflight, supports paper simulation with `--live-execution paper`, and only allows real order submission when `--provider kis --broker kis --live-execution live` and `TRADING_SYSTEM_ENABLE_LIVE_ORDERS=true` are set.
 2. **Secret handling**: inject credentials via environment/secret manager only.
 3. **Current scaffold limitation**: app composition currently focuses on a single-symbol runtime path for simplicity/safety.
 4. **Determinism first**: any backtest logic change should ship with deterministic regression tests.
 
 ### KO
-1. **실주문 미지원**: 현재 `live` 모드는 기본 preflight이며, `--live-execution paper` 지정 시 페이퍼 시뮬레이션만 지원합니다.
+1. **실주문은 명시적 활성화 + KIS 전용**: `live` 모드는 기본 preflight이며, `--live-execution paper`로 페이퍼 실행이 가능하고, `--provider kis --broker kis --live-execution live` + `TRADING_SYSTEM_ENABLE_LIVE_ORDERS=true` 조합일 때만 실주문을 허용합니다.
 2. **시크릿 관리**: 인증정보는 환경변수/시크릿 매니저로만 주입하세요.
 3. **현재 스캐폴드 제약**: 단순성과 안전성을 위해 앱 조립 경로는 단일 심볼 중심입니다.
 4. **결정성 우선**: 백테스트 로직 변경 시 결정성 회귀 테스트를 함께 추가하세요.
@@ -678,8 +694,9 @@ uv run --python .venv/bin/python --no-sync -m trading_system.patterns.example
 1. **CLI 기반 백테스트 실행**
    - 전략 신호 생성 → 주문 변환 → 리스크 검증 → 체결 시뮬레이션 → 포트폴리오 반영 → 성과 계산을 일괄 수행합니다.
 
-2. **라이브 실행(preflight/paper) 지원**
-   - `--mode live`는 기본적으로 preflight를 수행하며, `--live-execution paper`를 지정하면 실주문 없이 페이퍼 실행 루프를 수행합니다.
+2. **라이브 실행(preflight/paper/live) 지원**
+   - `--mode live`는 기본적으로 preflight를 수행하며, `--live-execution paper`로 페이퍼 실행 루프를 수행합니다.
+   - 실주문은 `--provider kis --broker kis --live-execution live` + `TRADING_SYSTEM_ENABLE_LIVE_ORDERS=true` 조합에서만 허용됩니다.
 
 3. **시장 데이터 공급 선택**
    - `mock` 인메모리 데이터(테스트/스모크용)
@@ -770,8 +787,9 @@ uv run --python .venv/bin/python --no-sync -m trading_system.patterns.example
 
 ### 6) 운영 시 주의사항
 
-1. **실주문 미지원**
-   - 현재 `live`는 기본 preflight이며, `--live-execution paper`로 페이퍼 실행만 가능합니다(실주문 제출 미구현).
+1. **실주문은 명시적 활성화**
+   - 현재 `live`는 기본 preflight이며, `--live-execution paper`로 페이퍼 실행이 가능합니다.
+   - 실주문은 `--provider kis --broker kis --live-execution live`와 `TRADING_SYSTEM_ENABLE_LIVE_ORDERS=true`를 함께 지정해야 동작합니다.
 
 2. **시크릿 관리**
    - API 키는 반드시 환경변수/시크릿 매니저로 주입하고 코드/로그에 직접 남기지 마세요.

--- a/examples/sample_live_kis.yaml
+++ b/examples/sample_live_kis.yaml
@@ -1,4 +1,8 @@
 name: kis_live_preflight_smoke
+# For real order submission, use:
+#   --mode live --provider kis --broker kis --live-execution live
+# and set environment variable:
+#   TRADING_SYSTEM_ENABLE_LIVE_ORDERS=true
 app:
   environment: local
   timezone: Asia/Seoul

--- a/src/trading_system/api/routes/backtest.py
+++ b/src/trading_system/api/routes/backtest.py
@@ -162,4 +162,6 @@ def run_live_preflight(payload: LivePreflightRequestDTO) -> LivePreflightRespons
     paper_result = None
     if settings.live_execution == LiveExecutionMode.PAPER:
         paper_result = _to_api_result_dto(_to_serialized_result(services.run_live_paper()))
+    if settings.live_execution == LiveExecutionMode.LIVE:
+        paper_result = _to_api_result_dto(_to_serialized_result(services.run_live_execution()))
     return LivePreflightResponseDTO(message=message, paper_result=paper_result)

--- a/src/trading_system/api/schemas.py
+++ b/src/trading_system/api/schemas.py
@@ -21,7 +21,7 @@ class BacktestRunRequestDTO(BaseModel):
     symbols: list[str] = Field(min_length=1)
     provider: Literal["mock", "csv", "kis"] = "mock"
     broker: Literal["paper", "kis"] = "paper"
-    live_execution: Literal["preflight", "paper"] = "preflight"
+    live_execution: Literal["preflight", "paper", "live"] = "preflight"
     risk: RiskSettingsDTO
     backtest: BacktestSettingsDTO
 
@@ -31,7 +31,7 @@ class LivePreflightRequestDTO(BaseModel):
     symbols: list[str] = Field(min_length=1)
     provider: Literal["mock", "csv", "kis"] = "mock"
     broker: Literal["paper", "kis"] = "paper"
-    live_execution: Literal["preflight", "paper"] = "preflight"
+    live_execution: Literal["preflight", "paper", "live"] = "preflight"
     risk: RiskSettingsDTO
     backtest: BacktestSettingsDTO
 

--- a/src/trading_system/app/main.py
+++ b/src/trading_system/app/main.py
@@ -57,6 +57,9 @@ def run(argv: list[str] | None = None) -> int:
             if settings.live_execution == LiveExecutionMode.PAPER:
                 result = services.run_live_paper()
                 print(format_result(result))
+            if settings.live_execution == LiveExecutionMode.LIVE:
+                result = services.run_live_execution()
+                print(format_result(result))
             return 0
 
         result = services.run()

--- a/src/trading_system/app/services.py
+++ b/src/trading_system/app/services.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Callable
 
 from trading_system.app.sample_data import build_sample_bars
-from trading_system.app.settings import AppMode, AppSettings
+from trading_system.app.settings import AppMode, AppSettings, LiveExecutionMode
 from trading_system.backtest.engine import BacktestContext, BacktestResult, run_backtest
 from trading_system.core.ops import (
     EnvSecretProvider,
@@ -27,16 +27,19 @@ from trading_system.execution.broker import (
     ResilientBroker,
 )
 from trading_system.execution.kis_adapter import KisBrokerAdapter
+from trading_system.integrations.kis import KisApiClient
 from trading_system.portfolio.book import PortfolioBook
 from trading_system.risk.limits import RiskLimits
 from trading_system.strategy.base import Strategy
 from trading_system.strategy.example import MomentumStrategy
-from trading_system.integrations.kis import KisApiClient
 
 
 @dataclass(slots=True)
 class AppServices:
     mode: AppMode
+    provider: str
+    broker: str
+    live_execution: LiveExecutionMode
     strategy: Strategy
     data_provider: MarketDataProvider
     risk_limits: RiskLimits
@@ -83,6 +86,24 @@ class AppServices:
         )
         return run_backtest(bars=bars, strategy=self.strategy, context=context)
 
+    def run_live_execution(self) -> BacktestResult:
+        if self.mode != AppMode.LIVE:
+            raise RuntimeError(f"Unsupported mode '{self.mode}'.")
+        if self.live_execution != LiveExecutionMode.LIVE:
+            raise RuntimeError(
+                "run_live_execution requires --live-execution live."
+            )
+        if self.provider != "kis" or self.broker != "kis":
+            raise RuntimeError(
+                "Live order submission requires '--provider kis --broker kis'."
+            )
+        if not _is_live_orders_enabled():
+            raise RuntimeError(
+                "Live order submission is disabled. "
+                "Set TRADING_SYSTEM_ENABLE_LIVE_ORDERS=true to enable."
+            )
+        return self.run_live_paper()
+
     def _single_symbol(self, mode_name: str) -> str:
         if len(self.symbols) != 1:
             raise RuntimeError(
@@ -101,6 +122,9 @@ def build_services(settings: AppSettings) -> AppServices:
 
     return AppServices(
         mode=settings.mode,
+        provider=settings.provider,
+        broker=settings.broker,
+        live_execution=settings.live_execution,
         strategy=MomentumStrategy(trade_quantity=settings.backtest.trade_quantity),
         data_provider=_build_data_provider(settings, kis_client=kis_client),
         risk_limits=RiskLimits(
@@ -198,3 +222,7 @@ def _build_live_preflight(
         )
 
     return preflight
+
+
+def _is_live_orders_enabled() -> bool:
+    return os.getenv("TRADING_SYSTEM_ENABLE_LIVE_ORDERS", "").strip().lower() == "true"

--- a/src/trading_system/app/settings.py
+++ b/src/trading_system/app/settings.py
@@ -12,6 +12,7 @@ class AppMode(StrEnum):
 class LiveExecutionMode(StrEnum):
     PREFLIGHT = "preflight"
     PAPER = "paper"
+    LIVE = "live"
 
 
 class SettingsValidationError(ValueError):
@@ -97,9 +98,13 @@ class AppSettings:
         if self.broker not in {"paper", "kis"}:
             raise SettingsValidationError("--broker must be one of: 'paper', 'kis'.")
 
-        if self.live_execution not in {LiveExecutionMode.PREFLIGHT, LiveExecutionMode.PAPER}:
+        if self.live_execution not in {
+            LiveExecutionMode.PREFLIGHT,
+            LiveExecutionMode.PAPER,
+            LiveExecutionMode.LIVE,
+        }:
             raise SettingsValidationError(
-                "--live-execution must be one of: 'preflight', 'paper'."
+                "--live-execution must be one of: 'preflight', 'paper', 'live'."
             )
 
         if self.backtest.starting_cash <= 0:
@@ -137,5 +142,5 @@ def _parse_live_execution_mode(value: str) -> LiveExecutionMode:
         return LiveExecutionMode(normalized)
     except ValueError as exc:
         raise SettingsValidationError(
-            "--live-execution must be one of: 'preflight', 'paper'."
+            "--live-execution must be one of: 'preflight', 'paper', 'live'."
         ) from exc

--- a/tests/unit/test_api_server.py
+++ b/tests/unit/test_api_server.py
@@ -9,12 +9,12 @@ def _build_client() -> TestClient:
     return TestClient(create_app())
 
 
-def _base_payload(mode: str) -> dict:
+def _base_payload(mode: str, *, provider: str = "mock", broker: str = "paper") -> dict:
     return {
         "mode": mode,
         "symbols": ["BTCUSDT"],
-        "provider": "mock",
-        "broker": "paper",
+        "provider": provider,
+        "broker": broker,
         "live_execution": "preflight",
         "risk": {
             "max_position": "1",
@@ -90,3 +90,30 @@ def test_invalid_symbols_return_standardized_400() -> None:
         "error_code": "invalid_symbols",
         "message": "Exactly one symbol is required for this API runtime.",
     }
+
+
+def test_live_execution_requires_opt_in_flag(monkeypatch) -> None:
+    class _StubServicesKisClient:
+        def preflight_symbol(self, symbol: str):
+            class Quote:
+                def __init__(self, quote_symbol: str) -> None:
+                    self.symbol = quote_symbol
+                    self.price = "70000"
+                    self.volume = "1000"
+
+            return Quote(symbol)
+
+    monkeypatch.setattr(
+        "trading_system.app.services.KisApiClient.from_env",
+        lambda: _StubServicesKisClient(),
+    )
+    monkeypatch.setenv("TRADING_SYSTEM_ENABLE_LIVE_ORDERS", "false")
+    client = _build_client()
+    payload = _base_payload(mode="live", provider="kis", broker="kis")
+    payload["symbols"] = ["005930"]
+    payload["live_execution"] = "live"
+
+    response = client.post("/api/v1/live/preflight", json=payload)
+
+    assert response.status_code == 500
+    assert response.json()["error_code"] == "runtime_error"

--- a/tests/unit/test_app_main.py
+++ b/tests/unit/test_app_main.py
@@ -83,4 +83,42 @@ def test_cli_returns_validation_error_for_invalid_live_execution_mode(capsys) ->
     captured = capsys.readouterr()
     assert exit_code == 2
     assert "Configuration error:" in captured.err
-    assert "--live-execution must be one of: 'preflight', 'paper'." in captured.err
+    assert "--live-execution must be one of: 'preflight', 'paper', 'live'." in captured.err
+
+
+def test_cli_live_mode_rejects_live_execution_without_opt_in(capsys, monkeypatch) -> None:
+    class _StubServicesKisClient:
+        def preflight_symbol(self, symbol: str):
+            class Quote:
+                def __init__(self, quote_symbol: str) -> None:
+                    self.symbol = quote_symbol
+                    self.price = "70000"
+                    self.volume = "1000"
+
+            return Quote(symbol)
+
+    monkeypatch.setattr(
+        "trading_system.app.services.KisApiClient.from_env",
+        lambda: _StubServicesKisClient(),
+    )
+    monkeypatch.setenv("TRADING_SYSTEM_ENABLE_LIVE_ORDERS", "false")
+
+    exit_code = run(
+        [
+            "--mode",
+            "live",
+            "--symbols",
+            "005930",
+            "--provider",
+            "kis",
+            "--broker",
+            "kis",
+            "--live-execution",
+            "live",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 3
+    assert "Runtime error:" in captured.err
+    assert "TRADING_SYSTEM_ENABLE_LIVE_ORDERS=true" in captured.err

--- a/tests/unit/test_app_services.py
+++ b/tests/unit/test_app_services.py
@@ -141,6 +141,62 @@ def test_build_services_uses_kis_broker_adapter_when_broker_is_kis(monkeypatch) 
     assert isinstance(services.broker_simulator.delegate, KisBrokerAdapter)
 
 
+def test_live_execution_requires_opt_in_flag(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "trading_system.app.services.KisApiClient.from_env",
+        lambda: _StubKisClient(),
+    )
+    monkeypatch.setenv("TRADING_SYSTEM_ENABLE_LIVE_ORDERS", "false")
+
+    settings = AppSettings.from_cli(
+        mode="live",
+        symbols="005930",
+        provider="kis",
+        broker="kis",
+        live_execution="live",
+        starting_cash="1000000",
+        fee_bps="5",
+        trade_quantity="1",
+        max_position="10",
+        max_notional="100000000",
+        max_order_size="5",
+    )
+    settings.validate()
+
+    services = build_services(settings)
+
+    with pytest.raises(RuntimeError, match="TRADING_SYSTEM_ENABLE_LIVE_ORDERS=true"):
+        services.run_live_execution()
+
+
+def test_live_execution_runs_when_opted_in(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "trading_system.app.services.KisApiClient.from_env",
+        lambda: _StubKisClient(),
+    )
+    monkeypatch.setenv("TRADING_SYSTEM_ENABLE_LIVE_ORDERS", "true")
+
+    settings = AppSettings.from_cli(
+        mode="live",
+        symbols="005930",
+        provider="kis",
+        broker="kis",
+        live_execution="live",
+        starting_cash="1000000",
+        fee_bps="5",
+        trade_quantity="1",
+        max_position="10",
+        max_notional="100000000",
+        max_order_size="5",
+    )
+    settings.validate()
+
+    services = build_services(settings)
+    result = services.run_live_execution()
+
+    assert result.processed_bars == 1
+
+
 
 class _StubKisClient:
     def preflight_symbol(self, symbol: str):
@@ -149,5 +205,6 @@ class _StubKisClient:
                 self.symbol = quote_symbol
                 self.price = Decimal("70200")
                 self.volume = Decimal("1200")
+                self.as_of = datetime(2024, 1, 2, tzinfo=timezone.utc)
 
         return Quote(symbol)


### PR DESCRIPTION
### Motivation

- Introduce a guarded, explicit path for submitting real orders to the KIS broker while keeping the default `live` behavior safe (preflight/paper only). 
- Prevent accidental real order submission by requiring both the `--live-execution live` flag and an environment opt-in. 
- Document the new behavior and provide a sample configuration and tests to validate the guardrails. 

### Description

- Added a new `LiveExecutionMode.LIVE` value and allowed `--live-execution live` in `src/trading_system/app/settings.py` with validation and parsing updates. 
- Implemented `run_live_execution` and an environment opt-in check (`TRADING_SYSTEM_ENABLE_LIVE_ORDERS`) in `src/trading_system/app/services.py`, and threaded `provider`, `broker`, and `live_execution` into `AppServices`. 
- Wired CLI and app runtime to support the `live` execution path in `src/trading_system/app/main.py` and updated the HTTP route to call `run_live_execution` when appropriate in `src/trading_system/api/routes/backtest.py`. 
- Extended API schemas to accept `live` as a `live_execution` option in `src/trading_system/api/schemas.py` and added a sample `examples/sample_live_kis.yaml` snippet and README updates documenting usage, env var `TRADING_SYSTEM_ENABLE_LIVE_ORDERS`, and operational cautions. 
- Added/updated unit tests to verify the opt-in behavior and CLI/API error messages in `tests/unit/test_app_services.py`, `tests/unit/test_app_main.py`, and `tests/unit/test_api_server.py`. 

### Testing

- Ran the unit test suite with `pytest -q` including `tests/unit/test_app_services.py`, `tests/unit/test_app_main.py`, and `tests/unit/test_api_server.py`, and all tests passed. 
- Exercised CLI validation via `run(...)` tests that assert proper error messages for invalid `--live-execution` values and for missing opt-in, which succeeded. 
- Exercised the HTTP API preflight endpoint behavior with `TestClient` tests asserting that `live` execution without the opt-in returns a runtime error, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bb894748c08333beb413cb6e83814a)