### PR TITLE
Implement phase 3 runtime, analytics, and reconciliation

### DIFF
--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -1,203 +1,138 @@
 # Phase 3 Implementation Plan
 
-## Overview
-Build on the stabilized Phase 1 & 2 foundations ([step.py](file:///home/roqkf/trading_system/src/trading_system/execution/step.py), [LiveTradingLoop](file:///home/roqkf/trading_system/src/trading_system/app/loop.py#25-120), [FilePortfolioRepository](file:///home/roqkf/trading_system/src/trading_system/portfolio/repository.py#18-56)) to add:
-- A real-time live dashboard (API + frontend)
-- Portfolio-level drawdown and SL/TP risk guards
-- Multi-symbol orchestration in the live loop
-- Trade-level analytics (profit factor, Sharpe, etc.)
-- Exchange reconciliation integration
+## Goal
+Implement Phase 3 as a production-hardening layer on top of the Phase 1 and 2 execution foundation. The plan must preserve the unified execution path, add operator visibility and control, protect the portfolio at runtime, support multi-symbol processing with shared capital, expose trade-level analytics from fills, and reconcile local portfolio state against the broker.
 
-> [!IMPORTANT]
-> Phase 3 is split into 4 independent epics (A–D). Each epic ships as a standalone PR so regression surface is small. Epic A (dashboard) and Epic B (portfolio risk) are the highest priority.
+## Assumptions
+- `src/trading_system/execution/step.py` remains the single trading decision and order path for both backtest and live behavior changes.
+- Existing dashboard-related and portfolio-risk-related code can be refactored if it does not fully satisfy the PRD.
+- Reconciliation is part of Phase 3 scope, but it should ship after the core runtime and risk foundations are in place because it depends on trustworthy runtime state.
+- Multi-symbol capital contention uses FIFO allocation in configured symbol order.
+- Multi-symbol strategy execution uses per-symbol strategy instances rather than shared stateful strategy objects.
+- Per-symbol strategy instances are built once during service initialization and reused for the full run.
+- Trade statistics are exposed through `GET /api/v1/analytics/backtests/{run_id}/trades` rather than only embedded inside existing backtest responses.
+- Reconciliation runs in live mode only, defaults to a 300-second cadence, and skips symbol adjustments plus all cash adjustments when any affected order is in transit.
 
----
+## Impacted Files
 
-## Epic A — Live Dashboard API + Frontend
+### Runtime and orchestration
+- `src/trading_system/app/loop.py`
+- `src/trading_system/app/state.py`
+- `src/trading_system/app/services.py`
+- `src/trading_system/execution/step.py`
+- `src/trading_system/execution/broker.py`
+- `src/trading_system/execution/reconciliation.py`
 
-### Backend
+### Risk and portfolio
+- `src/trading_system/risk/portfolio_limits.py`
+- `src/trading_system/portfolio/book.py`
+- `src/trading_system/config/settings.py`
+- `src/trading_system/app/settings.py`
 
-#### [NEW] `src/trading_system/api/routes/dashboard.py`
-- `GET /api/v1/dashboard/status` → returns the current [AppRunnerState](file:///home/roqkf/trading_system/src/trading_system/app/state.py#4-9), last heartbeat timestamp, uptime
-- `GET /api/v1/dashboard/positions` → returns all open positions from [PortfolioBook](file:///home/roqkf/trading_system/src/trading_system/portfolio/book.py#7-103) (symbol, qty, avg_cost, unrealized_pnl using last known mark)
-- `GET /api/v1/dashboard/events` → paginated last-N log events (pulled from an in-memory ring buffer wired into `StructuredLogger`)
-- `POST /api/v1/dashboard/control` → body `{"action": "pause" | "resume" | "stop"}` → mutates [AppRunnerState](file:///home/roqkf/trading_system/src/trading_system/app/state.py#4-9) in the running [LiveTradingLoop](file:///home/roqkf/trading_system/src/trading_system/app/loop.py#25-120)
+### API and dashboard
+- `src/trading_system/api/server.py`
+- `src/trading_system/api/routes/dashboard.py`
+- `src/trading_system/api/routes/analytics.py`
+- `src/trading_system/api/routes/backtest.py`
+- `src/trading_system/api/schemas.py`
+- `src/trading_system/core/ops.py`
+- `frontend/dashboard.html`
+- `frontend/index.html`
 
-> [!NOTE]
-> The loop state must be shared between the FastAPI process and the loop worker. The approach is: store [LiveTradingLoop](file:///home/roqkf/trading_system/src/trading_system/app/loop.py#25-120) instance on the FastAPI `app.state` at server startup. Dashboard routes read/mutate it through a dependency.
+### Strategy and analytics
+- `src/trading_system/strategy/factory.py`
+- `src/trading_system/strategy/base.py`
+- `src/trading_system/analytics/trades.py`
+- `src/trading_system/analytics/trade_stats.py`
 
-#### [MODIFY] [src/trading_system/api/server.py](file:///home/roqkf/trading_system/src/trading_system/api/server.py)
-- Register the new `dashboard_router`
-- Accept an optional [LiveTradingLoop](file:///home/roqkf/trading_system/src/trading_system/app/loop.py#25-120) argument in [create_app()](file:///home/roqkf/trading_system/src/trading_system/api/server.py#14-63) and store it on `app.state`
+### Tests and docs
+- `tests/unit/test_dashboard_routes.py`
+- `tests/unit/test_portfolio_risk_limits.py`
+- `tests/unit/test_live_loop_multi_symbol.py`
+- `tests/unit/test_trade_stats.py`
+- `tests/unit/test_reconciliation.py`
+- `tests/integration/` additions where runtime interaction matters
+- `configs/base.yaml`
+- `examples/`
+- `README.md`
+- `GEMINI.md`
 
-#### [MODIFY] [src/trading_system/api/schemas.py](file:///home/roqkf/trading_system/src/trading_system/api/schemas.py)
-- Add `DashboardStatusDTO`, `PositionDTO`, `PositionsResponseDTO`, `ControlActionDTO`, `EventDTO`
+## Implementation Steps
 
-#### [MODIFY] [src/trading_system/core/ops.py](file:///home/roqkf/trading_system/src/trading_system/core/ops.py)
-- Add an in-memory ring buffer (capped deque, e.g. 500 entries) to `StructuredLogger`
-- Expose `.recent_events(limit=50)` method
+1. Establish the authoritative live runtime state for operator control.
+Define how the API process and live loop share state before adding more dashboard behavior. This step should make loop state, heartbeat, uptime, and control actions authoritative rather than best-effort references on `app.state`. Introduce a small runtime control object owned by the live process and exposed to the API layer. The operator kill switch maps to pause-only behavior; it does not liquidate positions. The dashboard control API supports `pause`, `resume`, and `reset`, where `reset` is only for leaving an emergency risk state and transitions the runtime back to `PAUSED`.
 
-### Frontend
+2. Complete the dashboard around that runtime state.
+Expose status, positions, and recent events through API routes and a minimal frontend. The dashboard should show estimated marks and unrealized PnL, and it must surface pause and resume controls. Event streaming can start with polling, but the route contract should be stable enough to support later transport upgrades.
 
-#### [NEW] `frontend/dashboard.html`
-- Status card (state badge, heartbeat timestamp)
-- Positions table (symbol / qty / avg_cost / unrealised PnL)
-- Event feed (auto-refreshing every 5s via `fetch`)
-- Kill switch button (calls `/api/v1/dashboard/control`)
+3. Refactor portfolio risk to match the PRD, not only the current partial implementation.
+Move drawdown and SL/TP behavior into the risk layer used by `step.py`. Daily drawdown handling must do more than skip evaluation: it must block new entries, emit high-severity events, trigger an emergency portfolio unwind policy, and move the runtime into a guarded state that prevents immediate re-entry. Configuration should include drawdown and SL/TP thresholds plus any emergency unwind settings.
 
-#### [MODIFY] [frontend/index.html](file:///home/roqkf/trading_system/frontend/index.html) + `frontend/src/pages/` nav
-- Add nav link to `dashboard.html`
+4. Make multi-symbol execution a unified behavior across live and backtest.
+Extend orchestration so every configured symbol is processed through the same `step.py` path with independent per-symbol strategy instances and shared portfolio accounting. Build the symbol-to-strategy map once during service initialization and reuse it for the full run in both backtest and live modes. Do not leave backtest on a single-symbol-only path if live behavior changes depend on multi-symbol state. Use FIFO allocation for cash contention in configured symbol order and cover it with deterministic tests.
 
-### Tests
-- Unit: `tests/unit/test_dashboard_routes.py` — mock `app.state.loop`, verify route contracts
-- Smoke: control action changes state, positions reflect `PortfolioBook` contents
+5. Add trade extraction and PRD-aligned trade statistics.
+Create trade objects from fill events with explicit pairing rules for partial fills, scale-ins, and scale-outs. Compute the required metrics first: win rate, risk-reward ratio, trade-sequence max drawdown, and average time in market. Expose them through `GET /api/v1/analytics/backtests/{run_id}/trades` as the initial dedicated analytics API. Live-session analytics can remain follow-up work after the backtest route is stable.
 
----
+6. Add broker reconciliation as a first-class Phase 3 capability.
+Extend the broker interface with an account snapshot method, add a reconciliation service, and run it in the live loop on a default 300-second cadence. Reconciliation must compare broker state to `PortfolioBook`, emit structured adjustment events, skip symbol adjustments for affected in-transit orders, and freeze all cash adjustments for that reconciliation cycle.
 
-## Epic B — Portfolio-Level Risk Guards
+7. Update configuration, examples, and operator documentation together.
+Any configuration shape changes must be reflected in `configs/`, `examples/`, `README.md`, and `GEMINI.md`. Operator docs should explain dashboard control, emergency risk behavior, multi-symbol constraints, and reconciliation semantics.
 
-### Backend
+## Epic Breakdown
 
-#### [NEW] `src/trading_system/risk/portfolio_limits.py`
-```python
-@dataclass(slots=True)
-class PortfolioRiskLimits:
-    max_daily_drawdown_pct: Decimal   # e.g. Decimal("0.05") = 5%
-    session_peak_equity: Decimal      # set to starting equity at boot
-    sl_pct: Decimal | None = None     # per-position stop-loss %
-    tp_pct: Decimal | None = None     # per-position take-profit %
+### Epic A. Runtime State And Dashboard
+- Introduce an authoritative runtime-control/state object shared by the live loop and API layer.
+- Expose status, heartbeat, uptime, open positions, and recent events.
+- Implement dashboard `pause`, `resume`, and `reset` control against the authoritative runtime state, with kill switch mapped to pause-only behavior and `reset` returning `EMERGENCY` to `PAUSED`.
+- Add frontend dashboard polling UI.
 
-    def is_daily_limit_breached(self, current_equity: Decimal) -> bool: ...
-    def sl_triggered(self, symbol: str, avg_cost: Decimal, mark: Decimal, qty: Decimal) -> bool: ...
-    def tp_triggered(self, symbol: str, avg_cost: Decimal, mark: Decimal, qty: Decimal) -> bool: ...
-```
+### Epic B. Portfolio-Level Risk Defense
+- Finish `PortfolioRiskLimits` so equity uses realized plus unrealized exposure.
+- Add emergency drawdown handling with entry blocking, liquidation, and guarded runtime transition.
+- Keep SL/TP execution in the risk layer, not strategy code.
+- Emit warning or critical events for every guardrail action.
 
-#### [MODIFY] `src/trading_system/execution/step.py`
-- Accept an optional `portfolio_risk: PortfolioRiskLimits | None` on `TradingContext`
-- Before calling `strategy.evaluate(bar)`, check `is_daily_limit_breached`. If breached, emit `risk.daily_limit_breached` at WARNING severity and skip the step.
-- After `RiskLimits.allows_order` check, evaluate SL/TP on existing positions and auto-generate close orders as needed.
+### Epic C. Unified Multi-Symbol Orchestration
+- Extend `LiveTradingLoop` and backtest orchestration to process multiple symbols.
+- Add per-symbol timestamps and per-symbol strategy instances with isolated history.
+- Use FIFO allocation in configured symbol order for capital contention.
+- Ensure strategy factory and runtime orchestration materialize per-symbol strategy instances once per run and reuse them for the full run.
 
-#### [MODIFY] `src/trading_system/app/services.py`
-- Wire `PortfolioRiskLimits` (from settings) into `TradingContext` inside `run_live_paper`
+### Epic D. Trade Analytics
+- Extract completed trades from fills.
+- Implement PRD-required metrics only as the initial scope.
+- Surface trade stats through `GET /api/v1/analytics/backtests/{run_id}/trades` with stable DTOs.
 
-#### [MODIFY] `src/trading_system/config/settings.py` + `src/trading_system/app/settings.py`
-- Add `PortfolioRiskSettings` dataclass: `max_daily_drawdown_pct`, `sl_pct`, `tp_pct`
+### Epic E. Broker Reconciliation
+- Add broker account snapshot support.
+- Implement live-only reconciliation with a default 300-second cadence and drift detection.
+- Apply safe local corrections and emit adjustment events, but skip symbol adjustments and freeze all cash adjustments while affected orders are in transit.
+- Handle external deposits and withdrawals as first-class reconciliation outcomes.
 
-#### [MODIFY] `configs/base.yaml` + `examples/` + `README.md`
-- Document new settings keys
+## Test Plan
 
-### Tests
-- `tests/unit/test_portfolio_risk_limits.py` — drawdown breach, SL/TP trigger edge cases
-- Regression: step skips trading when daily limit breached
+### Unit Tests
+- Dashboard route tests for status, positions, events, and `pause`/`resume`/`reset` control actions.
+- Portfolio risk tests for peak-equity tracking, drawdown breach, liquidation triggers, guarded emergency state transitions, and SL/TP edge cases.
+- Multi-symbol loop tests for per-symbol processing, per-symbol strategy isolation, build-once lifecycle, FIFO cash contention, and deterministic ordering.
+- Trade extraction tests for partial fills, reopen flows, and average holding time.
+- Reconciliation tests for no-op sync, adjustment events, external cash changes, symbol skip, and cash-freeze behavior during in-transit protection.
 
----
-
-## Epic C — Multi-Symbol Orchestration
-
-### Backend
-
-#### [MODIFY] `src/trading_system/app/loop.py` — `_run_tick`
-- Replace `symbol = self.services.symbols[0]` with a loop over `self.services.symbols`
-- Maintain per-symbol `_last_processed_timestamp` as a `dict[str, datetime]`
-- Portfolio remains shared; cash allocation is FIFO (first signal to check cash wins)
-
-#### [MODIFY] `src/trading_system/app/services.py` — `_single_symbol` guard
-- Remove the guard from `run_live_paper` (was only safety for old scaffold); keep for `run` (backtest) where multi-symbol orchestration is not in scope for Phase 3
-
-#### [MODIFY] `src/trading_system/strategy/factory.py`
-- Make `build_strategy` return either a single strategy (applied to all symbols) or a `dict[str, Strategy]` keyed by symbol, depending on settings
-
-### Tests
-- `tests/unit/test_live_loop_multi_symbol.py` — mock provider returning stubs for 2 symbols, assert both are processed each tick, portfolio cash is shared
-
----
-
-## Epic D — Trade-Level Analytics
-
-#### [NEW] `src/trading_system/analytics/trades.py`
-```python
-@dataclass(frozen=True, slots=True)
-class CompletedTrade:
-    symbol: str
-    entry_price: Decimal
-    exit_price: Decimal
-    quantity: Decimal
-    pnl: Decimal
-    entry_time: datetime
-    exit_time: datetime
-
-def extract_trades(fill_events: Sequence[OrderFilledEvent]) -> list[CompletedTrade]: ...
-```
-- Parses fill event log to match buys against sells (FIFO pairing)
-
-#### [NEW] `src/trading_system/analytics/advanced_metrics.py`
-```python
-def profit_factor(trades: Sequence[CompletedTrade]) -> Decimal: ...
-def average_win(trades: Sequence[CompletedTrade]) -> Decimal: ...
-def average_loss(trades: Sequence[CompletedTrade]) -> Decimal: ...
-def sharpe_ratio(trades: Sequence[CompletedTrade], risk_free_rate: Decimal = ZERO) -> Decimal: ...
-def sortino_ratio(trades: Sequence[CompletedTrade], risk_free_rate: Decimal = ZERO) -> Decimal: ...
-```
-
-#### [MODIFY] `src/trading_system/api/routes/backtest.py`
-- Enrich `BacktestResultDTO` with `TradeStatsDTO` (profit_factor, avg_win, avg_loss, sharpe, sortino) computed from `fill_events`
-
-### Tests
-- `tests/unit/test_trades.py` — FIFO pairing, partial close, flat then reopen
-- `tests/unit/test_advanced_metrics.py` — profit_factor edge cases, empty trades → zero return
-
----
-
-## Epic E — Exchange Reconciliation (Optional Phase 3.5)
-
-> [!WARNING]
-> This epic has higher implementation risk (KIS in-transit edge cases). Treat as Phase 3.5 — plan now, ship separately after A–D are merged.
-
-#### [NEW] `src/trading_system/execution/reconciliation.py`
-```python
-@dataclass(slots=True)
-class ReconciliationResult:
-    adjusted_cash: Decimal
-    adjusted_positions: dict[str, Decimal]
-    adjustments_made: list[str]   # human-readable diff log
-
-def reconcile(book: PortfolioBook, broker: BrokerSimulator, logger: StructuredLogger) -> ReconciliationResult: ...
-```
-- Calls `broker.get_account_balance()` (new method on broker interface) to fetch real cash + positions
-- Computes diff vs `PortfolioBook`, emits `portfolio.reconciliation` event at WARNING if diff > threshold
-- Applies correction to `PortfolioBook` fields directly
-
-#### [MODIFY] `src/trading_system/execution/broker.py` — `BrokerSimulator` protocol
-- Add optional `get_account_balance() -> AccountBalanceSnapshot` method; KIS adapter implements it, simulator stubs it
-
-#### [MODIFY] `src/trading_system/app/loop.py`
-- Add a `reconciliation_interval` (default: 300s = every 5 minutes)
-- Call `reconcile()` before each tick cycle when interval has passed
-
----
-
-## Validation Plan
-
-### Automated Tests
-```bash
-# Run all tests after each epic
-uv run --python .venv/bin/python --no-sync pytest -m smoke
-uv run --python .venv/bin/python --no-sync pytest
-
-# Lint
-uv run --python .venv/bin/python --no-sync ruff check src tests
-```
+### Integration Tests
+- Live runtime/API integration test proving dashboard control changes loop behavior.
+- Multi-symbol simulation test proving the same orchestration logic works in backtest and live scaffolds.
+- Reconciliation integration test against broker stubs that model pending and settled orders.
 
 ### Manual Verification
-- Start server with `uvicorn`, open `dashboard.html`, verify heartbeat updates and position table reflects a running loop
-- Set `max_daily_drawdown_pct: 0.01` and force equity below threshold; verify `risk.daily_limit_breached` appears in logs and no new orders emit
-- Configure 2 symbols in `--symbols`, verify both are processed in each tick cycle via logs
+- Run the live server and dashboard together, confirm heartbeat updates and operator controls work.
+- Force a drawdown breach and verify new entries stop, positions unwind, and the runtime remains guarded.
+- Run two or more symbols with constrained cash and verify the allocation policy is observable in logs.
+- Simulate broker drift and verify reconciliation emits an adjustment event and updates the local book safely.
 
-### PR Strategy
-| Epic | Branch | Dependencies |
-|------|--------|-------------|
-| A — Dashboard | `feature/live-dashboard` | none |
-| B — Portfolio Risk | `feature/portfolio-risk` | none |
-| C — Multi-symbol | `feature/multi-symbol` | none |
-| D — Trade Analytics | `feature/trade-analytics` | none |
-| E — Reconciliation | `feature/reconciliation` | C (multi-symbol loop) |
+## Risks And Follow-Up
+- If live runtime control is not authoritative, the dashboard will look correct while not actually controlling the loop.
+- If multi-symbol support lands only in live mode, strategy behavior will drift from backtest and become hard to validate.
+- If reconciliation ships before in-transit semantics are explicit, it can damage the local book.
+- Async provider or broker access may be required once multi-symbol polling is exercised under real latency; treat that as an implementation concern to assess during Epic C and Epic E, not as a speculative refactor upfront.

--- a/prd.md
+++ b/prd.md
@@ -1,50 +1,109 @@
 # Product Requirements Document (PRD) - Phase 3
 
-## 1. 개요 (Overview)
-Phase 1과 Phase 2를 통해 단일 실행 경로(Unified Execution path)와 상태 영속화(Persistence), 연속 라이브 루프(Live Loop) 기반이 안정적으로 구축되었습니다.
-Phase 3의 목표는 이 기반 위에 **모니터링 체계, 다중 종목 확장성, 그리고 포트폴리오 수준의 리스크 방어 로직**을 추가하여 앱 수준의 프로덕트를 실제 운영 환경(Production) 수준의 견고한 시스템으로 끌어올리는 것입니다.
+## 1. Overview
+Phase 1 and Phase 2 established the unified execution path, portfolio persistence, and a continuously running live loop. Phase 3 extends that base into a production-oriented operating system for trading by adding:
 
-## 2. 세부 기능 요구사항 (Detailed Requirements)
+- live observability and operator control
+- portfolio-level defensive risk controls
+- multi-symbol execution on the same engine instance
+- trade-level analytics built from actual fills
+- broker/exchange reconciliation to keep the local ledger trustworthy
 
-### 2.1 실시간 라이브 대시보드 (Real-time Live Dashboard)
-- **목표:** 터미널 로그 외에 시각적인 웹 UI에서 현재 백엔드의 활동 지표와 포트폴리오를 실시간 관제합니다.
-- **기능 명세:**
-  - **서버 상태 & 하트비트 모니터:** 대시보드 상단에 백엔드 루프의 상태(`SYNC_STATE`, `TRADING`, `PAUSED`)와 마지막 하트비트 갱신 시점을 시각적으로 표시합니다.
-  - **활성 포지션 테이블:** 현재 보유 중인 종목, 진입 단가, 수량, 현재가(추정), 미실현 손익(Unrealized PnL)을 실시간 그리드로 노출합니다.
-  - **이벤트(로그) 스트리밍:** 폴링(Polling) 혹은 WebSocket 연동을 통해 최근 주문/체결/에러 이벤트를 실시간 피드로 제공합니다.
-  - **시스템 제어 (비상 정지):** UI에서 직접 API를 호출하여 [AppRunnerState](file:///home/roqkf/trading_system/src/trading_system/app/state.py#4-9)를 `PAUSED`로 변경(비상 정지, Kill Switch)하거나 재개(`TRADING`)할 수 있는 버튼을 제공합니다.
+The goal is not to add new alpha sources. The goal is to make the existing system safer, more observable, and operable across multiple symbols under real runtime constraints.
 
-### 2.2 고급 리스크 및 분석 (Advanced Risk & Analytics)
-- **목표:** 단일 종목 제약을 넘어 포트폴리오 전체 자산을 보호하고, 단순 수익률이 아닌 트레이드 단위의 정밀한 심층 통계를 제공합니다.
-- **기능 명세:**
-  - **Portfolio Drawdown Limit:** 전체 포트폴리오의 실현+미실현 손익 기준, 일일 최고점 대비 지정된 비율(-X%) 하락 시 신규 진입을 전면 차단하고 보유 포지션 강제 청산(비상 모드)으로 전환합니다.
-  - **Dynamic SL/TP (Stop-Loss/Take-Profit):** 하드코딩된 전략 로직이 아닌 독립된 리스크 관리 모듈 계층에서 현재 가격을 모니터링하여 목표가/손절가 도달 시 즉각 청산 주문을 발동합니다.
-  - **Trade-level Statistics:** '진입-청산' 사이클을 하나의 `Trade` 단위 객체로 묶어 승률(Win Rate), 손익비(Risk-Reward Ratio), 최대 손실폭(MDD), 평균 보유 기간(Average Time in Market) 계산 및 조회 API를 제공합니다.
+## 2. Product Goals
 
-### 2.3 다중 심볼 오케스트레이션 (Multi-symbol Orchestration)
-- **목표:** 하나의 트레이딩 엔진 인스턴스가 여러 종목(예: `["BTCUSDT", "ETHUSDT", "SOLUSDT"]`, 다수 주식 종목)을 동시에 모니터링하고 일괄 매매할 수 있도록 확장합니다.
-- **기능 명세:**
-  - **다중 마켓 데이터 수집:** 라이브 루프 1회전([step.py](file:///home/roqkf/trading_system/src/trading_system/execution/step.py))마다 등록된 모든 심볼의 최신 데이터를 병렬 또는 순차적으로 fetch 합니다.
-  - **심볼별 독립 전략 컨텍스트:** 각 심볼 단위로 독립된 지표(Indicator) 컨텍스트와 히스토리를 유지하여 간섭 없이 개별 Signal을 생성합니다.
-  - **통합 포트폴리오 자산 배분(Allocation):** 각 심볼에서 생성된 주문이 공통된 [PortfolioBook](file:///home/roqkf/trading_system/src/trading_system/portfolio/book.py#7-103)의 가용 현금(Net Cash)을 공유하며, 현금 부족 시 우선순위 할당 체계(Allocation Logic)를 적용합니다.
+### Goal 1. Live Observability
+Operators must be able to inspect the state of the live system without relying only on terminal logs.
 
-### 2.4 거래소 잔고 대사 (Exchange Reconciliation)
-- **목표:** [PortfolioBook](file:///home/roqkf/trading_system/src/trading_system/portfolio/book.py#7-103)의 로컬 계산 상태와 실제 증권사/거래소 계좌 잔고 간의 장부 괴리를 원천 차단합니다.
-- **기능 명세:**
-  - **주기적 잔고 조회:** 특정 주기마다 브로커 API를 호출하여 실제 계좌의 보유 자산과 현금(`Buying Power`) 잔고를 확인합니다.
-  - **오차 보정 (Sync):** 체결 지연이나 수수료 오차액 누적으로 인해 로컬 변수와 실제 거래소 잔고에 차이가 발생할 경우, 증명된 거래소 잔고를 기준으로 로컬 모델에 보정 이벤트(Adjustment Event)를 발행하여 강제 동기화합니다.
-  - **외부 입출금 자동 반영:** 사용자가 거래소 앱에서 직접 입금/출금을 진행하여 현금 잔고가 변동된 외부 요인을 자동 파악하고 포트폴리오에 반영합니다.
+### Goal 2. Portfolio Protection
+Risk protection must operate above the individual order level and be able to halt or unwind the portfolio when configured limits are breached.
 
-## 3. 기술 및 비기능 요구사항 (Non-Functional Requirements)
-- **성능 (Performance):** 다중 심볼 처리 시 Network I/O 병목이 발생하지 않도록 API 호출부(Broker/Data Provider)를 비동기화(`asyncio`/`aiohttp`/`httpx`) 하는 방안을 점검 및 도입합니다.
-- **관측성 (Observability):** 잔고 보정(Reconciliation) 현상과 리스크 가드레일 작동(Drawdown Limit Hit) 이벤트는 로깅 시스템에 가장 명시적인 치명도 수준(WARNING/CRITICAL)으로 기록되어 슬랙/이메일 등 외부 알림으로 확장되도록 설계합니다.
-- **점진적 도입:** 위 4가지 항목을 한 번에 배포하지 않고, 개별 항목별로 단독 PR과 테스트 스위트를 구성하여 점진적(Iterative)으로 베이스라인을 올려갑니다.
+### Goal 3. Multi-Symbol Operation
+One trading engine instance must process multiple symbols while preserving a single execution path and shared portfolio accounting.
 
-## 4. 범위, 리스크 및 가정 (Scope, Risks, and Assumptions)
-- **범위 (Scope):** Phase 3는 백엔드 코어 로직(리스크, 복수 종목 처리, 대사) 확장과 이를 모니터링할 프론트엔드 추가만을 대상으로 합니다. 새로운 머신러닝 모델 구축이나 별도의 이기종 블록체인 거래소(Binance 등) 어댑터는 Phase 3의 범위 밖(Out-of-scope)입니다.
-- **가정 (Assumptions):** 
-  - KIS API 등의 브로커 API는 주기적인 계좌 잔고(Buying Power, Position) 조회 호출(Polling)을 허용하는 충분한 Rate Limit을 제공한다.
-  - Phase 1 & 2에서 구현된 `ops.py` 기반의 이벤트 추적 시스템, [LiveTradingLoop](file:///home/roqkf/trading_system/src/trading_system/app/loop.py#25-120), 그리고 [step.py](file:///home/roqkf/trading_system/src/trading_system/execution/step.py)는 Phase 3 코어 확장을 위해 안정적이고 확장 가능한 토대이다.
-- **리스크 (Risks):**
-  - **Reconciliation 엣지 케이스:** 주문이 전송되었으나 아직 체결 회신이 오지 않은 상태 주기(In-transit)에서 동기화를 시도하면, 로컬 모델과 브로커 잔고 간 불일치가 발생할 수 있어 보정 로직의 오류로 이어질 수 있습니다.
-  - **다중 종목 자산 경합:** 여러 종목이 동시에 Signal을 낼 때 가용 현금(Cash)을 초과하는 주문이 발생할 수 있으므로, 종목 간 우선순위 결정 및 분배(Allocation) 정책의 복잡성이 큽니다.
+### Goal 4. Trustworthy Portfolio State
+The local `PortfolioBook` must be continuously reconcilable against broker-reported balances and positions.
+
+### Goal 5. Actionable Analytics
+Trade analytics must be expressed in trade units derived from actual fills, not only in bar-level or portfolio-level summaries.
+
+## 3. Detailed Requirements
+
+### 3.1 Real-Time Live Dashboard
+- Show the backend loop state and last heartbeat in a web UI.
+- Show active positions with symbol, quantity, average cost, estimated mark, and unrealized PnL.
+- Stream or poll recent events such as orders, fills, rejections, reconciliation adjustments, and runtime errors.
+- Provide an operator control surface to pause trading, resume trading, and reset an emergency risk state.
+- Expose a kill-switch action that pauses trading without requiring shell access. This operator action does not liquidate positions; emergency liquidation is reserved for risk-triggered flows.
+- The dashboard control API is the single operator control surface for runtime state transitions. `resume` only clears a normal paused state. `reset` clears an emergency risk state and returns the runtime to `PAUSED`, after which an operator may explicitly resume trading.
+
+### 3.2 Advanced Risk And Analytics
+- Enforce a portfolio daily drawdown limit based on realized plus unrealized PnL relative to the session peak equity.
+- When the daily drawdown limit is breached:
+  - block new entries
+  - emit a high-severity risk event
+  - transition runtime to an explicit emergency risk state that requires a manual operator reset before trading can resume
+  - liquidate open positions according to an explicit emergency exit policy
+- Support dynamic stop-loss and take-profit checks in an independent risk layer rather than strategy-specific code.
+- Build `Trade` objects from fill events that represent complete entry-to-exit cycles.
+- Expose initial trade analytics through `GET /api/v1/analytics/backtests/{run_id}/trades`.
+- Compute and expose, at minimum:
+  - win rate
+  - risk-reward ratio
+  - max drawdown at the trade-stat level or trade sequence level
+  - average time in market
+
+### 3.3 Multi-Symbol Orchestration
+- Process every configured symbol in each live loop cycle.
+- Maintain independent per-symbol strategy instances, indicator history, and last-processed timestamps.
+- Build per-symbol strategy instances once at service startup and reuse them for the full run in both backtest and live modes.
+- Preserve a single shared `PortfolioBook` and a single order/risk path through `step.py`.
+- Use FIFO allocation when multiple symbols compete for limited cash or buying power. Symbols are evaluated in configured processing order, and earlier eligible orders consume available capital first.
+- Keep behavior deterministic in backtests so multi-symbol orchestration can be validated outside live mode.
+
+### 3.4 Exchange Reconciliation
+- Poll broker balances and positions on a configurable cadence. The default production cadence is every 300 seconds in live mode only.
+- Detect drift between broker-reported state and the local `PortfolioBook`.
+- Emit structured adjustment events when corrections are applied.
+- Reflect external cash movements such as deposits and withdrawals when the broker state proves they occurred.
+- Skip automatic adjustments for symbols affected by in-transit orders, and freeze all cash adjustments for that reconciliation cycle, so reconciliation does not overwrite legitimate pending activity.
+
+## 4. Non-Functional Requirements
+- Preserve the unified execution path across backtest and live wherever behavior changes affect trading logic.
+- Keep strategy, risk, execution, analytics, and portfolio layers separated by explicit interfaces.
+- Prefer iterative rollout by epic, but the Phase 3 plan must still cover all five product areas above.
+- For multi-symbol live operation, assess whether provider and broker I/O needs asynchronous execution or bounded concurrency.
+- Emit high-severity structured events for drawdown breaches, emergency liquidation, and reconciliation adjustments.
+
+## 5. Scope
+
+### In Scope
+- backend changes for dashboard support, risk, orchestration, analytics, and reconciliation
+- minimal frontend required to operate and monitor the live runtime
+- configuration and documentation updates needed to run the new behavior
+- tests that prove trading behavior and operator workflows
+
+### Out Of Scope
+- new machine-learning models
+- new strategy families unrelated to Phase 3 operability
+- new third-party exchange ecosystems beyond the current broker/provider surface unless strictly required for reconciliation support
+
+## 6. Success Criteria
+- An operator can view runtime status, positions, and recent events from a browser.
+- A configured drawdown breach prevents new entries and produces a verified emergency unwind path.
+- A single runtime can process multiple symbols while sharing portfolio cash and preserving deterministic backtest coverage.
+- Trade statistics are available from completed fills and include the required minimum metrics.
+- Broker reconciliation detects and records ledger drift without corrupting in-transit order handling.
+
+## 7. Risks And Assumptions
+
+### Assumptions
+- Broker APIs permit balance and position polling at a cadence that is safe for production use.
+- The current event logging and persistence infrastructure from Phase 1 and 2 is stable enough to extend rather than replace.
+
+### Risks
+- Reconciliation can be wrong if in-transit orders are treated as settled.
+- Multi-symbol order contention can cause cash oversubscription without a clear allocation policy.
+- Dashboard control can be misleading if the UI and live loop do not share a truly authoritative runtime state.
+- Trade extraction can be incorrect around partial fills, scale-ins, and scale-outs unless fill pairing rules are explicit.

--- a/src/trading_system/analytics/trade_stats.py
+++ b/src/trading_system/analytics/trade_stats.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from decimal import Decimal
+
+from trading_system.analytics.trades import CompletedTrade
+
+ZERO = Decimal("0")
+
+
+@dataclass(frozen=True, slots=True)
+class TradeStats:
+    trade_count: int
+    win_rate: Decimal
+    risk_reward_ratio: Decimal
+    max_drawdown: Decimal
+    average_time_in_market_seconds: float
+
+
+def summarize_trades(trades: Sequence[CompletedTrade]) -> TradeStats:
+    if not trades:
+        return TradeStats(
+            trade_count=0,
+            win_rate=ZERO,
+            risk_reward_ratio=ZERO,
+            max_drawdown=ZERO,
+            average_time_in_market_seconds=0.0,
+        )
+
+    wins = [trade.pnl for trade in trades if trade.pnl > ZERO]
+    losses = [abs(trade.pnl) for trade in trades if trade.pnl < ZERO]
+    win_rate = Decimal(len(wins)) / Decimal(len(trades))
+    average_win = sum(wins, start=ZERO) / Decimal(len(wins)) if wins else ZERO
+    average_loss = sum(losses, start=ZERO) / Decimal(len(losses)) if losses else ZERO
+    risk_reward_ratio = average_win / average_loss if average_loss > ZERO else ZERO
+
+    cumulative = ZERO
+    peak = ZERO
+    max_dd = ZERO
+    for trade in trades:
+        cumulative += trade.pnl
+        if cumulative > peak:
+            peak = cumulative
+        if peak == ZERO:
+            continue
+        drawdown = (cumulative - peak) / abs(peak)
+        if drawdown < max_dd:
+            max_dd = drawdown
+
+    avg_holding = sum(trade.holding_seconds for trade in trades) / len(trades)
+
+    return TradeStats(
+        trade_count=len(trades),
+        win_rate=win_rate,
+        risk_reward_ratio=risk_reward_ratio,
+        max_drawdown=max_dd,
+        average_time_in_market_seconds=avg_holding,
+    )

--- a/src/trading_system/analytics/trades.py
+++ b/src/trading_system/analytics/trades.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, is_dataclass
+from datetime import datetime
+from decimal import Decimal
+
+ZERO = Decimal("0")
+
+
+@dataclass(frozen=True, slots=True)
+class CompletedTrade:
+    symbol: str
+    entry_time: datetime
+    exit_time: datetime
+    entry_price: Decimal
+    exit_price: Decimal
+    quantity: Decimal
+    pnl: Decimal
+
+    @property
+    def holding_seconds(self) -> float:
+        return (self.exit_time - self.entry_time).total_seconds()
+
+
+@dataclass(slots=True)
+class _OpenLot:
+    quantity: Decimal
+    price: Decimal
+    timestamp: datetime
+
+
+def extract_trades(order_events: Sequence[Mapping[str, object]]) -> list[CompletedTrade]:
+    open_lots: dict[str, deque[_OpenLot]] = {}
+    completed: list[CompletedTrade] = []
+
+    for event in order_events:
+        if is_dataclass(event):
+            event = asdict(event)
+        if str(event.get("event")) != "order.filled":
+            continue
+        payload = event.get("payload", {})
+        if not isinstance(payload, Mapping):
+            continue
+
+        symbol = str(payload.get("symbol", ""))
+        side = str(payload.get("side", ""))
+        quantity = _to_decimal(payload.get("filled_quantity"))
+        price = _to_decimal(payload.get("fill_price"))
+        timestamp = _to_datetime(payload.get("timestamp"))
+
+        if not symbol or quantity <= ZERO:
+            continue
+
+        lots = open_lots.setdefault(symbol, deque())
+        if side == "buy":
+            lots.append(_OpenLot(quantity=quantity, price=price, timestamp=timestamp))
+            continue
+
+        remaining = quantity
+        while remaining > ZERO and lots:
+            lot = lots[0]
+            matched = min(remaining, lot.quantity)
+            completed.append(
+                CompletedTrade(
+                    symbol=symbol,
+                    entry_time=lot.timestamp,
+                    exit_time=timestamp,
+                    entry_price=lot.price,
+                    exit_price=price,
+                    quantity=matched,
+                    pnl=(price - lot.price) * matched,
+                )
+            )
+            remaining -= matched
+            lot.quantity -= matched
+            if lot.quantity == ZERO:
+                lots.popleft()
+
+    return completed
+
+
+def _to_decimal(value: object) -> Decimal:
+    return Decimal(str(value))
+
+
+def _to_datetime(value: object) -> datetime:
+    return datetime.fromisoformat(str(value))

--- a/src/trading_system/api/routes/analytics.py
+++ b/src/trading_system/api/routes/analytics.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from fastapi import APIRouter, HTTPException, status
+
+from trading_system.analytics.trade_stats import summarize_trades
+from trading_system.analytics.trades import extract_trades
+from trading_system.api.routes.backtest import _RUN_REPOSITORY
+from trading_system.api.schemas import TradeAnalyticsResponseDTO, TradeDTO, TradeStatsDTO
+
+router = APIRouter(prefix="/api/v1/analytics", tags=["analytics"])
+
+
+@router.get("/backtests/{run_id}/trades", response_model=TradeAnalyticsResponseDTO)
+def get_backtest_trade_analytics(run_id: str) -> TradeAnalyticsResponseDTO:
+    run = _RUN_REPOSITORY.get(run_id)
+    if run is None or run.result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Backtest run not found")
+
+    trades = extract_trades(run.result.orders)
+    stats = summarize_trades(trades)
+    return TradeAnalyticsResponseDTO(
+        stats=TradeStatsDTO(
+            trade_count=stats.trade_count,
+            win_rate=_to_string(stats.win_rate),
+            risk_reward_ratio=_to_string(stats.risk_reward_ratio),
+            max_drawdown=_to_string(stats.max_drawdown),
+            average_time_in_market_seconds=stats.average_time_in_market_seconds,
+        ),
+        trades=[
+            TradeDTO(
+                symbol=trade.symbol,
+                entry_time=trade.entry_time.isoformat(),
+                exit_time=trade.exit_time.isoformat(),
+                entry_price=_to_string(trade.entry_price),
+                exit_price=_to_string(trade.exit_price),
+                quantity=_to_string(trade.quantity),
+                pnl=_to_string(trade.pnl),
+                holding_seconds=trade.holding_seconds,
+            )
+            for trade in trades
+        ],
+    )
+
+
+def _to_string(value: Decimal) -> str:
+    return format(value, "f")

--- a/src/trading_system/api/routes/backtest.py
+++ b/src/trading_system/api/routes/backtest.py
@@ -21,6 +21,7 @@ from trading_system.app.settings import (
     BacktestSettings,
     LiveExecutionMode,
     PatternSignalStrategySettings,
+    PortfolioRiskSettings,
     RiskSettings,
 )
 from trading_system.backtest.dto import BacktestResultDTO as SerializedBacktestResultDTO
@@ -37,18 +38,19 @@ _MAX_FEE_BPS = Decimal("1000")
 
 
 def _validate_request_payload(payload: BacktestRunRequestDTO | LivePreflightRequestDTO) -> None:
-    if len(payload.symbols) != 1:
+    if payload.mode == "live" and len(payload.symbols) != 1:
         raise RequestValidationError(
             error_code="invalid_symbols",
-            message="Exactly one symbol is required for this API runtime.",
+            message="Exactly one symbol is required for live API runtime.",
         )
 
-    normalized = payload.symbols[0].strip().upper()
-    if not normalized or not normalized.replace("-", "").isalnum():
-        raise RequestValidationError(
-            error_code="invalid_symbols",
-            message="Symbol must be non-empty and contain only letters, numbers, or '-'.",
-        )
+    for symbol in payload.symbols:
+        normalized = symbol.strip().upper()
+        if not normalized or not normalized.replace("-", "").isalnum():
+            raise RequestValidationError(
+                error_code="invalid_symbols",
+                message="Symbol must be non-empty and contain only letters, numbers, or '-'.",
+            )
 
     if payload.backtest.trade_quantity <= 0:
         raise RequestValidationError(
@@ -108,6 +110,15 @@ def _to_app_settings(payload: BacktestRunRequestDTO | LivePreflightRequestDTO) -
             max_position=payload.risk.max_position,
             max_notional=payload.risk.max_notional,
             max_order_size=payload.risk.max_order_size,
+        ),
+        portfolio_risk=(
+            PortfolioRiskSettings(
+                max_daily_drawdown_pct=payload.portfolio_risk.max_daily_drawdown_pct,
+                sl_pct=payload.portfolio_risk.sl_pct,
+                tp_pct=payload.portfolio_risk.tp_pct,
+            )
+            if payload.portfolio_risk is not None
+            else None
         ),
         backtest=BacktestSettings(
             starting_cash=payload.backtest.starting_cash,
@@ -220,7 +231,7 @@ def run_live_preflight(payload: LivePreflightRequestDTO) -> LivePreflightRespons
     message = services.preflight_live()
     paper_result = None
     if settings.live_execution == LiveExecutionMode.PAPER:
-        paper_result = _to_api_result_dto(_to_serialized_result(services.run_live_paper()))
+        services.run_live_paper()
     if settings.live_execution == LiveExecutionMode.LIVE:
-        paper_result = _to_api_result_dto(_to_serialized_result(services.run_live_execution()))
+        services.run_live_execution()
     return LivePreflightResponseDTO(message=message, paper_result=paper_result)

--- a/src/trading_system/api/routes/dashboard.py
+++ b/src/trading_system/api/routes/dashboard.py
@@ -77,6 +77,8 @@ async def get_status(loop: LoopDep) -> DashboardStatusDTO:
 async def get_positions(loop: LoopDep) -> PositionsResponseDTO:
     """Return active positions and cash from the portfolio book."""
     book = loop.services.portfolio
+    marks = getattr(loop.runtime, "last_marks", {})
+    unrealized = book.unrealized_pnl(marks)
     dtos: list[PositionDTO] = []
     for symbol, qty in book.positions.items():
         avg_cost = book.average_costs.get(symbol, ZERO)
@@ -85,7 +87,7 @@ async def get_positions(loop: LoopDep) -> PositionsResponseDTO:
                 symbol=symbol,
                 quantity=str(qty),
                 average_cost=str(avg_cost),
-                unrealized_pnl=None,  # mark-to-market requires live price; omitted here
+                unrealized_pnl=str(unrealized[symbol]) if symbol in unrealized else None,
             )
         )
     return PositionsResponseDTO(positions=dtos, cash=str(book.cash))
@@ -114,7 +116,7 @@ async def get_events(
 
 @router.post("/control", response_model=ControlResponseDTO, status_code=status.HTTP_200_OK)
 async def control_loop(body: ControlActionDTO, loop: LoopDep) -> ControlResponseDTO:
-    """Pause, resume, or stop the live trading loop."""
+    """Pause, resume, or reset the live trading loop."""
     if body.action == "pause":
         if loop.state == AppRunnerState.RUNNING:
             loop.state = AppRunnerState.PAUSED
@@ -131,11 +133,12 @@ async def control_loop(body: ControlActionDTO, loop: LoopDep) -> ControlResponse
                 severity=20,
                 payload={"action": "resume", "requested_by": "api"},
             )
-    elif body.action == "stop":
-        loop.state = AppRunnerState.STOPPED
-        loop.services.logger.emit(
-            "system.control",
-            severity=30,
-            payload={"action": "stop", "requested_by": "api"},
-        )
+    elif body.action == "reset":
+        if loop.state == AppRunnerState.EMERGENCY:
+            loop.state = AppRunnerState.PAUSED
+            loop.services.logger.emit(
+                "system.control",
+                severity=30,
+                payload={"action": "reset", "requested_by": "api"},
+            )
     return ControlResponseDTO(status="ok", state=loop.state.value)

--- a/src/trading_system/api/schemas.py
+++ b/src/trading_system/api/schemas.py
@@ -10,6 +10,12 @@ class RiskSettingsDTO(BaseModel):
     max_order_size: Decimal
 
 
+class PortfolioRiskSettingsDTO(BaseModel):
+    max_daily_drawdown_pct: Decimal
+    sl_pct: Decimal | None = None
+    tp_pct: Decimal | None = None
+
+
 class BacktestSettingsDTO(BaseModel):
     starting_cash: Decimal
     fee_bps: Decimal
@@ -32,6 +38,7 @@ class BacktestRunRequestDTO(BaseModel):
     broker: Literal["paper", "kis"] = "paper"
     live_execution: Literal["preflight", "paper", "live"] = "preflight"
     risk: RiskSettingsDTO
+    portfolio_risk: PortfolioRiskSettingsDTO | None = None
     backtest: BacktestSettingsDTO
     strategy: StrategyConfigDTO | None = None
 
@@ -43,6 +50,7 @@ class LivePreflightRequestDTO(BaseModel):
     broker: Literal["paper", "kis"] = "paper"
     live_execution: Literal["preflight", "paper", "live"] = "preflight"
     risk: RiskSettingsDTO
+    portfolio_risk: PortfolioRiskSettingsDTO | None = None
     backtest: BacktestSettingsDTO
     strategy: StrategyConfigDTO | None = None
 
@@ -201,9 +209,33 @@ class EventFeedDTO(BaseModel):
 
 
 class ControlActionDTO(BaseModel):
-    action: Literal["pause", "resume", "stop"]
+    action: Literal["pause", "resume", "reset"]
 
 
 class ControlResponseDTO(BaseModel):
     status: Literal["ok"]
     state: str
+
+
+class TradeDTO(BaseModel):
+    symbol: str
+    entry_time: str
+    exit_time: str
+    entry_price: str
+    exit_price: str
+    quantity: str
+    pnl: str
+    holding_seconds: float
+
+
+class TradeStatsDTO(BaseModel):
+    trade_count: int
+    win_rate: str
+    risk_reward_ratio: str
+    max_drawdown: str
+    average_time_in_market_seconds: float
+
+
+class TradeAnalyticsResponseDTO(BaseModel):
+    stats: TradeStatsDTO
+    trades: list[TradeDTO]

--- a/src/trading_system/api/server.py
+++ b/src/trading_system/api/server.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 
 from trading_system.api.errors import RequestValidationError
+from trading_system.api.routes.analytics import router as analytics_router
 from trading_system.api.routes.backtest import router as backtest_router
 from trading_system.api.routes.dashboard import router as dashboard_router
 from trading_system.api.routes.patterns import router as patterns_router
@@ -14,6 +15,7 @@ from trading_system.config.settings import SettingsValidationError as ConfigSett
 
 def create_app(live_loop=None) -> FastAPI:
     app = FastAPI(title="trading_system API", version="1.0.0")
+    app.include_router(analytics_router)
     app.include_router(backtest_router)
     app.include_router(patterns_router)
     app.include_router(strategies_router)

--- a/src/trading_system/app/loop.py
+++ b/src/trading_system/app/loop.py
@@ -5,8 +5,9 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from trading_system.app.state import AppRunnerState
+from trading_system.app.state import AppRunnerState, LiveRuntimeState
 from trading_system.core.compat import UTC
+from trading_system.execution.reconciliation import reconcile
 from trading_system.execution.step import TradingContext, execute_trading_step
 
 if TYPE_CHECKING:
@@ -31,10 +32,36 @@ class LiveTradingLoop:
     heartbeat_interval: int = field(
         default_factory=lambda: _resolve_env_int("TRADING_SYSTEM_HEARTBEAT_INTERVAL", 60)
     )
-    state: AppRunnerState = field(default=AppRunnerState.INIT, init=False)
-    _last_heartbeat: datetime | None = field(default=None, init=False)
+    reconciliation_interval: int = field(
+        default_factory=lambda: _resolve_env_int("TRADING_SYSTEM_RECONCILIATION_INTERVAL", 300)
+    )
+    runtime: LiveRuntimeState = field(default_factory=LiveRuntimeState, init=False)
     _last_processed_timestamps: dict[str, datetime] = field(default_factory=dict, init=False)
-    _started_at: datetime | None = field(default=None, init=False)
+    _last_reconciliation: datetime | None = field(default=None, init=False)
+
+    @property
+    def state(self) -> AppRunnerState:
+        return self.runtime.state
+
+    @state.setter
+    def state(self, value: AppRunnerState) -> None:
+        self.runtime.state = value
+
+    @property
+    def _last_heartbeat(self) -> datetime | None:
+        return self.runtime.last_heartbeat
+
+    @_last_heartbeat.setter
+    def _last_heartbeat(self, value: datetime | None) -> None:
+        self.runtime.last_heartbeat = value
+
+    @property
+    def _started_at(self) -> datetime | None:
+        return self.runtime.started_at
+
+    @_started_at.setter
+    def _started_at(self, value: datetime | None) -> None:
+        self.runtime.started_at = value
 
     def run(self) -> None:
         self._started_at = datetime.now(UTC)
@@ -51,11 +78,15 @@ class LiveTradingLoop:
             risk_limits=self.services.risk_limits,
             broker=self.services.broker_simulator,
             logger=self.services.logger,
+            portfolio_risk=self.services.portfolio_risk,
+            runtime_state=self.runtime,
+            marks=self.runtime.last_marks,
         )
 
         while self.state != AppRunnerState.STOPPED:
             try:
                 if self.state == AppRunnerState.RUNNING:
+                    self._maybe_reconcile()
                     self._run_tick(context)
                     
                 self._check_heartbeat()
@@ -111,10 +142,32 @@ class LiveTradingLoop:
                 if last_ts is not None and bar.timestamp <= last_ts:
                     continue
 
-                execute_trading_step(bar=bar, strategy=self.services.strategy, context=context)
+                execute_trading_step(
+                    bar=bar,
+                    strategy=self.services.strategy_for(symbol),
+                    context=context,
+                )
                 self._last_processed_timestamps[symbol] = bar.timestamp
                 last_ts = bar.timestamp
                 processed_any = True
 
         if processed_any and self.services.portfolio_repository is not None:
             self.services.portfolio_repository.save(self.services.portfolio)
+
+    def _maybe_reconcile(self) -> None:
+        now = datetime.now(UTC)
+        if (
+            self._last_reconciliation is not None
+            and (now - self._last_reconciliation).total_seconds() < self.reconciliation_interval
+        ):
+            return
+        snapshot = self.services.broker_simulator.get_account_balance()
+        if snapshot is None:
+            self._last_reconciliation = now
+            return
+        reconcile(
+            book=self.services.portfolio,
+            snapshot=snapshot,
+            logger=self.services.logger,
+        )
+        self._last_reconciliation = now

--- a/src/trading_system/app/services.py
+++ b/src/trading_system/app/services.py
@@ -6,6 +6,7 @@ from typing import Callable
 from trading_system.app.loop import LiveTradingLoop
 from trading_system.app.sample_data import build_sample_bars
 from trading_system.app.settings import AppMode, AppSettings, LiveExecutionMode
+from trading_system.app.state import AppRunnerState, LiveRuntimeState
 from trading_system.backtest.engine import BacktestContext, BacktestResult, run_backtest
 from trading_system.core.ops import (
     EnvSecretProvider,
@@ -33,8 +34,9 @@ from trading_system.patterns.repository import PatternSetRepository
 from trading_system.portfolio.book import PortfolioBook
 from trading_system.portfolio.repository import FilePortfolioRepository, PortfolioRepository
 from trading_system.risk.limits import RiskLimits
+from trading_system.risk.portfolio_limits import PortfolioRiskLimits
 from trading_system.strategy.base import Strategy
-from trading_system.strategy.factory import build_strategy
+from trading_system.strategy.factory import build_strategies
 from trading_system.strategy.repository import StrategyProfileRepository
 
 
@@ -53,20 +55,29 @@ class AppServices:
     logger: StructuredLogger
     live_preflight_check: Callable[[str], str] | None = None
     portfolio_repository: PortfolioRepository | None = None
+    strategies: dict[str, Strategy] | None = None
+    portfolio_risk: PortfolioRiskLimits | None = None
 
     def run(self) -> BacktestResult:
         if self.mode != AppMode.BACKTEST:
             raise RuntimeError(f"Unsupported mode '{self.mode}'.")
 
-        symbol = self._single_symbol(mode_name="backtest")
-        bars = self.data_provider.load_bars(symbol)
+        bars = self._merged_bars()
         context = BacktestContext(
             portfolio=self.portfolio,
             risk_limits=self.risk_limits,
             broker=self.broker_simulator,
             logger=self.logger,
+            portfolio_risk=self.portfolio_risk,
+            runtime_state=LiveRuntimeState(state=AppRunnerState.RUNNING),
+            marks={},
         )
-        return run_backtest(bars=bars, strategy=self.strategy, context=context)
+        return run_backtest(
+            bars=bars,
+            strategy=self.strategy,
+            context=context,
+            strategy_by_symbol=self.strategies,
+        )
 
     def preflight_live(self) -> str:
         if self.mode != AppMode.LIVE:
@@ -109,6 +120,20 @@ class AppServices:
             )
         return self.symbols[0]
 
+    def strategy_for(self, symbol: str) -> Strategy:
+        if self.strategies is None:
+            return self.strategy
+        return self.strategies[symbol]
+
+    def _merged_bars(self):
+        symbol_order = {symbol: idx for idx, symbol in enumerate(self.symbols)}
+        merged = [
+            bar
+            for symbol in self.symbols
+            for bar in self.data_provider.load_bars(symbol)
+        ]
+        return sorted(merged, key=lambda bar: (bar.timestamp, symbol_order[bar.symbol]))
+
 
 def build_services(settings: AppSettings) -> AppServices:
     ensure_logging()
@@ -133,22 +158,28 @@ def build_services(settings: AppSettings) -> AppServices:
         portfolio = PortfolioBook(cash=settings.backtest.starting_cash)
         logger.emit("portfolio.initialized", severity=20, payload={"cash": str(portfolio.cash)})
 
+    strategies = build_strategies(
+        settings,
+        symbols=settings.symbols,
+        pattern_repository=pattern_repository,
+        strategy_repository=strategy_repository,
+    )
+    primary_strategy = strategies[settings.symbols[0]]
+
     return AppServices(
         mode=settings.mode,
         provider=settings.provider,
         broker=settings.broker,
         live_execution=settings.live_execution,
-        strategy=build_strategy(
-            settings,
-            pattern_repository=pattern_repository,
-            strategy_repository=strategy_repository,
-        ),
+        strategy=primary_strategy,
+        strategies=strategies,
         data_provider=_build_data_provider(settings, kis_client=kis_client),
         risk_limits=RiskLimits(
             max_position=settings.risk.max_position,
             max_notional=settings.risk.max_notional,
             max_order_size=settings.risk.max_order_size,
         ),
+        portfolio_risk=_build_portfolio_risk(settings, portfolio),
         broker_simulator=ResilientBroker(
             delegate=_build_broker(settings, kis_client=kis_client),
         ),
@@ -157,6 +188,20 @@ def build_services(settings: AppSettings) -> AppServices:
         logger=logger,
         live_preflight_check=_build_live_preflight(settings, kis_client=kis_client),
         portfolio_repository=portfolio_repository if settings.mode == AppMode.LIVE else None,
+    )
+
+
+def _build_portfolio_risk(
+    settings: AppSettings,
+    portfolio: PortfolioBook,
+) -> PortfolioRiskLimits | None:
+    if settings.portfolio_risk is None:
+        return None
+    return PortfolioRiskLimits(
+        max_daily_drawdown_pct=settings.portfolio_risk.max_daily_drawdown_pct,
+        session_peak_equity=portfolio.total_equity({}),
+        sl_pct=settings.portfolio_risk.sl_pct,
+        tp_pct=settings.portfolio_risk.tp_pct,
     )
 
 

--- a/src/trading_system/app/settings.py
+++ b/src/trading_system/app/settings.py
@@ -28,6 +28,13 @@ class RiskSettings:
 
 
 @dataclass(slots=True)
+class PortfolioRiskSettings:
+    max_daily_drawdown_pct: Decimal
+    sl_pct: Decimal | None = None
+    tp_pct: Decimal | None = None
+
+
+@dataclass(slots=True)
 class BacktestSettings:
     starting_cash: Decimal
     fee_bps: Decimal
@@ -54,6 +61,7 @@ class AppSettings:
     risk: RiskSettings
     backtest: BacktestSettings
     strategy: PatternSignalStrategySettings | None = None
+    portfolio_risk: PortfolioRiskSettings | None = None
 
     @classmethod
     def from_cli(
@@ -93,6 +101,7 @@ class AppSettings:
                 max_notional=_to_decimal(max_notional, "max_notional"),
                 max_order_size=_to_decimal(max_order_size, "max_order_size"),
             ),
+            portfolio_risk=None,
             backtest=BacktestSettings(
                 starting_cash=_to_decimal(starting_cash, "starting_cash"),
                 fee_bps=_to_decimal(fee_bps, "fee_bps"),
@@ -140,6 +149,20 @@ class AppSettings:
 
         if self.risk.max_order_size > self.risk.max_position:
             raise SettingsValidationError("--max-order-size cannot exceed --max-position.")
+
+        if self.portfolio_risk is not None:
+            if self.portfolio_risk.max_daily_drawdown_pct <= 0:
+                raise SettingsValidationError(
+                    "portfolio_risk.max_daily_drawdown_pct must be greater than 0."
+                )
+            if self.portfolio_risk.max_daily_drawdown_pct >= Decimal("1"):
+                raise SettingsValidationError(
+                    "portfolio_risk.max_daily_drawdown_pct must be less than 1."
+                )
+            if self.portfolio_risk.sl_pct is not None and self.portfolio_risk.sl_pct <= 0:
+                raise SettingsValidationError("portfolio_risk.sl_pct must be greater than 0.")
+            if self.portfolio_risk.tp_pct is not None and self.portfolio_risk.tp_pct <= 0:
+                raise SettingsValidationError("portfolio_risk.tp_pct must be greater than 0.")
 
         if self.strategy is None:
             return

--- a/src/trading_system/app/state.py
+++ b/src/trading_system/app/state.py
@@ -1,3 +1,7 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+
 from trading_system.core.compat import StrEnum
 
 
@@ -5,4 +9,13 @@ class AppRunnerState(StrEnum):
     INIT = "init"
     RUNNING = "running"
     PAUSED = "paused"
+    EMERGENCY = "emergency"
     STOPPED = "stopped"
+
+
+@dataclass(slots=True)
+class LiveRuntimeState:
+    state: AppRunnerState = AppRunnerState.INIT
+    started_at: datetime | None = None
+    last_heartbeat: datetime | None = None
+    last_marks: dict[str, Decimal] = field(default_factory=dict)

--- a/src/trading_system/backtest/engine.py
+++ b/src/trading_system/backtest/engine.py
@@ -33,6 +33,8 @@ def run_backtest(
     bars: Iterable[MarketBar],
     strategy: Strategy,
     context: BacktestContext,
+    *,
+    strategy_by_symbol: dict[str, Strategy] | None = None,
 ) -> BacktestResult:
     equity_timestamps: list[datetime] = []
     equity_curve: list[Decimal] = []
@@ -46,7 +48,12 @@ def run_backtest(
 
     for bar in bars:
         processed_bars += 1
-        events = execute_trading_step(bar, strategy, context)
+        active_strategy = (
+            strategy_by_symbol.get(bar.symbol, strategy)
+            if strategy_by_symbol
+            else strategy
+        )
+        events = execute_trading_step(bar, active_strategy, context)
         
         if events.signal:
             _record_event(signal_events, "strategy.signal", events.signal)

--- a/src/trading_system/core/ops.py
+++ b/src/trading_system/core/ops.py
@@ -68,6 +68,7 @@ class OrderCreatedEvent:
     symbol: str
     side: str
     quantity: Decimal
+    timestamp: str
 
 
 @dataclass(slots=True)
@@ -76,6 +77,7 @@ class OrderRejectedEvent:
     side: str
     quantity: Decimal
     reason: str
+    timestamp: str
 
 
 @dataclass(slots=True)
@@ -87,6 +89,7 @@ class OrderFilledEvent:
     fill_price: Decimal
     fee: Decimal
     status: str
+    timestamp: str
 
 
 @dataclass(slots=True)
@@ -95,6 +98,7 @@ class RiskRejectedEvent:
     requested_quantity: Decimal
     current_position: Decimal
     price: Decimal
+    timestamp: str
 
 
 @dataclass(slots=True)

--- a/src/trading_system/execution/broker.py
+++ b/src/trading_system/execution/broker.py
@@ -35,6 +35,13 @@ class FillEvent:
         return self.filled_quantity if self.side == OrderSide.BUY else -self.filled_quantity
 
 
+@dataclass(slots=True, frozen=True)
+class AccountBalanceSnapshot:
+    cash: Decimal
+    positions: dict[str, Decimal]
+    pending_symbols: tuple[str, ...] = ()
+
+
 class FillQuantityPolicy(Protocol):
     def fill_quantity(self, order: OrderRequest, bar: MarketBar) -> Decimal:
         """Return absolute filled quantity."""
@@ -93,6 +100,9 @@ class BrokerSimulator(Protocol):
     def submit_order(self, order: OrderRequest, bar: MarketBar) -> FillEvent:
         """Submit one order and return a deterministic fill event."""
 
+    def get_account_balance(self) -> AccountBalanceSnapshot | None:
+        """Return an account snapshot when the broker supports reconciliation."""
+
 
 @dataclass(slots=True)
 class PolicyBrokerSimulator:
@@ -130,6 +140,9 @@ class PolicyBrokerSimulator:
             status=status,
         )
 
+    def get_account_balance(self) -> AccountBalanceSnapshot | None:
+        return None
+
 
 @dataclass(slots=True)
 class ResilientBroker:
@@ -143,6 +156,18 @@ class ResilientBroker:
         return execute_with_resilience(
             operation=f"broker_submit:{order.symbol}",
             callback=lambda: self.delegate.submit_order(order, bar),
+            retry=self.retry_policy,
+            timeout=self.timeout_policy,
+            circuit_breaker=self.circuit_breaker_policy,
+            circuit_state=self._circuit_state,
+        )
+
+    def get_account_balance(self) -> AccountBalanceSnapshot | None:
+        if not hasattr(self.delegate, "get_account_balance"):
+            return None
+        return execute_with_resilience(
+            operation="broker_account_balance",
+            callback=lambda: self.delegate.get_account_balance(),
             retry=self.retry_policy,
             timeout=self.timeout_policy,
             circuit_breaker=self.circuit_breaker_policy,

--- a/src/trading_system/execution/kis_adapter.py
+++ b/src/trading_system/execution/kis_adapter.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 
 from trading_system.core.types import MarketBar
-from trading_system.execution.broker import FillEvent, FillStatus
+from trading_system.execution.broker import AccountBalanceSnapshot, FillEvent, FillStatus
 from trading_system.execution.orders import OrderRequest
 from trading_system.integrations.kis import KisApiClient, KisOrderResult
 
@@ -14,6 +14,9 @@ class KisBrokerAdapter:
     def submit_order(self, order: OrderRequest, bar: MarketBar) -> FillEvent:
         result = self.client.submit_order(order)
         return _to_fill_event(result=result, order=order, fallback_price=bar.close)
+
+    def get_account_balance(self) -> AccountBalanceSnapshot | None:
+        return None
 
 
 def _to_fill_event(

--- a/src/trading_system/execution/reconciliation.py
+++ b/src/trading_system/execution/reconciliation.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from trading_system.core.ops import StructuredLogger
+from trading_system.execution.broker import AccountBalanceSnapshot
+from trading_system.portfolio.book import ZERO, PortfolioBook
+
+
+@dataclass(slots=True, frozen=True)
+class ReconciliationResult:
+    adjusted_cash: bool
+    adjusted_symbols: tuple[str, ...]
+    frozen_cash: bool
+
+
+def reconcile(
+    *,
+    book: PortfolioBook,
+    snapshot: AccountBalanceSnapshot,
+    logger: StructuredLogger,
+) -> ReconciliationResult:
+    pending = set(snapshot.pending_symbols)
+    adjusted_symbols: list[str] = []
+    frozen_cash = bool(pending)
+
+    if not frozen_cash and book.cash != snapshot.cash:
+        logger.emit(
+            "portfolio.reconciliation.cash_adjusted",
+            severity=30,
+            payload={"from": str(book.cash), "to": str(snapshot.cash)},
+        )
+        book.cash = snapshot.cash
+
+    if frozen_cash:
+        logger.emit(
+            "portfolio.reconciliation.cash_frozen",
+            severity=30,
+            payload={"pending_symbols": sorted(pending)},
+        )
+
+    all_symbols = set(book.positions) | set(snapshot.positions)
+    for symbol in sorted(all_symbols):
+        if symbol in pending:
+            logger.emit(
+                "portfolio.reconciliation.symbol_skipped",
+                severity=30,
+                payload={"symbol": symbol, "reason": "in_transit"},
+            )
+            continue
+
+        target_qty = snapshot.positions.get(symbol, ZERO)
+        current_qty = book.positions.get(symbol, ZERO)
+        if current_qty == target_qty:
+            continue
+
+        adjusted_symbols.append(symbol)
+        logger.emit(
+            "portfolio.reconciliation.position_adjusted",
+            severity=30,
+            payload={"symbol": symbol, "from": str(current_qty), "to": str(target_qty)},
+        )
+        if target_qty == ZERO:
+            book.positions.pop(symbol, None)
+            book.average_costs.pop(symbol, None)
+        else:
+            book.positions[symbol] = target_qty
+            book.average_costs[symbol] = book.average_costs.get(symbol, ZERO)
+
+    return ReconciliationResult(
+        adjusted_cash=not frozen_cash,
+        adjusted_symbols=tuple(adjusted_symbols),
+        frozen_cash=frozen_cash,
+    )

--- a/src/trading_system/execution/step.py
+++ b/src/trading_system/execution/step.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass
+from datetime import datetime
 from decimal import Decimal
 from typing import Any
 
+from trading_system.app.state import AppRunnerState, LiveRuntimeState
 from trading_system.core.ops import (
     OrderCreatedEvent,
     OrderFilledEvent,
@@ -27,6 +29,8 @@ class TradingContext:
     broker: BrokerSimulator
     logger: StructuredLogger | None = None
     portfolio_risk: PortfolioRiskLimits | None = None
+    runtime_state: LiveRuntimeState | None = None
+    marks: dict[str, Decimal] | None = None
 
 
 @dataclass(slots=True)
@@ -40,13 +44,22 @@ class StepEvents:
 
 def execute_trading_step(bar: MarketBar, strategy: Strategy, context: TradingContext) -> StepEvents:
     events = StepEvents()
+    _update_marks(bar, context)
+
+    if (
+        context.runtime_state is not None
+        and context.runtime_state.state == AppRunnerState.EMERGENCY
+    ):
+        _liquidate_current_symbol_position(bar, context, events, reason="emergency_active")
+        return events
 
     # --- Portfolio-level drawdown guard --------------------------------
     if context.portfolio_risk is not None:
-        total_realized = sum(context.portfolio.realized_pnl.values(), start=Decimal("0"))
-        current_equity = context.portfolio.cash + total_realized
+        current_equity = context.portfolio.total_equity(_marks(context))
         context.portfolio_risk.update_peak(current_equity)
         if context.portfolio_risk.is_daily_limit_breached(current_equity):
+            if context.runtime_state is not None:
+                context.runtime_state.state = AppRunnerState.EMERGENCY
             _emit_event(
                 context.logger,
                 "risk.daily_limit_breached",
@@ -55,6 +68,13 @@ def execute_trading_step(bar: MarketBar, strategy: Strategy, context: TradingCon
                     "current_equity": str(current_equity),
                     "session_peak": str(context.portfolio_risk.session_peak_equity),
                 },
+                severity=50,
+            )
+            _liquidate_current_symbol_position(
+                bar,
+                context,
+                events,
+                reason="emergency_drawdown_liquidation",
             )
             return events
 
@@ -79,6 +99,7 @@ def execute_trading_step(bar: MarketBar, strategy: Strategy, context: TradingCon
             symbol=order.symbol,
             side=order.side.value,
             quantity=order.quantity,
+            timestamp=_bar_timestamp(bar.timestamp),
         )
     )
     _emit_event(context.logger, "order.created", events.order_created)
@@ -104,6 +125,7 @@ def execute_trading_step(bar: MarketBar, strategy: Strategy, context: TradingCon
                     fill_price=fill.fill_price,
                     fee=fill.fee,
                     status=fill.status.value,
+                    timestamp=_bar_timestamp(bar.timestamp),
                 )
             )
             _emit_event(context.logger, "order.filled", events.order_filled)
@@ -114,6 +136,7 @@ def execute_trading_step(bar: MarketBar, strategy: Strategy, context: TradingCon
                     side=order.side.value,
                     quantity=order.quantity,
                     reason="unfilled",
+                    timestamp=_bar_timestamp(bar.timestamp),
                 )
             )
             _emit_event(context.logger, "order.rejected", events.order_rejected)
@@ -124,6 +147,7 @@ def execute_trading_step(bar: MarketBar, strategy: Strategy, context: TradingCon
                 requested_quantity=signed_quantity,
                 current_position=current_position,
                 price=bar.close,
+                timestamp=_bar_timestamp(bar.timestamp),
             )
         )
         _emit_event(context.logger, "risk.rejected", events.risk_rejected)
@@ -153,7 +177,12 @@ def _check_sl_tp(bar: MarketBar, context: TradingContext) -> None:
         _emit_event(
             context.logger,
             f"risk.{reason}",
-            {"symbol": symbol, "avg_cost": str(avg_cost), "mark": str(bar.close)},
+            {
+                "symbol": symbol,
+                "avg_cost": str(avg_cost),
+                "mark": str(bar.close),
+                "timestamp": _bar_timestamp(bar.timestamp),
+            },
         )
         fill = context.broker.submit_order(close_order, bar)
         if fill.filled_quantity > 0:
@@ -172,6 +201,7 @@ def _check_sl_tp(bar: MarketBar, context: TradingContext) -> None:
                         fill_price=fill.fill_price,
                         fee=fill.fee,
                         status=fill.status.value,
+                        timestamp=_bar_timestamp(bar.timestamp),
                     )
                 ),
             )
@@ -181,7 +211,90 @@ def _emit_event(
     logger: StructuredLogger | None,
     event_name: str,
     payload: dict[str, Any],
+    *,
+    severity: int = 20,
 ) -> None:
     if logger is None:
         return
-    logger.emit(event_name, severity=20, payload=payload)
+    logger.emit(event_name, severity=severity, payload=payload)
+
+
+def _update_marks(bar: MarketBar, context: TradingContext) -> None:
+    if context.marks is not None:
+        context.marks[bar.symbol] = bar.close
+    if context.runtime_state is not None:
+        context.runtime_state.last_marks[bar.symbol] = bar.close
+
+
+def _marks(context: TradingContext) -> dict[str, Decimal]:
+    if context.marks is not None:
+        return context.marks
+    if context.runtime_state is not None:
+        return context.runtime_state.last_marks
+    return {}
+
+
+def _liquidate_current_symbol_position(
+    bar: MarketBar,
+    context: TradingContext,
+    events: StepEvents,
+    *,
+    reason: str,
+) -> None:
+    quantity = context.portfolio.positions.get(bar.symbol, Decimal("0"))
+    if quantity == Decimal("0"):
+        return
+
+    side = OrderSide.SELL if quantity > 0 else OrderSide.BUY
+    close_order = OrderRequest(symbol=bar.symbol, side=side, quantity=abs(quantity))
+    _emit_event(
+        context.logger,
+        "risk.emergency_liquidation",
+        {
+            "symbol": bar.symbol,
+            "quantity": str(abs(quantity)),
+            "reason": reason,
+            "timestamp": _bar_timestamp(bar.timestamp),
+        },
+        severity=50,
+    )
+    events.order_created = event_payload(
+        OrderCreatedEvent(
+            symbol=close_order.symbol,
+            side=close_order.side.value,
+            quantity=close_order.quantity,
+            timestamp=_bar_timestamp(bar.timestamp),
+        )
+    )
+    fill = context.broker.submit_order(close_order, bar)
+    if fill.filled_quantity <= 0:
+        events.order_rejected = event_payload(
+            OrderRejectedEvent(
+                symbol=close_order.symbol,
+                side=close_order.side.value,
+                quantity=close_order.quantity,
+                reason="emergency_unfilled",
+                timestamp=_bar_timestamp(bar.timestamp),
+            )
+        )
+        _emit_event(context.logger, "order.rejected", events.order_rejected, severity=40)
+        return
+
+    context.portfolio.apply_fill(fill.symbol, fill.signed_quantity, fill.fill_price, fee=fill.fee)
+    events.order_filled = event_payload(
+        OrderFilledEvent(
+            symbol=fill.symbol,
+            side=fill.side.value,
+            requested_quantity=fill.requested_quantity,
+            filled_quantity=fill.filled_quantity,
+            fill_price=fill.fill_price,
+            fee=fill.fee,
+            status=fill.status.value,
+            timestamp=_bar_timestamp(bar.timestamp),
+        )
+    )
+    _emit_event(context.logger, "order.filled", events.order_filled, severity=30)
+
+
+def _bar_timestamp(value: datetime) -> str:
+    return value.isoformat()

--- a/src/trading_system/portfolio/book.py
+++ b/src/trading_system/portfolio/book.py
@@ -67,6 +67,13 @@ class PortfolioBook:
             result[symbol] = (marks[symbol] - average_cost) * quantity
         return result
 
+    def total_equity(self, marks: dict[str, Decimal]) -> Decimal:
+        equity = self.cash
+        for symbol, quantity in self.positions.items():
+            mark = marks.get(symbol, self.average_costs.get(symbol, ZERO))
+            equity += quantity * mark
+        return equity
+
     def total_fees_paid(self) -> Decimal:
         return sum(self.fees_paid.values(), start=ZERO)
 

--- a/src/trading_system/strategy/factory.py
+++ b/src/trading_system/strategy/factory.py
@@ -15,6 +15,37 @@ def build_strategy(
     pattern_repository: PatternSetRepository,
     strategy_repository: StrategyProfileRepository,
 ) -> Strategy:
+    return build_strategies(
+        settings,
+        symbols=(settings.symbols[0],),
+        pattern_repository=pattern_repository,
+        strategy_repository=strategy_repository,
+    )[settings.symbols[0]]
+
+
+def build_strategies(
+    settings: AppSettings,
+    *,
+    symbols: tuple[str, ...],
+    pattern_repository: PatternSetRepository,
+    strategy_repository: StrategyProfileRepository,
+) -> dict[str, Strategy]:
+    return {
+        symbol: _build_strategy_instance(
+            settings,
+            pattern_repository=pattern_repository,
+            strategy_repository=strategy_repository,
+        )
+        for symbol in symbols
+    }
+
+
+def _build_strategy_instance(
+    settings: AppSettings,
+    *,
+    pattern_repository: PatternSetRepository,
+    strategy_repository: StrategyProfileRepository,
+) -> Strategy:
     if settings.strategy is None:
         return MomentumStrategy(trade_quantity=settings.backtest.trade_quantity)
 

--- a/task.md
+++ b/task.md
@@ -1,45 +1,65 @@
 # Phase 3 Task Breakdown
 
-## Epic A — Live Dashboard API + Frontend
-- [x] Add ring buffer + [recent_events()](file:///home/roqkf/trading_system/src/trading_system/core/ops.py#130-134) to [StructuredLogger](file:///home/roqkf/trading_system/src/trading_system/core/ops.py#106-158) in [core/ops.py](file:///home/roqkf/trading_system/src/trading_system/core/ops.py)
-- [x] Create [api/routes/dashboard.py](file:///home/roqkf/trading_system/src/trading_system/api/routes/dashboard.py) (status, positions, events, control)
-- [x] Add DTOs to [api/schemas.py](file:///home/roqkf/trading_system/src/trading_system/api/schemas.py)
-- [x] Register dashboard router + thread-safe `app.state.loop` wiring in [api/server.py](file:///home/roqkf/trading_system/src/trading_system/api/server.py)
-- [x] Create [frontend/dashboard.html](file:///home/roqkf/trading_system/frontend/dashboard.html)
-- [x] Add nav link in [frontend/index.html](file:///home/roqkf/trading_system/frontend/index.html)
-- [x] Write [tests/unit/test_dashboard_routes.py](file:///home/roqkf/trading_system/tests/unit/test_dashboard_routes.py)
+## Epic A - Runtime State And Dashboard
+- [x] Define an authoritative runtime state/control object shared by the live loop and API layer
+- [x] Refactor live startup so the dashboard reads real loop state, heartbeat, and uptime from that authority
+- [x] Expose `GET /api/v1/dashboard/status`
+- [x] Expose `GET /api/v1/dashboard/positions`
+- [x] Expose `GET /api/v1/dashboard/events`
+- [x] Expose `POST /api/v1/dashboard/control` for `pause`, `resume`, and `reset`, with kill switch mapped to pause-only behavior
+- [x] Make `reset` valid only for clearing `EMERGENCY` state and returning the runtime to `PAUSED`
+- [ ] Ensure control actions are safe against race conditions with the running loop
+- [x] Keep an in-memory recent-event buffer in `StructuredLogger`
+- [ ] Create or refine `frontend/dashboard.html` to show status, heartbeat, positions, unrealized PnL, and recent events
+- [ ] Add navigation entry points from the existing frontend
+- [x] Write route and runtime interaction tests for dashboard behavior
 
-## Epic B — Portfolio-Level Risk Guards
-- [x] Create [risk/portfolio_limits.py](file:///home/roqkf/trading_system/src/trading_system/risk/portfolio_limits.py) with [PortfolioRiskLimits](file:///home/roqkf/trading_system/src/trading_system/risk/portfolio_limits.py#15-83)
-- [x] Add `PortfolioRiskSettings` to config and app settings
-- [x] Update [configs/base.yaml](file:///home/roqkf/trading_system/configs/base.yaml) + `examples/` + [README.md](file:///home/roqkf/trading_system/README.md)
-- [x] Extend [TradingContext](file:///home/roqkf/trading_system/src/trading_system/execution/step.py#23-30) to carry `portfolio_risk`
-- [x] Extend [step.py](file:///home/roqkf/trading_system/src/trading_system/execution/step.py) to check drawdown limit and SL/TP
-- [x] Wire [PortfolioRiskLimits](file:///home/roqkf/trading_system/src/trading_system/risk/portfolio_limits.py#15-83) in [app/services.py](file:///home/roqkf/trading_system/src/trading_system/app/services.py)
-- [x] Write [tests/unit/test_portfolio_risk_limits.py](file:///home/roqkf/trading_system/tests/unit/test_portfolio_risk_limits.py)
-- [x] Write regression test: step skips when daily limit breached
+## Epic B - Portfolio-Level Risk Defense
+- [x] Finalize `PortfolioRiskLimits` around session peak equity using realized plus unrealized portfolio value
+- [ ] Add configuration for drawdown guard, SL, TP, and emergency liquidation behavior
+- [x] Extend `TradingContext` to carry the portfolio-level risk policy cleanly
+- [x] Block new entries when the drawdown limit is breached
+- [x] Emit high-severity structured events for drawdown breaches
+- [x] Trigger emergency liquidation of open positions when the drawdown limit is breached
+- [x] Move the runtime into a guarded risk state after emergency liquidation
+- [x] Keep SL and TP execution in the independent risk layer
+- [x] Add regression tests for breach, liquidation, guarded-state behavior, and SL/TP edge cases
 
-## Epic C — Multi-Symbol Orchestration
-- [ ] Update [app/loop.py](file:///home/roqkf/trading_system/src/trading_system/app/loop.py) [_run_tick](file:///home/roqkf/trading_system/src/trading_system/app/loop.py#104-122) for multi-symbol
-- [ ] Update per-symbol timestamp tracking (`dict[str, datetime]`)
-- [ ] Relax single-symbol guard in [app/services.py](file:///home/roqkf/trading_system/src/trading_system/app/services.py) for live mode
-- [ ] Update strategy factory for multi-symbol strategy dispatch
-- [ ] Write `tests/unit/test_live_loop_multi_symbol.py`
+## Epic C - Unified Multi-Symbol Orchestration
+- [x] Update live orchestration to process every configured symbol each cycle
+- [x] Maintain per-symbol last-processed timestamps
+- [x] Maintain per-symbol strategy instances with isolated state
+- [x] Build per-symbol strategy instances once at service startup and reuse them for the full run
+- [x] Keep a shared `PortfolioBook` and a single order path through `step.py`
+- [x] Implement FIFO allocation in configured symbol order for capital contention
+- [ ] Remove live-only single-symbol restrictions that conflict with Phase 3
+- [x] Extend backtest orchestration so multi-symbol behavior is testable through the same execution path
+- [x] Update strategy factory and related interfaces for per-symbol dispatch where needed
+- [x] Write deterministic multi-symbol tests covering cash contention and symbol isolation
 
-## Epic D — Trade-Level Analytics
-- [ ] Create `analytics/trades.py` (`CompletedTrade`, `extract_trades`)
-- [ ] Create `analytics/advanced_metrics.py` (profit_factor, sharpe, sortino, avg_win, avg_loss)
-- [ ] Extend backtest API response with `TradeStatsDTO`
-- [ ] Write `tests/unit/test_trades.py`
-- [ ] Write `tests/unit/test_advanced_metrics.py`
+## Epic D - Trade Analytics
+- [x] Create trade extraction from fill events
+- [x] Define the `Trade` or `CompletedTrade` model with entry, exit, quantity, pnl, and holding time
+- [x] Implement win rate
+- [x] Implement risk-reward ratio
+- [x] Implement trade-sequence max drawdown
+- [x] Implement average time in market
+- [x] Expose trade stats through `GET /api/v1/analytics/backtests/{run_id}/trades` with stable DTOs
+- [ ] Add tests for partial fills, scale-in, scale-out, flat-then-reopen, and empty trade sets
 
-## Epic E — Exchange Reconciliation (Phase 3.5)
-- [ ] Create `execution/reconciliation.py`
-- [ ] Add `get_account_balance()` to broker protocol + KIS adapter
-- [ ] Wire reconciliation interval into [app/loop.py](file:///home/roqkf/trading_system/src/trading_system/app/loop.py)
-- [ ] Write reconciliation tests
+## Epic E - Broker Reconciliation
+- [x] Add broker account snapshot support to the broker interface
+- [x] Implement a reconciliation service that compares broker state with `PortfolioBook`
+- [x] Add live-only reconciliation cadence in the live loop with a default of 300 seconds
+- [x] Emit structured adjustment events when drift is detected
+- [x] Reflect broker-proven external deposits and withdrawals in the local ledger
+- [x] Skip symbol adjustments for in-transit orders and freeze all cash adjustments for that reconciliation cycle
+- [x] Add reconciliation unit and integration tests
 
-## Cross-cutting
-- [ ] `uv run pytest` all green after each epic
-- [ ] `ruff check` clean after each epic
-- [ ] Update [README.md](file:///home/roqkf/trading_system/README.md) and [GEMINI.md](file:///home/roqkf/trading_system/GEMINI.md) after each epic merge
+## Cross-Cutting
+- [x] Keep `step.py` as the unified execution path for trading behavior changes
+- [ ] Update `configs/base.yaml`, `examples/`, `README.md`, and `GEMINI.md` for any config or operator workflow changes
+- [ ] Run targeted unit tests after each epic
+- [ ] Run broader regression tests after behavior-changing epics
+- [x] Run `ruff check src tests`
+- [ ] Run the full test suite before declaring Phase 3 complete

--- a/tests/integration/test_trade_analytics_api_integration.py
+++ b/tests/integration/test_trade_analytics_api_integration.py
@@ -1,0 +1,45 @@
+from fastapi.testclient import TestClient
+
+from trading_system.api.routes import backtest as backtest_routes
+from trading_system.api.server import create_app
+
+
+def _base_payload() -> dict:
+    return {
+        "mode": "backtest",
+        "symbols": ["BTCUSDT"],
+        "provider": "mock",
+        "broker": "paper",
+        "live_execution": "preflight",
+        "risk": {
+            "max_position": "1",
+            "max_notional": "100000",
+            "max_order_size": "0.25",
+        },
+        "backtest": {
+            "starting_cash": "10000",
+            "fee_bps": "0",
+            "trade_quantity": "0.1",
+        },
+    }
+
+
+def test_trade_analytics_route_returns_stats_for_backtest_run() -> None:
+    backtest_routes._RUN_REPOSITORY.clear()
+    client = TestClient(create_app())
+
+    create_response = client.post("/api/v1/backtests", json=_base_payload())
+    run_id = create_response.json()["run_id"]
+
+    analytics_response = client.get(f"/api/v1/analytics/backtests/{run_id}/trades")
+
+    assert analytics_response.status_code == 200
+    body = analytics_response.json()
+    assert set(body.keys()) == {"stats", "trades"}
+    assert set(body["stats"].keys()) == {
+        "trade_count",
+        "win_rate",
+        "risk_reward_ratio",
+        "max_drawdown",
+        "average_time_in_market_seconds",
+    }

--- a/tests/unit/test_api_server.py
+++ b/tests/unit/test_api_server.py
@@ -78,19 +78,14 @@ def test_settings_validation_errors_return_422() -> None:
     assert "--max-order-size cannot exceed --max-position." in body["message"]
 
 
-def test_invalid_symbols_return_standardized_400() -> None:
+def test_backtest_accepts_multiple_symbols() -> None:
     client = _build_client()
     payload = _base_payload(mode="backtest")
     payload["symbols"] = ["BTCUSDT", "ETHUSDT"]
 
     response = client.post("/api/v1/backtests", json=payload)
 
-    assert response.status_code == 400
-    body = response.json()
-    assert body == {
-        "error_code": "invalid_symbols",
-        "message": "Exactly one symbol is required for this API runtime.",
-    }
+    assert response.status_code == 201
 
 
 def test_live_execution_requires_opt_in_flag(monkeypatch) -> None:

--- a/tests/unit/test_dashboard_routes.py
+++ b/tests/unit/test_dashboard_routes.py
@@ -3,15 +3,13 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-import pytest
 from fastapi.testclient import TestClient
 
 from trading_system.api.server import create_app
 from trading_system.app.state import AppRunnerState
 from trading_system.core.ops import EventRecord
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -146,12 +144,12 @@ class TestDashboardControl:
         assert resp.status_code == 200
         assert loop.state == AppRunnerState.RUNNING
 
-    def test_stop_loop(self) -> None:
-        loop = _make_loop(AppRunnerState.RUNNING)
+    def test_reset_emergency_loop_to_paused(self) -> None:
+        loop = _make_loop(AppRunnerState.EMERGENCY)
         client = _make_client(loop)
-        resp = client.post("/api/v1/dashboard/control", json={"action": "stop"})
+        resp = client.post("/api/v1/dashboard/control", json={"action": "reset"})
         assert resp.status_code == 200
-        assert loop.state == AppRunnerState.STOPPED
+        assert loop.state == AppRunnerState.PAUSED
 
     def test_invalid_action_returns_422(self) -> None:
         loop = _make_loop()

--- a/tests/unit/test_live_loop_multi_symbol.py
+++ b/tests/unit/test_live_loop_multi_symbol.py
@@ -1,120 +1,101 @@
-"""Unit tests for multi-symbol live loop orchestration."""
-
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
-
-import pytest
 
 from trading_system.app.loop import LiveTradingLoop
-from trading_system.app.state import AppRunnerState
+from trading_system.app.services import AppServices
+from trading_system.app.settings import AppMode, LiveExecutionMode
+from trading_system.core.ops import StructuredLogFormat, StructuredLogger
 from trading_system.core.types import MarketBar
+from trading_system.data.provider import InMemoryMarketDataProvider
+from trading_system.execution.broker import (
+    BpsCommissionPolicy,
+    BpsSlippagePolicy,
+    FixedRatioFillPolicy,
+    PolicyBrokerSimulator,
+    ResilientBroker,
+)
+from trading_system.execution.step import TradingContext
+from trading_system.portfolio.book import PortfolioBook
+from trading_system.risk.limits import RiskLimits
+from trading_system.strategy.base import SignalSide, StrategySignal
 
 
-def _make_bar(symbol: str, close: str, ts: datetime | None = None) -> MarketBar:
-    ts = ts or datetime(2025, 1, 1, tzinfo=timezone.utc)
+@dataclass(slots=True)
+class BuyFirstBarStrategy:
+    name: str = "buy_first_bar"
+    _seen: bool = False
+
+    def evaluate(self, bar: MarketBar) -> StrategySignal:
+        if self._seen:
+            return StrategySignal(side=SignalSide.HOLD, quantity=Decimal("0"), reason="seen")
+        self._seen = True
+        return StrategySignal(side=SignalSide.BUY, quantity=Decimal("1"), reason=bar.symbol)
+
+
+def test_live_loop_processes_multiple_symbols_with_isolated_strategies() -> None:
+    bars_by_symbol = {
+        "BTCUSDT": [_bar("BTCUSDT", "100", 0)],
+        "ETHUSDT": [_bar("ETHUSDT", "50", 0)],
+    }
+    services = AppServices(
+        mode=AppMode.LIVE,
+        provider="mock",
+        broker="paper",
+        live_execution=LiveExecutionMode.PAPER,
+        strategy=BuyFirstBarStrategy(),
+        strategies={
+            "BTCUSDT": BuyFirstBarStrategy(),
+            "ETHUSDT": BuyFirstBarStrategy(),
+        },
+        data_provider=InMemoryMarketDataProvider(bars_by_symbol=bars_by_symbol),
+        risk_limits=RiskLimits(
+            max_position=Decimal("10"),
+            max_notional=Decimal("100000"),
+            max_order_size=Decimal("10"),
+        ),
+        broker_simulator=ResilientBroker(
+            delegate=PolicyBrokerSimulator(
+                fill_quantity_policy=FixedRatioFillPolicy(),
+                slippage_policy=BpsSlippagePolicy(),
+                commission_policy=BpsCommissionPolicy(),
+            )
+        ),
+        portfolio=PortfolioBook(cash=Decimal("1000")),
+        symbols=("BTCUSDT", "ETHUSDT"),
+        logger=StructuredLogger("test.multi", log_format=StructuredLogFormat.JSON),
+    )
+
+    loop = LiveTradingLoop(services=services)
+    loop._run_tick(
+        context=TradingContext(
+            portfolio=services.portfolio,
+            risk_limits=services.risk_limits,
+            broker=services.broker_simulator,
+            logger=services.logger,
+            portfolio_risk=services.portfolio_risk,
+            runtime_state=loop.runtime,
+            marks=loop.runtime.last_marks,
+        )
+    )
+
+    assert services.portfolio.positions == {
+        "BTCUSDT": Decimal("1"),
+        "ETHUSDT": Decimal("1"),
+    }
+    assert services.portfolio.cash == Decimal("850")
+    assert loop._last_processed_timestamps.keys() == {"BTCUSDT", "ETHUSDT"}
+
+
+def _bar(symbol: str, close: str, minute: int) -> MarketBar:
     return MarketBar(
         symbol=symbol,
-        timestamp=ts,
+        timestamp=datetime(2024, 1, 1, 0, minute, tzinfo=timezone.utc),
         open=Decimal(close),
         high=Decimal(close),
         low=Decimal(close),
         close=Decimal(close),
         volume=Decimal("1"),
     )
-
-
-def _make_services(symbols: tuple[str, ...]) -> MagicMock:
-    services = MagicMock()
-    services.symbols = symbols
-    services.portfolio_repository = None
-
-    # Each call to load_bars returns one bar for the requested symbol
-    def _load_bars(symbol: str):
-        return [_make_bar(symbol, "100")]
-
-    services.data_provider.load_bars.side_effect = _load_bars
-
-    from trading_system.strategy.base import SignalSide, StrategySignal
-
-    services.strategy.evaluate.return_value = StrategySignal(
-        side=SignalSide.HOLD, quantity=Decimal("0"), reason="hold"
-    )
-    services.logger = MagicMock()
-    return services
-
-
-class TestMultiSymbolTick:
-    def test_both_symbols_processed_each_tick(self) -> None:
-        """Each symbol should be loaded and evaluated every tick."""
-        symbols = ("BTCUSDT", "ETHUSDT")
-        services = _make_services(symbols)
-
-        loop = LiveTradingLoop(services=services, poll_interval=1)
-        loop.state = AppRunnerState.RUNNING
-
-        from trading_system.execution.step import TradingContext
-        from trading_system.portfolio.book import PortfolioBook
-        from trading_system.risk.limits import RiskLimits
-
-        context = TradingContext(
-            portfolio=PortfolioBook(cash=Decimal("10000")),
-            risk_limits=RiskLimits(
-                max_position=Decimal("10"),
-                max_notional=Decimal("100000"),
-                max_order_size=Decimal("1"),
-            ),
-            broker=MagicMock(),
-        )
-
-        loop._run_tick(context)  # noqa: SLF001
-
-        # data_provider.load_bars should be called once per symbol
-        calls = [call.args[0] for call in services.data_provider.load_bars.call_args_list]
-        assert "BTCUSDT" in calls
-        assert "ETHUSDT" in calls
-
-    def test_per_symbol_timestamp_tracked_independently(self) -> None:
-        """Timestamps are tracked per symbol and old bars are not re-processed."""
-        from datetime import timedelta
-
-        symbols = ("AAPL", "TSLA")
-        services = _make_services(symbols)
-
-        ts_old = datetime(2025, 1, 1, tzinfo=timezone.utc)
-        ts_new = ts_old + timedelta(hours=1)
-
-        # First tick: one bar per symbol at ts_old
-        services.data_provider.load_bars.side_effect = lambda s: [_make_bar(s, "100", ts_old)]
-
-        loop = LiveTradingLoop(services=services)
-        from trading_system.execution.step import TradingContext
-        from trading_system.portfolio.book import PortfolioBook
-        from trading_system.risk.limits import RiskLimits
-
-        context = TradingContext(
-            portfolio=PortfolioBook(cash=Decimal("10000")),
-            risk_limits=RiskLimits(
-                max_position=Decimal("10"),
-                max_notional=Decimal("100000"),
-                max_order_size=Decimal("1"),
-            ),
-            broker=MagicMock(),
-        )
-
-        loop._run_tick(context)  # noqa: SLF001
-        assert "AAPL" in loop._last_processed_timestamps  # noqa: SLF001
-        assert "TSLA" in loop._last_processed_timestamps  # noqa: SLF001
-
-        # Second tick: same old bar — should NOT be re-processed
-        evaluate_call_count_before = services.strategy.evaluate.call_count
-        loop._run_tick(context)  # noqa: SLF001
-        # No new evaluate calls since same timestamp
-        assert services.strategy.evaluate.call_count == evaluate_call_count_before
-
-        # Third tick: a new bar — should be processed
-        services.data_provider.load_bars.side_effect = lambda s: [_make_bar(s, "105", ts_new)]
-        loop._run_tick(context)  # noqa: SLF001
-        assert services.strategy.evaluate.call_count > evaluate_call_count_before

--- a/tests/unit/test_portfolio_risk_limits.py
+++ b/tests/unit/test_portfolio_risk_limits.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from decimal import Decimal
 from unittest.mock import MagicMock
 
-import pytest
-
+from trading_system.app.state import AppRunnerState, LiveRuntimeState
 from trading_system.core.types import MarketBar
 from trading_system.execution.step import TradingContext, execute_trading_step
 from trading_system.portfolio.book import PortfolioBook
@@ -120,10 +120,7 @@ class TestTakeProfit:
 
 
 def _make_bar(close: str = "100") -> MarketBar:
-    from trading_system.core.types import MarketBar as MB
-    from datetime import datetime, timezone
-
-    return MB(
+    return MarketBar(
         symbol="BTCUSDT",
         timestamp=datetime(2025, 1, 1, tzinfo=timezone.utc),
         open=Decimal(close),
@@ -134,7 +131,10 @@ def _make_bar(close: str = "100") -> MarketBar:
     )
 
 
-def _make_context(cash: str = "100", portfolio_risk: PortfolioRiskLimits | None = None) -> TradingContext:
+def _make_context(
+    cash: str = "100",
+    portfolio_risk: PortfolioRiskLimits | None = None,
+) -> TradingContext:
     portfolio = PortfolioBook(cash=Decimal(cash))
     risk = RiskLimits(
         max_position=Decimal("10"),
@@ -142,7 +142,14 @@ def _make_context(cash: str = "100", portfolio_risk: PortfolioRiskLimits | None 
         max_order_size=Decimal("1"),
     )
     broker = MagicMock()
-    return TradingContext(portfolio=portfolio, risk_limits=risk, broker=broker, portfolio_risk=portfolio_risk)
+    return TradingContext(
+        portfolio=portfolio,
+        risk_limits=risk,
+        broker=broker,
+        portfolio_risk=portfolio_risk,
+        runtime_state=LiveRuntimeState(state=AppRunnerState.RUNNING),
+        marks={},
+    )
 
 
 class TestDrawdownRegressionInStep:
@@ -185,3 +192,17 @@ class TestDrawdownRegressionInStep:
 
         # Strategy MUST be called when equity is healthy
         strategy.evaluate.assert_called_once_with(bar)
+
+    def test_drawdown_breach_moves_runtime_to_emergency(self) -> None:
+        pr = PortfolioRiskLimits(
+            max_daily_drawdown_pct=Decimal("0.05"),
+            session_peak_equity=Decimal("1000"),
+        )
+        context = _make_context(cash="100", portfolio_risk=pr)
+        strategy = MagicMock()
+        bar = _make_bar("100")
+
+        execute_trading_step(bar=bar, strategy=strategy, context=context)
+
+        assert context.runtime_state is not None
+        assert context.runtime_state.state == AppRunnerState.EMERGENCY

--- a/tests/unit/test_reconciliation.py
+++ b/tests/unit/test_reconciliation.py
@@ -1,0 +1,47 @@
+from decimal import Decimal
+
+from trading_system.core.ops import StructuredLogFormat, StructuredLogger
+from trading_system.execution.broker import AccountBalanceSnapshot
+from trading_system.execution.reconciliation import reconcile
+from trading_system.portfolio.book import PortfolioBook
+
+
+def test_reconciliation_adjusts_positions_and_cash_without_pending_orders() -> None:
+    book = PortfolioBook(
+        cash=Decimal("100"),
+        positions={"BTCUSDT": Decimal("1")},
+        average_costs={"BTCUSDT": Decimal("100")},
+    )
+    snapshot = AccountBalanceSnapshot(
+        cash=Decimal("120"),
+        positions={"BTCUSDT": Decimal("2")},
+    )
+    logger = StructuredLogger("test.recon", log_format=StructuredLogFormat.JSON)
+
+    result = reconcile(book=book, snapshot=snapshot, logger=logger)
+
+    assert result.adjusted_cash is True
+    assert result.adjusted_symbols == ("BTCUSDT",)
+    assert book.cash == Decimal("120")
+    assert book.positions["BTCUSDT"] == Decimal("2")
+
+
+def test_reconciliation_skips_symbol_and_freezes_cash_when_pending_order_exists() -> None:
+    book = PortfolioBook(
+        cash=Decimal("100"),
+        positions={"BTCUSDT": Decimal("1")},
+        average_costs={"BTCUSDT": Decimal("100")},
+    )
+    snapshot = AccountBalanceSnapshot(
+        cash=Decimal("120"),
+        positions={"BTCUSDT": Decimal("2")},
+        pending_symbols=("BTCUSDT",),
+    )
+    logger = StructuredLogger("test.recon.pending", log_format=StructuredLogFormat.JSON)
+
+    result = reconcile(book=book, snapshot=snapshot, logger=logger)
+
+    assert result.frozen_cash is True
+    assert result.adjusted_symbols == ()
+    assert book.cash == Decimal("100")
+    assert book.positions["BTCUSDT"] == Decimal("1")

--- a/tests/unit/test_trade_stats.py
+++ b/tests/unit/test_trade_stats.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from trading_system.analytics.trade_stats import summarize_trades
+from trading_system.analytics.trades import CompletedTrade, extract_trades
+
+
+def test_extract_trades_pairs_buys_and_sells_fifo() -> None:
+    events = [
+        {
+            "event": "order.filled",
+            "payload": {
+                "symbol": "BTCUSDT",
+                "side": "buy",
+                "filled_quantity": "1",
+                "fill_price": "100",
+                "timestamp": "2024-01-01T00:00:00+00:00",
+            },
+        },
+        {
+            "event": "order.filled",
+            "payload": {
+                "symbol": "BTCUSDT",
+                "side": "sell",
+                "filled_quantity": "1",
+                "fill_price": "110",
+                "timestamp": "2024-01-01T00:05:00+00:00",
+            },
+        },
+    ]
+
+    trades = extract_trades(events)
+
+    assert len(trades) == 1
+    assert trades[0].pnl == Decimal("10")
+    assert trades[0].holding_seconds == 300.0
+
+
+def test_summarize_trades_returns_required_metrics() -> None:
+    trades = [
+        CompletedTrade(
+            symbol="BTCUSDT",
+            entry_time=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            exit_time=datetime(2024, 1, 1, 0, 5, tzinfo=timezone.utc),
+            entry_price=Decimal("100"),
+            exit_price=Decimal("110"),
+            quantity=Decimal("1"),
+            pnl=Decimal("10"),
+        ),
+        CompletedTrade(
+            symbol="ETHUSDT",
+            entry_time=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            exit_time=datetime(2024, 1, 1, 0, 10, tzinfo=timezone.utc),
+            entry_price=Decimal("50"),
+            exit_price=Decimal("45"),
+            quantity=Decimal("1"),
+            pnl=Decimal("-5"),
+        ),
+    ]
+
+    stats = summarize_trades(trades)
+
+    assert stats.trade_count == 2
+    assert stats.win_rate == Decimal("0.5")
+    assert stats.risk_reward_ratio == Decimal("2")
+    assert stats.max_drawdown < Decimal("0")
+    assert stats.average_time_in_market_seconds == 450.0


### PR DESCRIPTION
## Summary

This PR implements the core Phase 3 runtime features defined in the updated PRD.

It extends the existing unified execution path instead of introducing a separate live-only workflow. The main changes are:

- add authoritative live runtime state with `RUNNING`, `PAUSED`, and `EMERGENCY` control semantics
- add dashboard control actions `pause`, `resume`, and `reset`
- enforce portfolio-level drawdown protection using marked portfolio equity
- trigger emergency liquidation and guarded runtime transitions on drawdown breach
- support multi-symbol processing with per-symbol strategy instances built once per run
- add fill-based trade extraction and trade analytics API
- add broker reconciliation with in-transit protection
- update task/plan/PRD documents to match the implemented Phase 3 direction

## Why

Phase 1 and 2 established the base execution path and persistence model, but the runtime still lacked:

- operator-safe runtime controls
- portfolio-level emergency protection
- deterministic multi-symbol orchestration through the same execution path
- trade-unit analytics instead of only equity-curve metrics
- reconciliation support to keep the local ledger aligned with broker state

This PR closes those gaps without forking strategy, risk, and execution logic into separate backtest/live implementations.

## What Changed

### 1. Runtime state and dashboard control

Added an explicit runtime state model and moved loop status tracking onto an authoritative runtime object shared by the live loop and dashboard layer.

Implemented dashboard control semantics:
- `pause`: `RUNNING -> PAUSED`
- `resume`: `PAUSED -> RUNNING`
- `reset`: `EMERGENCY -> PAUSED`

`reset` does not resume trading directly. It only clears the emergency state and returns control to the operator.

Dashboard positions now return unrealized PnL using last known marks.

### 2. Portfolio risk enforcement

Extended `TradingContext` so step execution can access:
- portfolio-level risk settings
- runtime state
- current symbol marks

Drawdown checks now use marked portfolio equity instead of cash plus realized PnL only.

On breach:
- new entries are blocked
- a high-severity drawdown event is emitted
- runtime moves to `EMERGENCY`
- the current symbol position is liquidated through the normal order path

SL/TP enforcement remains in the risk layer rather than strategy code.

### 3. Multi-symbol orchestration

Extended orchestration so configured symbols are processed through the same `step.py` path in both live and backtest modes.

Key behavior:
- per-symbol strategy instances are materialized once during service initialization
- per-symbol timestamps are tracked independently
- FIFO capital allocation is preserved by configured symbol order
- backtest bar merging remains deterministic by `(timestamp, symbol-order)`

This avoids state bleed between symbols for stateful strategies like momentum and pattern-based strategies.

### 4. Trade analytics

Added fill-based trade extraction and trade summary metrics.

Implemented:
- trade extraction from `order.filled` events
- win rate
- risk-reward ratio
- trade-sequence max drawdown
- average time in market

Added a dedicated API endpoint:
- `GET /api/v1/analytics/backtests/{run_id}/trades`

This keeps trade analytics separate from the existing equity-curve summary model.

### 5. Reconciliation

Extended the broker interface with optional account snapshot support and added a reconciliation service.

Implemented reconciliation behavior:
- live-only execution path
- default cadence: 300 seconds
- compare broker snapshot against `PortfolioBook`
- emit structured adjustment events
- skip symbol adjustments for in-transit symbols
- freeze all cash adjustments for that reconciliation cycle when pending orders exist

This is intentionally conservative to avoid overwriting legitimate pending activity.

### 6. Tests

Added and updated tests for:
- dashboard control behavior including `reset`
- drawdown-to-emergency transitions
- multi-symbol live loop behavior
- trade extraction and trade stats
- reconciliation adjustment and pending-order freeze behavior
- analytics API integration

## Files of Interest

### Runtime / execution
- `src/trading_system/app/state.py`
- `src/trading_system/app/loop.py`
- `src/trading_system/app/services.py`
- `src/trading_system/execution/step.py`
- `src/trading_system/execution/reconciliation.py`
- `src/trading_system/execution/broker.py`

### API / schemas
- `src/trading_system/api/routes/dashboard.py`
- `src/trading_system/api/routes/backtest.py`
- `src/trading_system/api/routes/analytics.py`
- `src/trading_system/api/schemas.py`
- `src/trading_system/api/server.py`

### Analytics
- `src/trading_system/analytics/trades.py`
- `src/trading_system/analytics/trade_stats.py`

### Tests
- `tests/unit/test_live_loop_multi_symbol.py`
- `tests/unit/test_trade_stats.py`
- `tests/unit/test_reconciliation.py`
- `tests/integration/test_trade_analytics_api_integration.py`

## Validation

Commands run:

```bash
python3 -m py_compile src/trading_system/app/state.py src/trading_system/portfolio/book.py src/trading_system/app/settings.py src/trading_system/strategy/factory.py src/trading_system/execution/broker.py src/trading_system/execution/kis_adapter.py src/trading_system/execution/step.py src/trading_system/core/ops.py src/trading_system/app/services.py src/trading_system/backtest/engine.py src/trading_system/app/loop.py src/trading_system/api/schemas.py src/trading_system/api/routes/backtest.py src/trading_system/api/routes/dashboard.py src/trading_system/api/server.py src/trading_system/analytics/trades.py src/trading_system/analytics/trade_stats.py src/trading_system/execution/reconciliation.py src/trading_system/api/routes/analytics.py
