### PR TITLE
feat: Add phase-planner skill

### DIFF
--- a/.claude/skills/phase-planner/SKILL.md
+++ b/.claude/skills/phase-planner/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: phase-planner
+description: create a new phase PRD, implementation plan, and task tracking document set when a new feature or improvement cycle is requested. use when the user wants to start a new phase in the prd/ directory with structured planning documents.
+---
+
+# Phase planner
+
+Turn a feature request or improvement goal into a complete phase document set under `prd/`.
+
+## Trigger
+
+Use this skill when:
+- The user requests a new feature, improvement cycle, or phase
+- The user says "new phase", "phase plan", "phase-planner", or similar
+- A significant body of work needs structured PRD + implementation plan + task tracking
+
+## Workflow
+
+### Step 1. Detect next phase number
+
+1. Scan `prd/` for existing `phase_*_prd.md` files.
+2. Determine the highest phase number (treat `3_5` as `3.5`, etc.).
+3. Set the next phase number as `N+1` (integer). If the user specifies a number, use that.
+
+### Step 2. Analyze context
+
+1. Read the most recent `phase_*_prd.md` to understand the current baseline.
+2. Read the most recent `phase_*_task.md` to check for open follow-ups or residual risks.
+3. Identify what carries forward vs. what is new scope.
+
+### Step 3. Create PRD (`phase_{N}_prd.md`)
+
+Write the PRD following the structure in `references/prd-template.md`. Key rules:
+- Start with cross-reference links to the previous phase and sibling documents.
+- State the document purpose clearly.
+- Define Goal, Current Baseline, Non-Goals, Hard Decisions.
+- Break scope into Epics with explicit include/exclude boundaries.
+- List Impacted Files grouped by concern.
+- Define Delivery Slices for incremental progress.
+- End with Success Metrics and Risks/Follow-up.
+- Write in Korean following the established convention of this repository.
+
+### Step 4. Create Implementation Plan (`phase_{N}_implementation_plan.md`)
+
+Write the plan following `references/implementation-plan-template.md`. Key rules:
+- Restate the goal with core implementation principles.
+- Lock Preconditions and Design Decisions before listing steps.
+- Define Contract Deltas for each affected subsystem.
+- Sequence steps with: purpose, files, concrete work items, exit criteria.
+- Include a Validation Matrix (unit tests, integration tests, manual verification).
+- Recommend PR slices aligned to implementation steps.
+- End with Risks and Fallbacks with concrete mitigations.
+
+### Step 5. Create Task Breakdown (`phase_{N}_task.md`)
+
+Write the task doc following `references/task-template.md`. Key rules:
+- Start with Usage section explaining how this file is used.
+- Add a Status Note marking all items as active backlog (not yet implemented).
+- Create one section per implementation step with `- [ ]` checkboxes.
+- Each section must have explicit Exit Criteria.
+- Include a Verification Checklist (unit tests, integration tests, broader regression, manual verification).
+- Include an empty Execution Log section ready to be filled during implementation.
+- All checkboxes start unchecked.
+
+### Step 6. Validate cross-references
+
+- Ensure all three documents reference each other correctly.
+- Ensure slice/step numbering is consistent across all three documents.
+- Ensure impacted files mentioned in PRD appear in the implementation plan steps.
+
+## Output
+
+After creating all three files, report:
+1. The phase number assigned
+2. Summary of epics/scope defined
+3. Number of implementation steps
+4. File paths created
+
+## Repository guidance
+
+- All phase documents are written in Korean following existing convention.
+- Keep the same structural patterns visible in existing phase documents.
+- Do not modify existing phase documents unless explicitly asked.
+- Preserve the separation between PRD (what/why), implementation plan (how/sequence), and task (tracking/evidence).
+
+See `references/` for document templates.

--- a/.claude/skills/phase-planner/references/implementation-plan-template.md
+++ b/.claude/skills/phase-planner/references/implementation-plan-template.md
@@ -1,0 +1,94 @@
+# Implementation Plan Template
+
+This template defines the structure for `phase_{N}_implementation_plan.md` documents.
+
+## Required sections
+
+```markdown
+# Phase {N} Implementation Plan
+
+## Goal
+
+{Phase의 구현 목표를 간결하게 기술. 핵심 구현 원칙을 번호 리스트로 나열}
+
+## Preconditions
+
+{구현 시작 전에 고정해야 할 범위와 제약사항}
+
+## Locked Design Decisions
+
+### 1. {설계 결정 제목}
+{결정 내용, 방향, 고려사항을 구체적으로 기술}
+
+### 2. {설계 결정 제목}
+...
+
+## Contract Deltas
+
+## A. {서브시스템/계약 변경 제목}
+
+대상:
+- `파일 경로`
+
+필수 변화:
+- {반드시 변경되어야 하는 계약/동작}
+
+비고:
+- {추가 고려사항}
+
+## B. {서브시스템/계약 변경 제목}
+...
+
+## Sequenced Implementation
+
+### Step 0. {제목}
+
+목적:
+- {이 단계의 목적}
+
+파일:
+- `파일 경로`
+
+구체 작업:
+- {수행할 구체적 작업 항목}
+
+종료 조건:
+- {이 단계가 완료되었다고 판단하는 기준}
+
+### Step 1. {제목}
+...
+
+## Validation Matrix
+
+### Required unit tests
+- {테스트 파일 또는 테스트 대상}
+
+### Required integration tests
+- {통합 테스트 범위}
+
+### Manual verification
+- {수동 확인이 필요한 항목}
+
+## Recommended PR Slices
+
+1. {PR 단위 설명}
+2. ...
+
+## Risks and Fallbacks
+
+- {리스크 설명}
+
+대응:
+- {각 Step별 대응 전략}
+```
+
+## Writing rules
+
+- Write in Korean.
+- Steps should be sequenced so that each step builds on the previous one.
+- Each step must have: purpose, files, concrete work items, exit criteria.
+- Contract Deltas should describe what changes in the system's interfaces/behaviors.
+- Preconditions should prevent scope creep during implementation.
+- Design Decisions should be "locked" — not open questions, but resolved choices.
+- PR Slices should align with implementation steps for reviewable increments.
+- Risks and Fallbacks should have concrete mitigations, not just risk statements.

--- a/.claude/skills/phase-planner/references/prd-template.md
+++ b/.claude/skills/phase-planner/references/prd-template.md
@@ -1,0 +1,103 @@
+# PRD Template
+
+This template defines the structure for `phase_{N}_prd.md` documents.
+
+## Required sections
+
+```markdown
+# Phase {N} PRD
+
+관련 문서:
+- 이전 phase 범위/결과: `prd/phase_{N-1}_prd.md`
+- 상세 구현 계획: `prd/phase_{N}_implementation_plan.md`
+- 실행 및 검증 기록: `prd/phase_{N-1}_task.md`
+- 실행 추적: `prd/phase_{N}_task.md`
+
+## 문서 목적
+
+{이 phase가 왜 필요한지, 이전 phase와의 관계, 이번 phase의 초점을 2-3문단으로 설명}
+
+## Goal
+
+{이번 phase의 핵심 목표를 명확히 기술. 반드시 달성해야 하는 원칙도 함께 나열}
+
+## Current Baseline
+
+{현재 시스템 상태를 bullet point로 정리. 이전 phase에서 완료된 것, 남은 것, 현재 제약사항}
+
+## Non-Goals
+
+{이번 phase에서 명시적으로 다루지 않는 항목. 범위 확장 방지를 위해 구체적으로 나열}
+
+## Hard Decisions
+
+### D-1. {결정 제목}
+{결정 내용과 근거를 설명}
+
+### D-2. {결정 제목}
+...
+
+## Product Requirements
+
+### PR-1. {요구사항 제목}
+{구체적인 요구사항 설명. 무엇이 어떻게 동작해야 하는지}
+
+### PR-2. {요구사항 제목}
+...
+
+## Scope By Epic
+
+### Epic A. {에픽 제목}
+
+목표:
+- {에픽의 핵심 목표}
+
+포함:
+- {구현 범위에 포함되는 항목}
+
+제외:
+- {명시적으로 제외되는 항목}
+
+### Epic B. {에픽 제목}
+...
+
+## Impacted Files
+
+### {그룹명 (예: Planning and task docs)}
+- `파일 경로`
+
+### {그룹명 (예: Configuration and runtime)}
+- `파일 경로`
+
+### {그룹명 (예: Validation and docs)}
+- `파일 경로`
+
+## Delivery Slices
+
+### Slice 0. {제목}
+- {이 slice에서 달성할 내용}
+
+### Slice 1. {제목}
+...
+
+## Success Metrics
+
+- {측정 가능한 성공 기준}
+- ...
+
+## Risks and Follow-up
+
+- {잠재적 리스크와 후속 작업}
+- ...
+```
+
+## Writing rules
+
+- Write in Korean.
+- Be specific: avoid vague statements like "improve performance" without measurable criteria.
+- Non-Goals should prevent scope creep: list things that might seem related but are explicitly out.
+- Hard Decisions should explain the rationale, not just the decision.
+- Product Requirements should be testable.
+- Epics should have explicit include/exclude boundaries.
+- Delivery Slices should be ordered for incremental value delivery.
+- Impacted Files should cover code, config, docs, and tests.

--- a/.claude/skills/phase-planner/references/task-template.md
+++ b/.claude/skills/phase-planner/references/task-template.md
@@ -1,0 +1,101 @@
+# Task Template
+
+This template defines the structure for `phase_{N}_task.md` documents.
+
+## Required sections
+
+```markdown
+# Phase {N} Task Breakdown
+
+## Usage
+
+- 이 파일은 Phase {N} 구현 진행 상황과 검증 증적을 기록한다.
+- 체크박스는 실제 구현 작업과 검증 기준을 뜻한다.
+- 각 slice가 끝날 때 `Execution Log`를 갱신한다.
+- PRD 수준 범위는 `phase_{N}_prd.md`를 기준으로 한다.
+- 상세 설계와 순서는 `phase_{N}_implementation_plan.md`를 기준으로 한다.
+
+## Status Note
+
+- 이 문서는 `prd/phase_{N}_prd.md`의 실행 추적 문서다.
+- 현재 체크박스는 active backlog를 slice 단위로 분해한 것이며, 아직 구현 완료를 의미하지 않는다.
+
+## Phase {N}-0. {Step 0 제목}
+
+- [ ] {구현/검증 항목}
+- [ ] {구현/검증 항목}
+...
+
+Exit criteria:
+- {이 단계의 종료 기준}
+
+## Phase {N}-1. {Step 1 제목}
+
+- [ ] {구현/검증 항목}
+- [ ] {구현/검증 항목}
+...
+
+Exit criteria:
+- {이 단계의 종료 기준}
+
+## Phase {N}-{M}. {마지막 Step 제목}
+...
+
+## Verification Checklist
+
+### Required unit tests
+
+- [ ] `pytest tests/unit/{관련 테스트}.py -q`
+...
+
+### Required integration tests
+
+- [ ] `pytest tests/integration/{관련 테스트}.py -q`
+...
+
+### Broader regression
+
+- [ ] 관련 API/config/live loop 회귀 테스트 실행
+- [ ] touched area 통과 후 broader regression 실행
+
+### Manual verification
+
+- [ ] {수동 확인 항목}
+...
+
+## Execution Log
+
+### Date
+- {구현 시작 시 날짜 기입}
+
+### Owner
+- {구현 주체}
+
+### Slice completed
+- {완료된 slice/step 기록}
+
+### Scope implemented
+- {구현된 범위 요약}
+
+### Files changed
+- {변경된 파일 목록}
+
+### Commands run
+- {실행한 검증 명령어와 결과}
+
+### Validation results
+- {검증 결과 요약}
+
+### Risks / follow-up
+- {잔여 리스크 및 후속 작업}
+```
+
+## Writing rules
+
+- Write in Korean.
+- All checkboxes start as `- [ ]` (unchecked). Never pre-check items in a new document.
+- Each phase section maps 1:1 to a step in the implementation plan.
+- Task items should be concrete and verifiable, not vague ("구현 확인" is bad, "multi-symbol preflight 요청 시 모든 심볼에 대해 readiness 결과 반환 확인" is good).
+- Exit criteria should match the implementation plan's exit criteria.
+- Execution Log starts empty — it gets filled during actual implementation.
+- Verification Checklist should include actual pytest command paths where possible.


### PR DESCRIPTION
## Summary
- `prd/` 디렉토리의 기존 phase 문서 패턴(phase_5~6)을 분석하여 새로운 phase 문서 세트를 자동 생성하는 `phase-planner` 스킬 추가
- PRD, implementation plan, task breakdown 3종 템플릿을 한국어 기존 컨벤션에 맞춰 작성
- `/phase-planner` 호출 시 최신 phase 번호를 감지하고 다음 phase 문서 세트를 일괄 생성

## Files added
- `.claude/skills/phase-planner/SKILL.md` — 스킬 정의 (6단계 워크플로우)
- `references/prd-template.md` — PRD 템플릿 (Goal, Baseline, Epics, Slices 등)
- `references/implementation-plan-template.md` — 구현 계획 템플릿 (Steps, Contract Deltas, Validation Matrix 등)
- `references/task-template.md` — 태스크 추적 템플릿 (체크박스, Execution Log 등)

## Test plan
- [x] `/phase-planner` 스킬이 스킬 목록에 표시되는지 확인
- [x] 새 phase 요청 시 3종 문서가 올바른 번호와 구조로 생성되는지 확인
- [x] 생성된 문서가 기존 phase_6 문서와 동일한 섹션 구조를 따르는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)