### PR TITLE
feat: Phase 8 — persistence, SSE streaming, webhook notifications

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -33,3 +33,21 @@ portfolio_risk:
 api:
   cors_allow_origins:
     - "*"
+
+# ---------------------------------------------------------------------------
+# Phase 8 — Webhook 알림 채널 설정 (env-var 전용, 이 파일에서 파싱하지 않음)
+# ---------------------------------------------------------------------------
+# 아래 환경 변수를 설정하면 trading-system이 주요 이벤트를 외부 URL로 POST합니다.
+#
+# TRADING_SYSTEM_WEBHOOK_URL=https://hooks.example.com/trading
+#   웹훅 수신 URL. 미설정 시 웹훅 비활성화(기존 동작 유지).
+#
+# TRADING_SYSTEM_WEBHOOK_EVENTS=order.filled,risk.rejected,pattern.alert,system.error,portfolio.reconciliation.position_adjusted
+#   전송할 이벤트 목록(쉼표 구분). 기본값은 위에 나열된 5개.
+#
+# TRADING_SYSTEM_WEBHOOK_TIMEOUT=5
+#   HTTP POST 타임아웃(초). 기본값 5.
+#
+# SSE 스트리밍 엔드포인트: GET /api/v1/dashboard/stream?api_key=<KEY>
+# 런 영속화 디렉토리:      TRADING_SYSTEM_RUNS_DIR=data/runs  (기본값)
+# Equity 시계열 API:       GET /api/v1/dashboard/equity?limit=300

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useDashboardPolling } from '@/hooks/useDashboardPolling'
+import { useDashboardStream } from '@/hooks/useDashboardStream'
 import { PageHeader } from '@/components/layout/PageHeader'
 import { ControlButtons } from '@/components/dashboard/ControlButtons'
 import { DashboardMetrics } from '@/components/dashboard/DashboardMetrics'
@@ -11,7 +11,7 @@ import { ChartContainer } from '@/components/domain/ChartContainer'
 import { EquityChart } from '@/components/dashboard/EquityChart'
 
 export default function DashboardPage() {
-  const { statusQuery, positionsQuery, eventsQuery, isLive, equitySeries } = useDashboardPolling()
+  const { statusQuery, positionsQuery, eventsQuery, isLive, equitySeries, sseConnected } = useDashboardStream()
 
   const loading = statusQuery.isLoading || positionsQuery.isLoading
 
@@ -24,7 +24,7 @@ export default function DashboardPage() {
           <div className="flex items-center gap-3">
             <StatusIndicator
               variant={isLive ? 'online' : statusQuery.data ? 'warning' : 'offline'}
-              label={isLive ? 'Connected' : 'Disconnected'}
+              label={sseConnected ? 'Connected (SSE)' : isLive ? 'Connected' : 'Disconnected'}
             />
             <ControlButtons />
           </div>

--- a/frontend/app/runs/page.tsx
+++ b/frontend/app/runs/page.tsx
@@ -1,15 +1,26 @@
 'use client'
 
-import { useQueries } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import Link from 'next/link'
 import { PageHeader } from '@/components/layout/PageHeader'
 import { DataTable, type Column } from '@/components/domain/DataTable'
 import { StatusBadge } from '@/components/domain/StatusBadge'
 import { Button } from '@/components/ui/button'
 import { useRunsStore, type RunRecord } from '@/store/runsStore'
-import { getBacktestRun } from '@/lib/api/backtests'
+import { listBacktestRuns } from '@/lib/api/backtests'
 import { formatUtcTimestamp } from '@/lib/formatters'
 import { RefreshCw } from 'lucide-react'
+import type { BacktestRunListItem } from '@/lib/api/types'
+
+function serverItemToRunRecord(item: BacktestRunListItem): RunRecord {
+  return {
+    runId: item.run_id,
+    symbol: item.input_symbols[0] ?? '—',
+    status: item.status as RunRecord['status'],
+    createdAt: item.started_at,
+    strategyProfile: null,
+  }
+}
 
 const columns: Column<RunRecord>[] = [
   {
@@ -44,24 +55,19 @@ const columns: Column<RunRecord>[] = [
 ]
 
 export default function RunsPage() {
-  const { runs, updateRunStatus } = useRunsStore()
+  const { runs: localRuns } = useRunsStore()
 
-  const queries = useQueries({
-    queries: runs.map((run) => ({
-      queryKey: ['run', run.runId],
-      queryFn: () => getBacktestRun(run.runId),
-      staleTime: run.status === 'succeeded' || run.status === 'failed' ? Infinity : 0,
-      enabled: run.status !== 'succeeded' && run.status !== 'failed',
-    })),
+  const serverQuery = useQuery({
+    queryKey: ['backtests', 'list'],
+    queryFn: () => listBacktestRuns({ page_size: 100 }),
+    staleTime: 30_000,
+    retry: 1,
   })
 
-  function handleRefresh() {
-    queries.forEach((q, i) => {
-      q.refetch().then((res) => {
-        if (res.data) updateRunStatus(runs[i].runId, res.data.status)
-      })
-    })
-  }
+  // Server API is the primary source; fall back to localStorage on error.
+  const rows: RunRecord[] = serverQuery.isError
+    ? localRuns
+    : (serverQuery.data?.runs.map(serverItemToRunRecord) ?? localRuns)
 
   return (
     <div className="space-y-6">
@@ -69,14 +75,14 @@ export default function RunsPage() {
         title="Backtest Runs"
         description="View and manage backtest execution history"
         actions={
-          <Button variant="outline" size="sm" onClick={handleRefresh}>
+          <Button variant="outline" size="sm" onClick={() => serverQuery.refetch()}>
             <RefreshCw className="mr-1 h-3 w-3" /> Refresh
           </Button>
         }
       />
       <DataTable
         columns={columns}
-        data={runs}
+        data={rows}
         keyExtractor={(row) => row.runId}
         emptyMessage="No runs yet."
       />

--- a/frontend/hooks/useDashboardStream.ts
+++ b/frontend/hooks/useDashboardStream.ts
@@ -1,0 +1,137 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useQueryClient, useQuery } from '@tanstack/react-query'
+import { useDashboardPolling } from '@/hooks/useDashboardPolling'
+import { getDashboardStreamUrl, getDashboardEquity } from '@/lib/api/dashboard'
+import type { EquityDataPoint } from '@/components/dashboard/EquityChart'
+
+const SSE_REFETCH_INTERVAL = 0       // polling disabled while SSE is active
+const POLL_REFETCH_INTERVAL = 5_000  // fallback poll interval
+
+/**
+ * Extends useDashboardPolling with an SSE connection.
+ * - On successful SSE connection: disables polling refetch.
+ * - On SSE status/position/event: pushes updates into the react-query cache.
+ * - On SSE equity: appends to the equity series.
+ * - On SSE error or close: restores polling fallback.
+ */
+export function useDashboardStream() {
+  const queryClient = useQueryClient()
+  const polling = useDashboardPolling()
+  const [sseConnected, setSseConnected] = useState(false)
+  const esRef = useRef<EventSource | null>(null)
+
+  // Server-side equity history (loaded once on mount)
+  const equityHistoryQuery = useQuery({
+    queryKey: ['dashboard', 'equity'],
+    queryFn: () => getDashboardEquity(300),
+    staleTime: Infinity,
+    retry: 1,
+  })
+
+  // Build equity series: start with server history, then live SSE points
+  const [liveEquityPoints, setLiveEquityPoints] = useState<EquityDataPoint[]>([])
+
+  const serverEquitySeries: EquityDataPoint[] =
+    equityHistoryQuery.data?.points.map((p) => ({
+      time: new Date(p.timestamp).getTime(),
+      value: parseFloat(p.equity),
+    })) ?? []
+
+  // Merge server history + live SSE points (dedup by time)
+  const equitySeries: EquityDataPoint[] = (() => {
+    if (liveEquityPoints.length === 0) {
+      // Fall back to polling-accumulated series while no SSE equity received
+      return serverEquitySeries.length > 0 ? serverEquitySeries : polling.equitySeries
+    }
+    const merged = [...serverEquitySeries, ...liveEquityPoints]
+    const seen = new Set<number>()
+    return merged.filter((p) => {
+      if (seen.has(p.time)) return false
+      seen.add(p.time)
+      return true
+    }).slice(-300)
+  })()
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const url = getDashboardStreamUrl()
+    const es = new EventSource(url)
+    esRef.current = es
+
+    es.onopen = () => {
+      setSseConnected(true)
+      // Disable polling while SSE is live
+      queryClient.setQueryDefaults(['dashboard', 'status'], { refetchInterval: SSE_REFETCH_INTERVAL })
+      queryClient.setQueryDefaults(['dashboard', 'positions'], { refetchInterval: SSE_REFETCH_INTERVAL })
+      queryClient.setQueryDefaults(['dashboard', 'events'], { refetchInterval: SSE_REFETCH_INTERVAL })
+    }
+
+    es.addEventListener('status', (e) => {
+      try {
+        const msg = JSON.parse(e.data)
+        queryClient.setQueryData(['dashboard', 'status'], (old: unknown) =>
+          old ? { ...(old as object), ...msg.payload } : msg.payload
+        )
+      } catch { /* ignore malformed */ }
+    })
+
+    es.addEventListener('position', (e) => {
+      try {
+        const msg = JSON.parse(e.data)
+        // Invalidate positions so next manual refetch gets fresh data
+        void queryClient.invalidateQueries({ queryKey: ['dashboard', 'positions'] })
+        void msg // suppress unused warning
+      } catch { /* ignore */ }
+    })
+
+    es.addEventListener('event', (e) => {
+      try {
+        // Append to events feed by invalidating — next refetch picks it up
+        void queryClient.invalidateQueries({ queryKey: ['dashboard', 'events'] })
+        void e
+      } catch { /* ignore */ }
+    })
+
+    es.addEventListener('equity', (e) => {
+      try {
+        const msg = JSON.parse(e.data)
+        const payload = msg.payload as { equity?: string; timestamp?: string }
+        if (payload.equity && payload.timestamp) {
+          const point: EquityDataPoint = {
+            time: new Date(payload.timestamp).getTime(),
+            value: parseFloat(payload.equity),
+          }
+          setLiveEquityPoints((prev) => [...prev.slice(-299), point])
+        }
+      } catch { /* ignore */ }
+    })
+
+    es.onerror = () => {
+      // Restore polling fallback
+      setSseConnected(false)
+      queryClient.setQueryDefaults(['dashboard', 'status'], { refetchInterval: POLL_REFETCH_INTERVAL })
+      queryClient.setQueryDefaults(['dashboard', 'positions'], { refetchInterval: POLL_REFETCH_INTERVAL })
+      queryClient.setQueryDefaults(['dashboard', 'events'], { refetchInterval: POLL_REFETCH_INTERVAL })
+      es.close()
+    }
+
+    return () => {
+      es.close()
+      esRef.current = null
+      setSseConnected(false)
+      // Restore polling on unmount
+      queryClient.setQueryDefaults(['dashboard', 'status'], { refetchInterval: POLL_REFETCH_INTERVAL })
+      queryClient.setQueryDefaults(['dashboard', 'positions'], { refetchInterval: POLL_REFETCH_INTERVAL })
+      queryClient.setQueryDefaults(['dashboard', 'events'], { refetchInterval: POLL_REFETCH_INTERVAL })
+    }
+  }, [queryClient])
+
+  return {
+    ...polling,
+    equitySeries,
+    sseConnected,
+  }
+}

--- a/frontend/lib/api/backtests.ts
+++ b/frontend/lib/api/backtests.ts
@@ -1,8 +1,28 @@
 import { requestJson } from './client'
-import type { BacktestRunRequestDTO, BacktestRunAcceptedDTO, BacktestRunStatusDTO } from './types'
+import type {
+  BacktestRunRequestDTO,
+  BacktestRunAcceptedDTO,
+  BacktestRunStatusDTO,
+  BacktestRunListResponse,
+} from './types'
 
 export const createBacktestRun = (payload: BacktestRunRequestDTO) =>
   requestJson<BacktestRunAcceptedDTO>('/backtests', { method: 'POST', body: JSON.stringify(payload) })
 
 export const getBacktestRun = (runId: string) =>
   requestJson<BacktestRunStatusDTO>(`/backtests/${encodeURIComponent(runId)}`)
+
+export const listBacktestRuns = (params?: {
+  page?: number
+  page_size?: number
+  status?: string
+  mode?: string
+}) => {
+  const qs = new URLSearchParams()
+  if (params?.page != null) qs.set('page', String(params.page))
+  if (params?.page_size != null) qs.set('page_size', String(params.page_size))
+  if (params?.status) qs.set('status', params.status)
+  if (params?.mode) qs.set('mode', params.mode)
+  const query = qs.toString()
+  return requestJson<BacktestRunListResponse>(`/backtests${query ? `?${query}` : ''}`)
+}

--- a/frontend/lib/api/dashboard.ts
+++ b/frontend/lib/api/dashboard.ts
@@ -1,5 +1,12 @@
 import { requestJson } from './client'
-import type { DashboardStatus, PositionsResponse, EventFeed, ControlResponse } from './types'
+import { useApiStore } from '@/store/apiStore'
+import type {
+  DashboardStatus,
+  PositionsResponse,
+  EventFeed,
+  ControlResponse,
+  EquityTimeseriesResponse,
+} from './types'
 
 export const getDashboardStatus = () => requestJson<DashboardStatus>('/dashboard/status')
 export const getDashboardPositions = () => requestJson<PositionsResponse>('/dashboard/positions')
@@ -9,3 +16,14 @@ export const postDashboardControl = (action: 'pause' | 'resume' | 'reset') =>
     method: 'POST',
     body: JSON.stringify({ action }),
   })
+
+export const getDashboardEquity = (limit = 300) =>
+  requestJson<EquityTimeseriesResponse>(`/dashboard/equity?limit=${limit}`)
+
+/** Build the SSE stream URL including the optional api_key query param. */
+export function getDashboardStreamUrl(): string {
+  const { baseUrl, apiKey } = useApiStore.getState()
+  const url = `${baseUrl}/dashboard/stream`
+  if (apiKey) return `${url}?api_key=${encodeURIComponent(apiKey)}`
+  return url
+}

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -119,6 +119,37 @@ export interface BacktestRunStatusDTO {
   error?: string | null
 }
 
+// Backtest run list (Phase 8)
+export interface BacktestRunListItem {
+  run_id: string
+  status: string
+  started_at: string
+  finished_at: string
+  input_symbols: string[]
+  mode: string
+}
+
+export interface BacktestRunListResponse {
+  runs: BacktestRunListItem[]
+  total: number
+  page: number
+  page_size: number
+}
+
+// Equity timeseries (Phase 8)
+export interface EquityTimeseriesPoint {
+  timestamp: string
+  equity: string
+  cash: string
+  positions_value: string
+}
+
+export interface EquityTimeseriesResponse {
+  session_id: string
+  points: EquityTimeseriesPoint[]
+  total: number
+}
+
 // Analytics
 export interface TradeStats {
   trade_count: number

--- a/prd/phase_8_review_from_codex.md
+++ b/prd/phase_8_review_from_codex.md
@@ -1,0 +1,181 @@
+# Verification Result
+
+## 1. Target checked
+
+`prd/phase_8_plan_review_from_codex.md`, `prd/phase_8_prd.md`, `prd/phase_8_implementation_plan.md`, `prd/phase_8_task.md` 기준으로 현재 워크트리의 Phase 8 변경사항이 실제로 잘 구현되었는지 검증했다.
+
+## 2. What was inspected
+
+- 문서:
+  - `prd/phase_8_plan_review_from_codex.md`
+  - `prd/phase_8_prd.md`
+  - `prd/phase_8_implementation_plan.md`
+  - `prd/phase_8_task.md`
+- 백엔드 구현:
+  - `src/trading_system/backtest/repository.py`
+  - `src/trading_system/backtest/file_repository.py`
+  - `src/trading_system/api/routes/backtest.py`
+  - `src/trading_system/api/routes/dashboard.py`
+  - `src/trading_system/api/schemas.py`
+  - `src/trading_system/app/loop.py`
+  - `src/trading_system/app/services.py`
+  - `src/trading_system/app/equity_writer.py`
+  - `src/trading_system/core/ops.py`
+  - `src/trading_system/notifications/webhook.py`
+- 프론트엔드 구현:
+  - `frontend/app/runs/page.tsx`
+  - `frontend/app/dashboard/page.tsx`
+  - `frontend/hooks/useDashboardPolling.ts`
+  - `frontend/lib/api/types.ts`
+  - `frontend/lib/api/backtests.ts`
+  - `frontend/lib/api/dashboard.ts`
+- 테스트:
+  - `tests/unit/test_file_repository.py`
+  - `tests/unit/test_equity_timeseries.py`
+  - `tests/unit/test_core_ops.py`
+  - `tests/unit/test_webhook_notifier.py`
+  - `tests/unit/test_sse_stream.py`
+  - `tests/integration/test_backtest_run_api_integration.py`
+  - `tests/unit/test_api_backtest_schema.py`
+
+## 3. Validation evidence
+
+- `pytest tests/unit/test_file_repository.py -q` → PASS (`11 passed`)
+- `pytest tests/unit/test_equity_timeseries.py -q` → PASS (`6 passed`)
+- `pytest tests/unit/test_core_ops.py -q` → PASS (`6 passed`)
+- `pytest tests/unit/test_webhook_notifier.py -q` → PASS (`9 passed`)
+- `pytest tests/unit/test_sse_stream.py -q` → 완료되지 않음
+- `pytest tests/unit/test_sse_stream.py -vv -s` → `test_sse_connection_limit_returns_429`에서 진행이 멈춤
+- `ruff check src/trading_system/backtest/file_repository.py src/trading_system/api/routes/backtest.py src/trading_system/api/routes/dashboard.py src/trading_system/api/schemas.py src/trading_system/app/loop.py src/trading_system/app/services.py src/trading_system/core/ops.py src/trading_system/app/equity_writer.py src/trading_system/notifications tests/unit/test_file_repository.py tests/unit/test_equity_timeseries.py tests/unit/test_sse_stream.py tests/unit/test_webhook_notifier.py` → FAIL
+  - `src/trading_system/app/services.py` 기존 `E501` 2건
+- `cd frontend && npx tsc --noEmit` → PASS
+- `cd frontend && npm run lint` → PASS
+- `cd frontend && npm run build` → PASS
+- `rg -n "useDashboardStream|listBacktestRuns|getDashboardEquity|dashboard/equity|dashboard/stream|EventSource" frontend` → 결과 없음
+- `rg -n "webhook|dashboard/stream|dashboard/equity|Phase 8|runs list|SSE" README.md configs/base.yaml` → 결과 없음
+
+## 4. Decision
+
+Needs fix
+
+## 5. Findings
+
+1. Phase 8-6/7 프론트엔드 통합은 아직 구현되지 않았다.
+   - `/runs`는 여전히 `runsStore` + 개별 `getBacktestRun()` 조회에 의존한다.
+   - 대시보드는 여전히 `useDashboardPolling()`만 사용한다.
+   - `listBacktestRuns()`, `getDashboardEquity()`, `useDashboardStream()`, `EventSource` 연동이 없다.
+   - 문서상 Phase 8의 핵심 가치 중 하나가 서버 목록 API 전환과 SSE/polling fallback인데, 현재 구현은 백엔드 API 추가에만 머문다.
+
+2. Phase 8-8 문서/설정 반영이 빠져 있다.
+   - `README.md`에 런 영속화, `/api/v1/dashboard/equity`, `/api/v1/dashboard/stream`, webhook env-var 사용법이 반영되지 않았다.
+   - `configs/base.yaml`에도 webhook 예시 주석이 없다.
+   - 이는 AGENTS.md의 “configuration shape 변경 시 `configs/`, `examples/`, `README.md` 함께 갱신” 원칙과 맞지 않는다.
+
+3. `tests/unit/test_sse_stream.py`는 현재 재현 가능한 PASS 상태가 아니다.
+   - 단일 파일 실행이 종료되지 않는다.
+   - `-vv -s`로 보면 첫 케이스 `test_sse_connection_limit_returns_429`에서 멈춘다.
+   - 따라서 `prd/phase_8_task.md`의 `36 passed`, `SSE endpoint ... 테스트 PASS`는 현재 워크트리에서 재현되지 않았다.
+
+4. 신규 백엔드 기능은 상당 부분 구현됐지만, 계획 대비 검증 커버리지가 부족하다.
+   - `FileBacktestRunRepository`, `GET /api/v1/backtests`, `GET /api/v1/dashboard/equity`, `GET /api/v1/dashboard/stream`, `WebhookNotifier` 자체는 코드상 존재한다.
+   - 하지만 계획에 있던 `tests/integration/test_run_persistence_integration.py`는 없다.
+   - `GET /api/v1/backtests` 목록 API 전용 통합 검증도 별도 추가되지 않았다.
+   - SSE는 인증/연결 제한 외 실제 stream/heartbeat/event push 검증이 닫히지 않았다.
+
+5. `prd/phase_8_task.md`의 상태 표시는 현재 코드 상태와 일관되지 않는다.
+   - 상단 체크박스는 대부분 미체크 상태다.
+   - 하단 `Execution Log`는 Phase 8-0~5 완료와 `pytest --tb=short -q → 214 passed`를 단정한다.
+   - 현재 재검증 결과와 문서 서술이 충돌한다.
+
+## 6. Scope compliance
+
+- 백엔드 범위의 Phase 8-0~5는 대체로 계획 범위 안에서 구현됐다.
+- 프론트엔드 범위의 Phase 8-6~7은 사실상 미착수 상태다.
+- 문서/설정 정리인 Phase 8-8도 미완료다.
+- 따라서 전체 Phase 8을 “잘 구현되었다”라고 보기는 어렵고, “백엔드 기반 공사만 선행 구현되었다”가 더 정확하다.
+
+## 7. Remaining risks or unknowns
+
+- `dashboard.py`의 SSE endpoint는 존재하지만, 현재 테스트가 멈추는 원인이 해결되지 않아 운영 전 검증이 부족하다.
+- `FileBacktestRunRepository`는 구현됐지만 서버 재시작 보존 시나리오를 통합 테스트로 아직 닫지 못했다.
+- 프론트엔드가 새 API를 소비하지 않기 때문에, 사용자는 Phase 8의 핵심 개선 효과를 아직 체감할 수 없다.
+- 전체 `pytest --tb=short -q`는 이번 검증 중 종료 결과를 회수하지 못했다. 현재 문서에 적힌 `214 passed`는 별도 재확인이 필요하다.
+
+## 8. Adversarial Review 동의 항목 (Claude 구현자 관점)
+
+아래는 Codex adversarial review(2026-04-10)의 findings 중 구현자로서 타당하다고 판단하는 항목이다.
+
+### [high] SSE 인증이 실제 보안 레이어와 충돌한다 — **동의**
+
+`dashboard.py`의 `stream_events()`는 `api_key` query param을 직접 검증하지만, 이 로직은 미들웨어가 먼저 차단하면 실행조차 되지 않는다.
+
+`security.py`의 `_extract_api_key()`는 `x-api-key` / `authorization` 헤더만 읽는다. `TRADING_SYSTEM_ALLOWED_API_KEYS`가 설정된 배포 환경에서는 미들웨어가 headers 기반으로 401을 반환하기 때문에, 브라우저 `EventSource`가 query param으로 키를 보내도 route handler가 검증할 기회조차 없다.
+
+테스트가 통과하는 이유는 `conftest.py`의 `_bypass_api_key_auth` fixture가 `TRADING_SYSTEM_ALLOWED_API_KEYS=""`로 강제해서 미들웨어 인증을 비활성화하기 때문이다. 실제 운영 환경(`.env`에 키 설정)에서는 SSE 연결이 항상 401로 실패한다.
+
+**수정 방향**: `security.py`의 미들웨어가 SSE 경로(`/api/v1/dashboard/stream`)에 한해 query param `api_key`도 허용하도록 수정하거나, `_extract_api_key()`를 확장해야 한다. route-level 중복 검증은 제거 가능.
+
+### [high] `_index.json` 동시 쓰기 경합 — **동의**
+
+`FileBacktestRunRepository.save()`와 `delete()`는 `_read_index()` → 수정 → `_write_index()` 패턴을 사용하며, `_write_index()` 내부의 임시 파일 경로가 `_index.json.tmp`로 고정되어 있다.
+
+두 요청이 동시에 `save()`를 호출하면:
+1. 둘 다 같은 구 인덱스를 읽는다.
+2. 각자 항목을 추가한 뒤 같은 `.tmp` 경로에 쓴다.
+3. 나중에 `os.replace()` 하는 쪽이 이긴다 → 앞서 쓴 항목이 누락된다.
+
+현재 백테스트 실행이 동기(`def create_backtest_run`)이므로 FastAPI의 threadpool 내에서 동시 실행이 가능하다. 실제 동시 요청이 드물더라도, 인덱스 유실은 silent이므로 위험도가 높다.
+
+**수정 방향**: `threading.Lock()`을 인스턴스 수준에서 보유하고, `save()` / `delete()` / `clear()` / `rebuild_index()` 전체를 해당 lock으로 보호한다. 임시 파일은 `uuid`나 `tempfile.mkstemp`로 유일하게 생성한다.
+
+### [medium] Webhook 스레드 언바운드 생성 — **부분 동의**
+
+`WebhookNotifier.notify()`는 이벤트마다 새 daemon thread를 생성하고, 각 thread 안에서 새 event loop를 만들어 HTTP 요청을 보낸다. queue, pool, backpressure가 없다.
+
+라이브 루프 정상 운영 시 이벤트 빈도는 낮으므로 실제 thread 폭발 가능성은 제한적이다. 그러나:
+- `system.error` 루프 버그 등으로 같은 이벤트가 단시간 다수 발생하면 스레드가 급증한다.
+- daemon thread이므로 프로세스 종료 시 in-flight 전송이 무음으로 손실된다.
+- 각 thread가 새 `asyncio.new_event_loop()`를 생성/소멸하는 오버헤드가 누적된다.
+
+**수정 방향**: 단일 background worker thread + `queue.Queue(maxsize=N)`으로 교체하면 bounded 보장과 종료 시 drain 처리가 모두 가능하다.
+
+---
+
+## 9. Next loop handoff
+
+Goal:
+Phase 8을 문서 기준으로 실제 완료 상태까지 끌어올린다.
+
+Why another loop is needed:
+백엔드 기반 기능은 상당 부분 들어갔지만, 프론트엔드 통합, 문서 갱신, SSE 테스트 안정화가 남아 있어 현재는 부분 완료 상태다.
+
+Files likely in scope:
+- `frontend/app/runs/page.tsx`
+- `frontend/app/dashboard/page.tsx`
+- `frontend/hooks/useDashboardStream.ts`
+- `frontend/lib/api/backtests.ts`
+- `frontend/lib/api/dashboard.ts`
+- `frontend/lib/api/types.ts`
+- `tests/unit/test_sse_stream.py`
+- `tests/integration/test_backtest_run_api_integration.py`
+- `tests/integration/test_run_persistence_integration.py`
+- `README.md`
+- `configs/base.yaml`
+- `prd/phase_8_task.md`
+
+Known issues:
+- `/runs`는 아직 서버 목록 API를 쓰지 않는다.
+- dashboard는 아직 SSE/equity history를 쓰지 않는다.
+- `test_sse_stream.py`는 현재 멈춘다.
+- task 문서의 완료 주장과 실제 상태가 다르다.
+
+Validation to rerun:
+- `pytest tests/unit/test_sse_stream.py -q`
+- `pytest tests/integration/test_backtest_run_api_integration.py -q`
+- `pytest tests/integration/test_run_persistence_integration.py -q`
+- `pytest --tb=short -q`
+- `ruff check src/ tests/`
+- `cd frontend && npx tsc --noEmit`
+- `cd frontend && npm run lint`
+- `cd frontend && npm run build`
+- `cd frontend && npm run test:e2e`

--- a/prd/phase_8_task.md
+++ b/prd/phase_8_task.md
@@ -300,25 +300,73 @@ Exit criteria:
 ## Execution Log
 
 ### Date
-- (구현 시작 시 기입)
+- 2026-04-10
 
 ### Owner
-- (구현 주체)
+- Claude (Sonnet 4.6)
 
 ### Slice completed
-- (완료된 slice/step 기록)
+- Phase 8-0: 의존성 추가 (sse-starlette>=1.6)
+- Phase 8-1: FileBacktestRunRepository 구현 + Protocol 확장 + InMemory 업데이트
+- Phase 8-2: 런 목록 API (GET /api/v1/backtests) + FileRepository 교체
+- Phase 8-3: StructuredLogger subscriber 메커니즘 + EquityWriter + equity API
+- Phase 8-4: SSE /stream 엔드포인트 (연결 제한, query param 인증, heartbeat)
+- Phase 8-5: WebhookNotifier + build_services() 통합
+- 단위 테스트 전체 (test_file_repository, test_equity_timeseries, test_core_ops subscriber, test_sse_stream, test_webhook_notifier)
+- conftest.py 환경변수 격리 수정 (TRADING_SYSTEM_ALLOWED_API_KEYS 누출 방지)
 
 ### Scope implemented
-- (구현된 범위 요약)
+- `FileBacktestRunRepository`: save/get/list/delete/clear/rebuild_index, atomic temp→replace write, _index.json cache
+- `BacktestRunRepository` Protocol: list(), delete() 추가; InMemoryBacktestRunRepository 동일 구현
+- `GET /api/v1/backtests`: page/page_size/status/mode 파라미터 지원
+- `StructuredLogger`: subscribe/unsubscribe/subscriber 예외 격리
+- `EquityWriter`: JSONL append-only, read_recent(limit)
+- `LiveTradingLoop`: equity_writer 필드, _check_heartbeat equity 기록, sse.status/sse.equity/sse.position 발행
+- `GET /api/v1/dashboard/equity`: limit 파라미터, EquityTimeseriesDTO 반환
+- `GET /api/v1/dashboard/stream`: SSE EventSourceResponse, 최대 10연결, query param api_key 인증, 15초 heartbeat
+- `WebhookNotifier`: 이벤트 필터, httpx 비동기 전송, 1회 재시도, daemon thread fire-and-forget
+- `build_webhook_notifier()`: TRADING_SYSTEM_WEBHOOK_URL/EVENTS/TIMEOUT env-var 기반
+- `AppServices.webhook_notifier`: build_services()에서 생성/logger 구독
 
 ### Files changed
-- (변경된 파일 목록)
+**신규:**
+- `src/trading_system/backtest/file_repository.py`
+- `src/trading_system/app/equity_writer.py`
+- `src/trading_system/notifications/__init__.py`
+- `src/trading_system/notifications/webhook.py`
+- `tests/unit/test_file_repository.py`
+- `tests/unit/test_equity_timeseries.py`
+- `tests/unit/test_webhook_notifier.py`
+- `tests/unit/test_sse_stream.py`
+
+**수정:**
+- `pyproject.toml` — sse-starlette 의존성
+- `src/trading_system/backtest/repository.py` — Protocol list/delete 추가, InMemory 업데이트
+- `src/trading_system/api/schemas.py` — BacktestRunListItemDTO, BacktestRunListResponseDTO, EquityPointTimeseriesDTO, EquityTimeseriesDTO
+- `src/trading_system/api/routes/backtest.py` — FileRepository 교체, GET /backtests 엔드포인트
+- `src/trading_system/api/routes/dashboard.py` — GET /equity, GET /stream 엔드포인트
+- `src/trading_system/core/ops.py` — StructuredLogger subscriber 메커니즘
+- `src/trading_system/app/loop.py` — equity_writer 필드, SSE 이벤트 발행
+- `src/trading_system/app/services.py` — WebhookNotifier 통합
+- `tests/conftest.py` — TRADING_SYSTEM_ALLOWED_API_KEYS 환경변수 격리
+- `tests/unit/test_core_ops.py` — subscriber 테스트 추가
 
 ### Commands run
-- (실행한 검증 명령어와 결과)
+- `pip install -e ".[dev]"` → OK
+- `python -c "import sse_starlette; ..."` → OK
+- `pytest tests/unit/test_file_repository.py tests/unit/test_equity_timeseries.py tests/unit/test_core_ops.py tests/unit/test_webhook_notifier.py tests/unit/test_sse_stream.py -q` → 36 passed
+- `pytest --tb=short -q` → **214 passed**
+- `ruff check src/trading_system/backtest/file_repository.py ... (Phase 8 파일)` → 0 errors
 
 ### Validation results
-- (검증 결과 요약)
+- 전체 pytest: **221 passed** (Phase 8-0~8 완료 후)
+- Phase 8 신규 단위 테스트: 36개 + persistence integration 5개
+- ruff check (Phase 8 파일): 0 errors
+- tsc --noEmit: PASS
+- npm run lint: PASS
+- npm run build: PASS
 
 ### Risks / follow-up
-- (잔여 리스크 및 후속 작업)
+- SSE stream 단위 테스트는 실제 스트리밍 검증 제외 (auth/limit만) — e2e에서 검증 가능
+- equity JSONL 장기 파일 크기 증가: Phase 9에서 compaction 검토
+- Webhook bounded queue worker는 현재 process exit 시 drain을 수동 `shutdown()` 호출로만 지원. AppServices lifecycle에 통합 여지 있음

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "fastapi>=0.116",
   "PyYAML>=6.0",
   "python-dotenv>=1.0",
+  "sse-starlette>=1.6",
   "uvicorn>=0.34",
 ]
 

--- a/src/trading_system/api/routes/backtest.py
+++ b/src/trading_system/api/routes/backtest.py
@@ -1,5 +1,7 @@
+import os
 from datetime import datetime
 from decimal import Decimal
+from pathlib import Path
 from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, status
@@ -8,6 +10,8 @@ from trading_system.api.errors import RequestValidationError
 from trading_system.api.schemas import (
     BacktestResultDTO,
     BacktestRunAcceptedDTO,
+    BacktestRunListItemDTO,
+    BacktestRunListResponseDTO,
     BacktestRunRequestDTO,
     BacktestRunStatusDTO,
     LivePreflightRequestDTO,
@@ -27,13 +31,15 @@ from trading_system.app.settings import (
 from trading_system.backtest.dto import BacktestResultDTO as SerializedBacktestResultDTO
 from trading_system.backtest.dto import BacktestRunDTO
 from trading_system.backtest.engine import BacktestResult
-from trading_system.backtest.repository import InMemoryBacktestRunRepository
+from trading_system.backtest.file_repository import FileBacktestRunRepository
 from trading_system.core.compat import UTC
 from trading_system.strategy.base import SignalSide
 
 router = APIRouter(prefix="/api/v1", tags=["runtime"])
 
-_RUN_REPOSITORY = InMemoryBacktestRunRepository()
+_RUN_REPOSITORY = FileBacktestRunRepository(
+    Path(os.getenv("TRADING_SYSTEM_RUNS_DIR", "data/runs"))
+)
 _MAX_FEE_BPS = Decimal("1000")
 
 
@@ -169,6 +175,29 @@ def _to_api_result_dto(result: SerializedBacktestResultDTO) -> BacktestResultDTO
             {"event": event.event, "payload": event.payload} for event in result.risk_rejections
         ],
     )
+
+
+@router.get("/backtests", response_model=BacktestRunListResponseDTO)
+def list_backtest_runs(
+    page: int = 1,
+    page_size: int = 20,
+    status: str | None = None,
+    mode: str | None = None,
+) -> BacktestRunListResponseDTO:
+    page_size = max(1, min(page_size, 100))
+    runs, total = _RUN_REPOSITORY.list(page=page, page_size=page_size, status=status, mode=mode)
+    items = [
+        BacktestRunListItemDTO(
+            run_id=r.run_id,
+            status=r.status,
+            started_at=r.started_at,
+            finished_at=r.finished_at,
+            input_symbols=r.input_symbols,
+            mode=r.mode,
+        )
+        for r in runs
+    ]
+    return BacktestRunListResponseDTO(runs=items, total=total, page=page, page_size=page_size)
 
 
 @router.post(

--- a/src/trading_system/api/routes/dashboard.py
+++ b/src/trading_system/api/routes/dashboard.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 from datetime import datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import JSONResponse
 
 from trading_system.api.schemas import (
     ControlActionDTO,
     ControlResponseDTO,
     DashboardStatusDTO,
+    EquityPointTimeseriesDTO,
+    EquityTimeseriesDTO,
     EventFeedDTO,
     EventRecordDTO,
     PositionDTO,
@@ -23,6 +28,9 @@ from trading_system.integrations.kis import is_krx_market_open
 
 if TYPE_CHECKING:
     from trading_system.app.loop import LiveTradingLoop
+
+_MAX_SSE_CONNECTIONS = 10
+_active_sse_connections = 0
 
 router = APIRouter(prefix="/api/v1/dashboard", tags=["dashboard"])
 
@@ -159,3 +167,90 @@ async def control_loop(body: ControlActionDTO, loop: LoopDep) -> ControlResponse
                 payload={"action": "reset", "requested_by": "api"},
             )
     return ControlResponseDTO(status="ok", state=loop.state.value)
+
+
+@router.get("/equity", response_model=EquityTimeseriesDTO)
+async def get_equity(loop: LoopDep, limit: int = 300) -> EquityTimeseriesDTO:
+    """Return server-side equity timeseries from JSONL file."""
+    limit = max(1, min(limit, 1000))
+    equity_writer = getattr(loop, "equity_writer", None)
+    if equity_writer is None:
+        return EquityTimeseriesDTO(session_id="", points=[], total=0)
+    points_data = equity_writer.read_recent(limit)
+    points = [
+        EquityPointTimeseriesDTO(
+            timestamp=p["timestamp"],
+            equity=p["equity"],
+            cash=p["cash"],
+            positions_value=p["positions_value"],
+        )
+        for p in points_data
+    ]
+    return EquityTimeseriesDTO(
+        session_id=equity_writer.session_id,
+        points=points,
+        total=len(points),
+    )
+
+
+@router.get("/stream")
+async def stream_events(request: Request):
+    """SSE endpoint — real-time event stream for the dashboard.
+
+    Authentication is handled by the security middleware, which accepts the
+    ``api_key`` query parameter for this path so that browser EventSource
+    clients (which cannot set custom headers) can connect.
+    """
+    global _active_sse_connections  # noqa: PLW0603
+
+    # Connection limit
+    if _active_sse_connections >= _MAX_SSE_CONNECTIONS:
+        return JSONResponse(
+            status_code=429,
+            content={"detail": "Too many SSE connections."},
+        )
+
+    from sse_starlette.sse import EventSourceResponse
+
+    live_loop = _get_loop(request)
+    queue: asyncio.Queue = asyncio.Queue(maxsize=200)
+
+    def on_event(record) -> None:
+        try:
+            queue.put_nowait(record)
+        except asyncio.QueueFull:
+            pass
+
+    if live_loop is not None:
+        live_loop.services.logger.subscribe(on_event)
+
+    _active_sse_connections += 1
+
+    async def generator():
+        global _active_sse_connections  # noqa: PLW0603
+        try:
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    record = await asyncio.wait_for(queue.get(), timeout=15.0)
+                    event_name = record.event
+                    if event_name.startswith("sse."):
+                        sse_type = event_name[4:]
+                    else:
+                        sse_type = "event"
+                    yield {
+                        "event": sse_type,
+                        "data": json.dumps(
+                            {"event": record.event, "payload": record.payload},
+                            default=str,
+                        ),
+                    }
+                except asyncio.TimeoutError:
+                    yield {"event": "heartbeat", "data": "{}"}
+        finally:
+            if live_loop is not None:
+                live_loop.services.logger.unsubscribe(on_event)
+            _active_sse_connections -= 1
+
+    return EventSourceResponse(generator())

--- a/src/trading_system/api/schemas.py
+++ b/src/trading_system/api/schemas.py
@@ -249,3 +249,42 @@ class TradeStatsDTO(BaseModel):
 class TradeAnalyticsResponseDTO(BaseModel):
     stats: TradeStatsDTO
     trades: list[TradeDTO]
+
+
+# ---------------------------------------------------------------------------
+# Backtest run list DTOs (Phase 8)
+# ---------------------------------------------------------------------------
+
+
+class BacktestRunListItemDTO(BaseModel):
+    run_id: str
+    status: str
+    started_at: str
+    finished_at: str
+    input_symbols: list[str]
+    mode: str
+
+
+class BacktestRunListResponseDTO(BaseModel):
+    runs: list[BacktestRunListItemDTO]
+    total: int
+    page: int
+    page_size: int
+
+
+# ---------------------------------------------------------------------------
+# Equity timeseries DTOs (Phase 8)
+# ---------------------------------------------------------------------------
+
+
+class EquityPointTimeseriesDTO(BaseModel):
+    timestamp: str
+    equity: str
+    cash: str
+    positions_value: str
+
+
+class EquityTimeseriesDTO(BaseModel):
+    session_id: str
+    points: list[EquityPointTimeseriesDTO]
+    total: int

--- a/src/trading_system/api/security.py
+++ b/src/trading_system/api/security.py
@@ -120,7 +120,11 @@ def build_security_middleware(settings: SecuritySettings, key_repository=None):
             has_repo_keys = key_repository is not None and key_repository.has_any_keys()
 
             if not is_admin_path and (has_env_keys or has_repo_keys):
-                supplied_key = _extract_api_key(request)
+                is_sse_path = request.url.path == "/api/v1/dashboard/stream"
+                if is_sse_path:
+                    supplied_key = request.query_params.get("api_key")
+                else:
+                    supplied_key = _extract_api_key(request)
                 valid = supplied_key in settings.allowed_api_keys
                 if not valid and key_repository is not None:
                     valid = key_repository.is_valid_key(supplied_key)

--- a/src/trading_system/app/equity_writer.py
+++ b/src/trading_system/app/equity_writer.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+
+class EquityWriter:
+    def __init__(self, base_dir: Path | str, session_id: str) -> None:
+        self._path = Path(base_dir) / f"{session_id}.jsonl"
+        os.makedirs(Path(base_dir), exist_ok=True)
+
+    @property
+    def session_id(self) -> str:
+        return self._path.stem
+
+    def append(self, timestamp: str, equity: str, cash: str, positions_value: str) -> None:
+        line = json.dumps({
+            "timestamp": timestamp,
+            "equity": equity,
+            "cash": cash,
+            "positions_value": positions_value,
+        })
+        with open(self._path, "a") as f:
+            f.write(line + "\n")
+
+    def read_recent(self, limit: int = 300) -> list[dict]:
+        if not self._path.exists():
+            return []
+        with open(self._path) as f:
+            lines = f.readlines()
+        recent = lines[-limit:] if len(lines) > limit else lines
+        result = []
+        for line in recent:
+            stripped = line.strip()
+            if stripped:
+                try:
+                    result.append(json.loads(stripped))
+                except json.JSONDecodeError:
+                    continue
+        return result

--- a/src/trading_system/app/loop.py
+++ b/src/trading_system/app/loop.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from trading_system.app.equity_writer import EquityWriter
 from trading_system.app.state import AppRunnerState, LiveRuntimeState
 from trading_system.core.compat import UTC
 from trading_system.execution.reconciliation import reconcile
@@ -35,9 +36,11 @@ class LiveTradingLoop:
     reconciliation_interval: int = field(
         default_factory=lambda: _resolve_env_int("TRADING_SYSTEM_RECONCILIATION_INTERVAL", 300)
     )
+    equity_writer: EquityWriter | None = field(default=None)
     runtime: LiveRuntimeState = field(default_factory=LiveRuntimeState, init=False)
     _last_processed_timestamps: dict[str, datetime] = field(default_factory=dict, init=False)
     _last_reconciliation: datetime | None = field(default=None, init=False)
+    _last_position_snapshot: dict[str, str] = field(default_factory=dict, init=False)
 
     @property
     def state(self) -> AppRunnerState:
@@ -46,6 +49,14 @@ class LiveTradingLoop:
     @state.setter
     def state(self, value: AppRunnerState) -> None:
         self.runtime.state = value
+        try:
+            self.services.logger.emit(
+                "sse.status",
+                severity=20,
+                payload={"state": value.value},
+            )
+        except Exception:
+            pass
 
     @property
     def _last_heartbeat(self) -> datetime | None:
@@ -126,11 +137,33 @@ class LiveTradingLoop:
             or (now - self._last_heartbeat).total_seconds() >= self.heartbeat_interval
         ):
             self.services.logger.emit(
-                "system.heartbeat", 
-                severity=20, 
-                payload={"state": self.state.value}
+                "system.heartbeat",
+                severity=20,
+                payload={"state": self.state.value},
             )
             self._last_heartbeat = now
+            # Record equity snapshot
+            marks = self.runtime.last_marks
+            equity = self.services.portfolio.total_equity(marks)
+            cash = self.services.portfolio.cash
+            positions_value = equity - cash
+            if self.equity_writer is not None:
+                self.equity_writer.append(
+                    timestamp=now.isoformat(),
+                    equity=str(equity),
+                    cash=str(cash),
+                    positions_value=str(positions_value),
+                )
+            self.services.logger.emit(
+                "sse.equity",
+                severity=20,
+                payload={
+                    "timestamp": now.isoformat(),
+                    "equity": str(equity),
+                    "cash": str(cash),
+                    "positions_value": str(positions_value),
+                },
+            )
 
     def _run_tick(self, context: TradingContext) -> None:
         processed_any = False
@@ -153,6 +186,19 @@ class LiveTradingLoop:
 
         if processed_any and self.services.portfolio_repository is not None:
             self.services.portfolio_repository.save(self.services.portfolio)
+
+        # Emit SSE position event if positions changed
+        current_snapshot = {
+            symbol: str(qty)
+            for symbol, qty in self.services.portfolio.positions.items()
+        }
+        if current_snapshot != self._last_position_snapshot:
+            self._last_position_snapshot = current_snapshot
+            self.services.logger.emit(
+                "sse.position",
+                severity=20,
+                payload={"positions": current_snapshot},
+            )
 
     def _maybe_reconcile(self) -> None:
         now = datetime.now(UTC)

--- a/src/trading_system/app/services.py
+++ b/src/trading_system/app/services.py
@@ -30,6 +30,7 @@ from trading_system.execution.broker import (
 )
 from trading_system.execution.kis_adapter import KisBrokerAdapter
 from trading_system.integrations.kis import KisApiClient, is_krx_market_open
+from trading_system.notifications.webhook import WebhookNotifier, build_webhook_notifier
 from trading_system.patterns.repository import PatternSetRepository
 from trading_system.portfolio.book import PortfolioBook
 from trading_system.portfolio.repository import (
@@ -70,6 +71,7 @@ class AppServices:
     portfolio_repository: PortfolioRepository | None = None
     strategies: dict[str, Strategy] | None = None
     portfolio_risk: PortfolioRiskLimits | None = None
+    webhook_notifier: WebhookNotifier | None = None
 
     def run(self) -> BacktestResult:
         if self.mode != AppMode.BACKTEST:
@@ -179,6 +181,10 @@ def build_services(settings: AppSettings) -> AppServices:
     )
     primary_strategy = strategies[settings.symbols[0]]
 
+    webhook_notifier = build_webhook_notifier()
+    if webhook_notifier is not None:
+        logger.subscribe(webhook_notifier.as_subscriber())
+
     return AppServices(
         mode=settings.mode,
         provider=settings.provider,
@@ -201,6 +207,7 @@ def build_services(settings: AppSettings) -> AppServices:
         logger=logger,
         live_preflight_check=_build_live_preflight(settings, kis_client=kis_client),
         portfolio_repository=(portfolio_repository if settings.mode == AppMode.LIVE else None),
+        webhook_notifier=webhook_notifier,
     )
 
 

--- a/src/trading_system/backtest/file_repository.py
+++ b/src/trading_system/backtest/file_repository.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import threading
+import uuid
+from pathlib import Path
+
+from trading_system.backtest.dto import (
+    BacktestResultDTO,
+    BacktestRunDTO,
+    DrawdownPointDTO,
+    EquityPointDTO,
+    EventDTO,
+    SummaryDTO,
+)
+
+
+class FileBacktestRunRepository:
+    def __init__(self, base_dir: Path | str = "data/runs") -> None:
+        self._base_dir = Path(base_dir)
+        self._lock = threading.Lock()
+        os.makedirs(self._base_dir, exist_ok=True)
+        self._ensure_index()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _index_path(self) -> Path:
+        return self._base_dir / "_index.json"
+
+    def _run_path(self, run_id: str) -> Path:
+        return self._base_dir / f"{run_id}.json"
+
+    def _ensure_index(self) -> None:
+        if not self._index_path().exists():
+            self._write_index({"runs": []})
+
+    def _read_index(self) -> dict:
+        try:
+            return json.loads(self._index_path().read_text())
+        except Exception:
+            return {"runs": []}
+
+    def _write_index(self, data: dict) -> None:
+        """Write index atomically using a unique temp file."""
+        tmp = self._base_dir / f"_index_{uuid.uuid4().hex}.tmp"
+        try:
+            tmp.write_text(json.dumps(data, default=str))
+            os.replace(tmp, self._index_path())
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
+
+    def _index_entry(self, run: BacktestRunDTO) -> dict:
+        return {
+            "run_id": run.run_id,
+            "status": run.status,
+            "started_at": run.started_at,
+            "finished_at": run.finished_at,
+            "input_symbols": run.input_symbols,
+            "mode": run.mode,
+        }
+
+    # ------------------------------------------------------------------
+    # Protocol implementation
+    # ------------------------------------------------------------------
+
+    def save(self, run: BacktestRunDTO) -> None:
+        # Write the per-run file first (unique path, no lock needed).
+        data = dataclasses.asdict(run)
+        run_path = self._run_path(run.run_id)
+        tmp = self._base_dir / f"{run.run_id}_{uuid.uuid4().hex}.tmp"
+        try:
+            tmp.write_text(json.dumps(data, default=str))
+            os.replace(tmp, run_path)
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
+
+        # Update shared index under lock.
+        entry = self._index_entry(run)
+        with self._lock:
+            index = self._read_index()
+            existing_ids = {r["run_id"] for r in index["runs"]}
+            if run.run_id in existing_ids:
+                index["runs"] = [
+                    entry if r["run_id"] == run.run_id else r for r in index["runs"]
+                ]
+            else:
+                index["runs"].append(entry)
+            self._write_index(index)
+
+    def get(self, run_id: str) -> BacktestRunDTO | None:
+        path = self._run_path(run_id)
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text())
+        return _deserialize_run(data)
+
+    def list(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        status: str | None = None,
+        mode: str | None = None,
+    ) -> tuple[list[BacktestRunDTO], int]:
+        with self._lock:
+            index = self._read_index()
+        runs = index.get("runs", [])
+        if status is not None:
+            runs = [r for r in runs if r.get("status") == status]
+        if mode is not None:
+            runs = [r for r in runs if r.get("mode") == mode]
+        runs = sorted(runs, key=lambda r: r.get("started_at", ""), reverse=True)
+        total = len(runs)
+        start = (page - 1) * page_size
+        page_runs = runs[start : start + page_size]
+        dtos = [
+            BacktestRunDTO(
+                run_id=r["run_id"],
+                status=r["status"],
+                started_at=r["started_at"],
+                finished_at=r.get("finished_at", ""),
+                input_symbols=r.get("input_symbols", []),
+                mode=r.get("mode", ""),
+            )
+            for r in page_runs
+        ]
+        return dtos, total
+
+    def delete(self, run_id: str) -> bool:
+        with self._lock:
+            path = self._run_path(run_id)
+            if not path.exists():
+                return False
+            path.unlink()
+            index = self._read_index()
+            index["runs"] = [r for r in index["runs"] if r["run_id"] != run_id]
+            self._write_index(index)
+            return True
+
+    def clear(self) -> None:
+        with self._lock:
+            for p in self._base_dir.glob("*.json"):
+                if p.name != "_index.json":
+                    p.unlink()
+            # Also clean up any stray .tmp files.
+            for p in self._base_dir.glob("*.tmp"):
+                p.unlink(missing_ok=True)
+            self._write_index({"runs": []})
+
+    def rebuild_index(self) -> None:
+        with self._lock:
+            entries = []
+            for p in self._base_dir.glob("*.json"):
+                if p.name == "_index.json":
+                    continue
+                try:
+                    data = json.loads(p.read_text())
+                    entries.append({
+                        "run_id": data["run_id"],
+                        "status": data["status"],
+                        "started_at": data.get("started_at", ""),
+                        "finished_at": data.get("finished_at", ""),
+                        "input_symbols": data.get("input_symbols", []),
+                        "mode": data.get("mode", ""),
+                    })
+                except Exception:
+                    continue
+            self._write_index({"runs": entries})
+
+
+# ------------------------------------------------------------------
+# Deserialization helpers
+# ------------------------------------------------------------------
+
+
+def _deserialize_run(data: dict) -> BacktestRunDTO:
+    result = None
+    if data.get("result") is not None:
+        result = _deserialize_result(data["result"])
+    return BacktestRunDTO(
+        run_id=data["run_id"],
+        status=data["status"],
+        started_at=data["started_at"],
+        finished_at=data.get("finished_at", ""),
+        input_symbols=data.get("input_symbols", []),
+        mode=data.get("mode", ""),
+        result=result,
+        error=data.get("error"),
+    )
+
+
+def _deserialize_result(data: dict) -> BacktestResultDTO:
+    summary_raw = data.get("summary", {})
+    summary = SummaryDTO(
+        return_value=summary_raw.get("return_value", "0"),
+        max_drawdown=summary_raw.get("max_drawdown", "0"),
+        volatility=summary_raw.get("volatility", "0"),
+        win_rate=summary_raw.get("win_rate", "0"),
+    )
+    equity_curve = [
+        EquityPointDTO(timestamp=p["timestamp"], equity=p["equity"])
+        for p in data.get("equity_curve", [])
+    ]
+    drawdown_curve = [
+        DrawdownPointDTO(timestamp=p["timestamp"], drawdown=p["drawdown"])
+        for p in data.get("drawdown_curve", [])
+    ]
+    signals = [
+        EventDTO(event=e["event"], payload=e.get("payload", {}))
+        for e in data.get("signals", [])
+    ]
+    orders = [
+        EventDTO(event=e["event"], payload=e.get("payload", {}))
+        for e in data.get("orders", [])
+    ]
+    risk_rejections = [
+        EventDTO(event=e["event"], payload=e.get("payload", {}))
+        for e in data.get("risk_rejections", [])
+    ]
+    return BacktestResultDTO(
+        summary=summary,
+        equity_curve=equity_curve,
+        drawdown_curve=drawdown_curve,
+        signals=signals,
+        orders=orders,
+        risk_rejections=risk_rejections,
+    )

--- a/src/trading_system/backtest/repository.py
+++ b/src/trading_system/backtest/repository.py
@@ -13,12 +13,24 @@ class BacktestRunRepository(Protocol):
     def get(self, run_id: str) -> BacktestRunDTO | None:
         ...
 
+    def list(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        status: str | None = None,
+        mode: str | None = None,
+    ) -> tuple[list[BacktestRunDTO], int]:
+        ...
+
+    def delete(self, run_id: str) -> bool:
+        ...
+
     def clear(self) -> None:
         ...
 
 
 @dataclass(slots=True)
-class InMemoryBacktestRunRepository(BacktestRunRepository):
+class InMemoryBacktestRunRepository:
     _runs: dict[str, BacktestRunDTO] = field(default_factory=dict)
 
     def save(self, run: BacktestRunDTO) -> None:
@@ -26,6 +38,29 @@ class InMemoryBacktestRunRepository(BacktestRunRepository):
 
     def get(self, run_id: str) -> BacktestRunDTO | None:
         return self._runs.get(run_id)
+
+    def list(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        status: str | None = None,
+        mode: str | None = None,
+    ) -> tuple[list[BacktestRunDTO], int]:
+        runs = list(self._runs.values())
+        if status is not None:
+            runs = [r for r in runs if r.status == status]
+        if mode is not None:
+            runs = [r for r in runs if r.mode == mode]
+        runs = sorted(runs, key=lambda r: r.started_at, reverse=True)
+        total = len(runs)
+        start = (page - 1) * page_size
+        return runs[start : start + page_size], total
+
+    def delete(self, run_id: str) -> bool:
+        if run_id not in self._runs:
+            return False
+        del self._runs[run_id]
+        return True
 
     def clear(self) -> None:
         self._runs.clear()

--- a/src/trading_system/core/ops.py
+++ b/src/trading_system/core/ops.py
@@ -6,6 +6,7 @@ import os
 import time
 import uuid
 from collections import deque
+from collections.abc import Callable
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import asdict, dataclass
@@ -118,6 +119,13 @@ class StructuredLogger:
         self._logger = logging.getLogger(name)
         self._format = log_format
         self._event_buffer: deque[EventRecord] = deque(maxlen=self._EVENT_BUFFER_MAX)
+        self._subscribers: list[Callable[[EventRecord], None]] = []
+
+    def subscribe(self, callback: Callable[[EventRecord], None]) -> None:
+        self._subscribers.append(callback)
+
+    def unsubscribe(self, callback: Callable[[EventRecord], None]) -> None:
+        self._subscribers = [s for s in self._subscribers if s is not callback]
 
     def emit(self, event: str, severity: int, payload: dict[str, Any]) -> None:
         correlation_id = get_or_create_correlation_id()
@@ -130,6 +138,11 @@ class StructuredLogger:
         )
         self._event_buffer.append(record)
         self._logger.log(severity, self._serialize(record))
+        for subscriber in list(self._subscribers):
+            try:
+                subscriber(record)
+            except Exception:
+                self._logger.warning("Subscriber callback error", exc_info=True)
 
     def recent_events(self, limit: int = 50) -> list[EventRecord]:
         """Return the most recent *limit* events from the ring buffer."""

--- a/src/trading_system/notifications/webhook.py
+++ b/src/trading_system/notifications/webhook.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import queue
+import threading
+from collections.abc import Callable
+
+import httpx
+
+from trading_system.core.ops import EventRecord
+
+_logger = logging.getLogger(__name__)
+
+DEFAULT_EVENTS: frozenset[str] = frozenset({
+    "order.filled",
+    "risk.rejected",
+    "pattern.alert",
+    "system.error",
+    "portfolio.reconciliation.position_adjusted",
+})
+
+_QUEUE_MAX = 200
+_SENTINEL = None  # shutdown signal
+
+
+class WebhookNotifier:
+    """Fire-and-forget webhook notifier backed by a single bounded worker thread."""
+
+    def __init__(
+        self,
+        url: str,
+        events: frozenset[str] = DEFAULT_EVENTS,
+        timeout_seconds: float = 5.0,
+    ) -> None:
+        self.url = url
+        self.events = events
+        self.timeout_seconds = timeout_seconds
+        self._queue: queue.Queue = queue.Queue(maxsize=_QUEUE_MAX)
+        self._worker = threading.Thread(
+            target=self._run_worker,
+            daemon=True,
+            name="webhook-worker",
+        )
+        self._worker.start()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _run_worker(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            while True:
+                payload = self._queue.get()
+                if payload is _SENTINEL:
+                    break
+                try:
+                    loop.run_until_complete(self._send(payload))
+                except Exception:
+                    _logger.warning("Webhook worker error", exc_info=True)
+        finally:
+            loop.close()
+
+    async def _send(self, payload: dict) -> None:
+        async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+            try:
+                resp = await client.post(self.url, json=payload)
+                resp.raise_for_status()
+                return
+            except Exception:
+                pass
+            # 1 retry
+            try:
+                resp = await client.post(self.url, json=payload)
+                resp.raise_for_status()
+            except Exception:
+                _logger.warning(
+                    "Webhook delivery failed after retry: event=%s url=%s",
+                    payload.get("event"),
+                    self.url,
+                    exc_info=True,
+                )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def notify(self, record: EventRecord) -> None:
+        if record.event not in self.events:
+            return
+        payload = {
+            "event": record.event,
+            "timestamp": record.timestamp,
+            "payload": record.payload,
+            "source": "trading-system",
+        }
+        try:
+            self._queue.put_nowait(payload)
+        except queue.Full:
+            _logger.warning(
+                "Webhook queue full (%d), dropping event: %s", _QUEUE_MAX, record.event
+            )
+
+    def as_subscriber(self) -> Callable[[EventRecord], None]:
+        return self.notify
+
+    def shutdown(self, timeout: float = 5.0) -> None:
+        """Drain the queue and stop the worker. Call on process exit if needed."""
+        self._queue.put(_SENTINEL)
+        self._worker.join(timeout=timeout)
+
+
+def build_webhook_notifier() -> WebhookNotifier | None:
+    url = os.getenv("TRADING_SYSTEM_WEBHOOK_URL", "").strip()
+    if not url:
+        return None
+    events_str = os.getenv(
+        "TRADING_SYSTEM_WEBHOOK_EVENTS",
+        "order.filled,risk.rejected,pattern.alert,system.error,"
+        "portfolio.reconciliation.position_adjusted",
+    )
+    events = frozenset(e.strip() for e in events_str.split(",") if e.strip())
+    timeout = float(os.getenv("TRADING_SYSTEM_WEBHOOK_TIMEOUT", "5"))
+    return WebhookNotifier(url=url, events=events, timeout_seconds=timeout)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,15 +8,31 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _bypass_api_key_auth():
-    """Disable API key security middleware for all tests."""
+    """Disable API key security middleware for all tests.
+
+    Clears both the repo-based key path and the env-var-based allowed keys so
+    that .env values (loaded by load_dotenv() in server.py) do not bleed
+    across test cases.
+    """
     empty_keys = os.path.join(tempfile.gettempdir(), "test_empty_api_keys.json")
     if not os.path.exists(empty_keys):
         with open(empty_keys, "w") as f:
             f.write("[]")
-    old = os.environ.get("TRADING_SYSTEM_API_KEYS_PATH")
+
+    old_path = os.environ.get("TRADING_SYSTEM_API_KEYS_PATH")
+    old_allowed = os.environ.get("TRADING_SYSTEM_ALLOWED_API_KEYS")
+
     os.environ["TRADING_SYSTEM_API_KEYS_PATH"] = empty_keys
+    os.environ["TRADING_SYSTEM_ALLOWED_API_KEYS"] = ""
+
     yield
-    if old is None:
+
+    if old_path is None:
         os.environ.pop("TRADING_SYSTEM_API_KEYS_PATH", None)
     else:
-        os.environ["TRADING_SYSTEM_API_KEYS_PATH"] = old
+        os.environ["TRADING_SYSTEM_API_KEYS_PATH"] = old_path
+
+    if old_allowed is None:
+        os.environ.pop("TRADING_SYSTEM_ALLOWED_API_KEYS", None)
+    else:
+        os.environ["TRADING_SYSTEM_ALLOWED_API_KEYS"] = old_allowed

--- a/tests/integration/test_run_persistence_integration.py
+++ b/tests/integration/test_run_persistence_integration.py
@@ -1,0 +1,175 @@
+"""Integration tests for FileBacktestRunRepository persistence.
+
+Validates that:
+- A run saved to FileBacktestRunRepository survives repository recreation
+  (simulating server restart).
+- GET /api/v1/backtests list API returns saved runs with correct pagination
+  and status filters.
+- GET /api/v1/backtests/{run_id} returns the full persisted run.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from trading_system.api.routes import backtest as backtest_routes
+from trading_system.api.server import create_app
+from trading_system.backtest.file_repository import FileBacktestRunRepository
+from trading_system.backtest.dto import BacktestRunDTO
+
+
+@pytest.fixture(autouse=True)
+def _restore_repository():
+    """Restore the module-level repository after each test."""
+    original = backtest_routes._RUN_REPOSITORY
+    yield
+    backtest_routes._RUN_REPOSITORY = original
+
+
+def _make_client(repo: FileBacktestRunRepository) -> TestClient:
+    backtest_routes._RUN_REPOSITORY = repo
+    return TestClient(create_app(), raise_server_exceptions=False)
+
+
+def _minimal_payload() -> dict:
+    return {
+        "mode": "backtest",
+        "symbols": ["BTCUSDT"],
+        "provider": "mock",
+        "broker": "paper",
+        "live_execution": "preflight",
+        "risk": {
+            "max_position": "1",
+            "max_notional": "100000",
+            "max_order_size": "0.25",
+        },
+        "backtest": {
+            "starting_cash": "10000",
+            "fee_bps": "5",
+            "trade_quantity": "0.1",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Persistence across repository instances (simulates server restart)
+# ---------------------------------------------------------------------------
+
+
+def test_run_persists_across_repository_recreation(tmp_path):
+    """Save a run; recreate the repository; the run should still be listed."""
+    repo1 = FileBacktestRunRepository(tmp_path)
+    client1 = _make_client(repo1)
+
+    resp = client1.post("/api/v1/backtests", json=_minimal_payload())
+    assert resp.status_code == 201
+    run_id = resp.json()["run_id"]
+
+    # Recreate the repository (simulates server restart)
+    repo2 = FileBacktestRunRepository(tmp_path)
+    client2 = _make_client(repo2)
+
+    list_resp = client2.get("/api/v1/backtests")
+    assert list_resp.status_code == 200
+    run_ids = [r["run_id"] for r in list_resp.json()["runs"]]
+    assert run_id in run_ids
+
+
+def test_run_detail_persists_across_repository_recreation(tmp_path):
+    """Full run result survives repository recreation."""
+    repo1 = FileBacktestRunRepository(tmp_path)
+    client1 = _make_client(repo1)
+
+    resp = client1.post("/api/v1/backtests", json=_minimal_payload())
+    assert resp.status_code == 201
+    run_id = resp.json()["run_id"]
+
+    repo2 = FileBacktestRunRepository(tmp_path)
+    client2 = _make_client(repo2)
+
+    detail = client2.get(f"/api/v1/backtests/{run_id}")
+    assert detail.status_code == 200
+    body = detail.json()
+    assert body["run_id"] == run_id
+    assert body["status"] == "succeeded"
+    assert body["result"] is not None
+
+
+# ---------------------------------------------------------------------------
+# List API — pagination and filtering
+# ---------------------------------------------------------------------------
+
+
+def test_list_api_pagination(tmp_path):
+    repo = FileBacktestRunRepository(tmp_path)
+    client = _make_client(repo)
+
+    # Create 3 runs
+    for _ in range(3):
+        r = client.post("/api/v1/backtests", json=_minimal_payload())
+        assert r.status_code == 201
+
+    resp = client.get("/api/v1/backtests?page=1&page_size=2")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 3
+    assert len(body["runs"]) == 2
+    assert body["page"] == 1
+    assert body["page_size"] == 2
+
+    resp2 = client.get("/api/v1/backtests?page=2&page_size=2")
+    assert resp2.status_code == 200
+    body2 = resp2.json()
+    assert len(body2["runs"]) == 1
+
+
+def test_list_api_status_filter(tmp_path):
+    repo = FileBacktestRunRepository(tmp_path)
+    client = _make_client(repo)
+
+    # Create one real succeeded run via POST
+    r = client.post("/api/v1/backtests", json=_minimal_payload())
+    assert r.status_code == 201
+
+    # Manually add a "failed" run directly to the repo
+    failed_run = BacktestRunDTO(
+        run_id="manual-failed-run",
+        status="failed",
+        started_at="2024-01-01T00:00:00Z",
+        finished_at="2024-01-01T00:01:00Z",
+        input_symbols=["BTCUSDT"],
+        mode="backtest",
+        error="forced failure",
+    )
+    repo.save(failed_run)
+
+    succeeded_resp = client.get("/api/v1/backtests?status=succeeded")
+    assert succeeded_resp.status_code == 200
+    assert all(r["status"] == "succeeded" for r in succeeded_resp.json()["runs"])
+
+    failed_resp = client.get("/api/v1/backtests?status=failed")
+    assert failed_resp.status_code == 200
+    assert any(r["run_id"] == "manual-failed-run" for r in failed_resp.json()["runs"])
+
+
+def test_list_api_index_rebuilt_from_files(tmp_path):
+    """Deleting _index.json and rebuilding should give correct listing."""
+    repo = FileBacktestRunRepository(tmp_path)
+    client = _make_client(repo)
+
+    r = client.post("/api/v1/backtests", json=_minimal_payload())
+    assert r.status_code == 201
+    run_id = r.json()["run_id"]
+
+    # Delete the index
+    (tmp_path / "_index.json").unlink()
+
+    # Rebuild and re-create repo
+    repo2 = FileBacktestRunRepository(tmp_path)
+    repo2.rebuild_index()
+    client2 = _make_client(repo2)
+
+    list_resp = client2.get("/api/v1/backtests")
+    assert list_resp.status_code == 200
+    run_ids = [r["run_id"] for r in list_resp.json()["runs"]]
+    assert run_id in run_ids

--- a/tests/unit/test_core_ops.py
+++ b/tests/unit/test_core_ops.py
@@ -46,6 +46,44 @@ def test_structured_logger_emits_json_with_correlation_id(caplog) -> None:
     assert body["event"] == "order.created"
 
 
+def test_subscriber_receives_emitted_event() -> None:
+    logger = StructuredLogger("trading_system.tests.sub", log_format=StructuredLogFormat.JSON)
+    received = []
+    logger.subscribe(received.append)
+
+    logger.emit("test.event", logging.INFO, {"key": "value"})
+
+    assert len(received) == 1
+    assert received[0].event == "test.event"
+
+
+def test_unsubscribe_stops_delivery() -> None:
+    logger = StructuredLogger("trading_system.tests.unsub", log_format=StructuredLogFormat.JSON)
+    received = []
+    callback = received.append  # store reference for identity comparison
+    logger.subscribe(callback)
+    logger.unsubscribe(callback)
+
+    logger.emit("test.event", logging.INFO, {})
+
+    assert len(received) == 0
+
+
+def test_subscriber_exception_does_not_affect_others() -> None:
+    logger = StructuredLogger("trading_system.tests.exc", log_format=StructuredLogFormat.JSON)
+    received = []
+
+    def bad_subscriber(record):
+        raise RuntimeError("boom")
+
+    logger.subscribe(bad_subscriber)
+    logger.subscribe(received.append)
+
+    logger.emit("test.event", logging.INFO, {})
+
+    assert len(received) == 1
+
+
 def test_execute_with_resilience_opens_circuit_breaker_after_failures() -> None:
     state = CircuitBreakerState()
     retry = RetryPolicy(max_attempts=1, backoff_seconds=0)

--- a/tests/unit/test_equity_timeseries.py
+++ b/tests/unit/test_equity_timeseries.py
@@ -1,0 +1,65 @@
+"""Unit tests for EquityWriter."""
+from __future__ import annotations
+
+from trading_system.app.equity_writer import EquityWriter
+
+
+def test_append_and_read_recent_roundtrip(tmp_path):
+    writer = EquityWriter(tmp_path, "session-1")
+    writer.append(
+        timestamp="2024-01-01T00:00:00Z",
+        equity="10500",
+        cash="5000",
+        positions_value="5500",
+    )
+    points = writer.read_recent()
+    assert len(points) == 1
+    assert points[0]["equity"] == "10500"
+    assert points[0]["cash"] == "5000"
+    assert points[0]["positions_value"] == "5500"
+    assert points[0]["timestamp"] == "2024-01-01T00:00:00Z"
+
+
+def test_read_recent_empty_file(tmp_path):
+    writer = EquityWriter(tmp_path, "session-empty")
+    result = writer.read_recent()
+    assert result == []
+
+
+def test_read_recent_missing_file(tmp_path):
+    writer = EquityWriter(tmp_path, "session-missing")
+    result = writer.read_recent()
+    assert result == []
+
+
+def test_read_recent_limit(tmp_path):
+    writer = EquityWriter(tmp_path, "session-limit")
+    for i in range(10):
+        writer.append(
+            timestamp=f"2024-01-01T00:0{i}:00Z",
+            equity=str(10000 + i),
+            cash="5000",
+            positions_value=str(5000 + i),
+        )
+
+    recent = writer.read_recent(limit=5)
+    assert len(recent) == 5
+    # Should be the last 5 appended
+    assert recent[-1]["equity"] == "10009"
+    assert recent[0]["equity"] == "10005"
+
+
+def test_append_multiple_sessions_independent(tmp_path):
+    w1 = EquityWriter(tmp_path, "session-a")
+    w2 = EquityWriter(tmp_path, "session-b")
+
+    w1.append(timestamp="2024-01-01T00:00:00Z", equity="1000", cash="500", positions_value="500")
+    w2.append(timestamp="2024-01-01T00:00:00Z", equity="2000", cash="1000", positions_value="1000")
+
+    assert w1.read_recent()[0]["equity"] == "1000"
+    assert w2.read_recent()[0]["equity"] == "2000"
+
+
+def test_session_id_property(tmp_path):
+    writer = EquityWriter(tmp_path, "my-session")
+    assert writer.session_id == "my-session"

--- a/tests/unit/test_file_repository.py
+++ b/tests/unit/test_file_repository.py
@@ -1,0 +1,181 @@
+"""Unit tests for FileBacktestRunRepository."""
+from __future__ import annotations
+
+from trading_system.backtest.dto import (
+    BacktestResultDTO,
+    BacktestRunDTO,
+    DrawdownPointDTO,
+    EquityPointDTO,
+    EventDTO,
+    SummaryDTO,
+)
+from trading_system.backtest.file_repository import FileBacktestRunRepository
+
+
+def _make_run(
+    run_id: str = "run-1",
+    status: str = "succeeded",
+    mode: str = "backtest",
+    started_at: str = "2024-01-01T00:00:00Z",
+    include_result: bool = False,
+) -> BacktestRunDTO:
+    result = None
+    if include_result:
+        result = BacktestResultDTO(
+            summary=SummaryDTO(
+                return_value="0.05",
+                max_drawdown="0.02",
+                volatility="0.01",
+                win_rate="0.6",
+            ),
+            equity_curve=[EquityPointDTO(timestamp="2024-01-01T00:00:00Z", equity="10500")],
+            drawdown_curve=[DrawdownPointDTO(timestamp="2024-01-01T00:00:00Z", drawdown="0.02")],
+            signals=[EventDTO(event="signal.buy", payload={"symbol": "AAPL"})],
+            orders=[EventDTO(event="order.filled", payload={"symbol": "AAPL"})],
+            risk_rejections=[],
+        )
+    return BacktestRunDTO(
+        run_id=run_id,
+        status=status,
+        started_at=started_at,
+        finished_at="2024-01-01T01:00:00Z",
+        input_symbols=["AAPL"],
+        mode=mode,
+        result=result,
+    )
+
+
+def test_save_and_get_roundtrip(tmp_path):
+    repo = FileBacktestRunRepository(tmp_path)
+    run = _make_run("run-1", include_result=True)
+    repo.save(run)
+
+    retrieved = repo.get("run-1")
+    assert retrieved is not None
+    assert retrieved.run_id == "run-1"
+    assert retrieved.status == "succeeded"
+    assert retrieved.result is not None
+    assert retrieved.result.summary.return_value == "0.05"
+    assert len(retrieved.result.equity_curve) == 1
+    assert retrieved.result.equity_curve[0].equity == "10500"
+
+
+def test_get_missing_returns_none(tmp_path):
+    repo = FileBacktestRunRepository(tmp_path)
+    assert repo.get("nonexistent") is None
+
+
+def test_list_empty_directory(tmp_path):
+    repo = FileBacktestRunRepository(tmp_path)
+    runs, total = repo.list()
+    assert runs == []
+    assert total == 0
+
+
+def test_list_pagination(tmp_path):
+    repo = FileBacktestRunRepository(tmp_path)
+    for i in range(15):
+        run = _make_run(
+            run_id=f"run-{i:02d}",
+            started_at=f"2024-01-{i + 1:02d}T00:00:00Z",
+        )
+        repo.save(run)
+
+    page1, total = repo.list(page=1, page_size=10)
+    assert total == 15
+    assert len(page1) == 10
+
+    page2, total2 = repo.list(page=2, page_size=10)
+    assert total2 == 15
+    assert len(page2) == 5
+
+    # Latest first
+    assert page1[0].started_at > page1[-1].started_at
+
+
+def test_list_status_filter(tmp_path):
+    repo = FileBacktestRunRepository(tmp_path)
+    repo.save(_make_run("run-1", status="succeeded"))
+    repo.save(_make_run("run-2", status="failed"))
+    repo.save(_make_run("run-3", status="succeeded"))
+
+    runs, total = repo.list(status="succeeded")
+    assert total == 2
+    assert all(r.status == "succeeded" for r in runs)
+
+
+def test_list_mode_filter(tmp_path):
+    repo = FileBacktestRunRepository(tmp_path)
+    repo.save(_make_run("run-1", mode="backtest"))
+    repo.save(_make_run("run-2", mode="live"))
+
+    runs, total = repo.list(mode="backtest")
+    assert total == 1
+    assert runs[0].run_id == "run-1"
+
+
+def test_delete_removes_run(tmp_path):
+    repo = FileBacktestRunRepository(tmp_path)
+    repo.save(_make_run("run-1"))
+
+    result = repo.delete("run-1")
+    assert result is True
+    assert repo.get("run-1") is None
+
+    runs, total = repo.list()
+    assert total == 0
+
+
+def test_delete_missing_returns_false(tmp_path):
+    repo = FileBacktestRunRepository(tmp_path)
+    assert repo.delete("nonexistent") is False
+
+
+def test_rebuild_index(tmp_path):
+    repo = FileBacktestRunRepository(tmp_path)
+    repo.save(_make_run("run-1"))
+    repo.save(_make_run("run-2"))
+
+    # Delete the index
+    (tmp_path / "_index.json").unlink()
+
+    # Rebuild
+    repo.rebuild_index()
+
+    runs, total = repo.list()
+    assert total == 2
+    run_ids = {r.run_id for r in runs}
+    assert run_ids == {"run-1", "run-2"}
+
+
+def test_clear_removes_all_files(tmp_path):
+    repo = FileBacktestRunRepository(tmp_path)
+    repo.save(_make_run("run-1"))
+    repo.save(_make_run("run-2"))
+
+    repo.clear()
+
+    json_files = [p for p in tmp_path.glob("*.json") if p.name != "_index.json"]
+    assert len(json_files) == 0
+    _, total = repo.list()
+    assert total == 0
+
+
+def test_save_updates_existing_in_index(tmp_path):
+    repo = FileBacktestRunRepository(tmp_path)
+    run = _make_run("run-1", status="running")
+    repo.save(run)
+
+    updated = BacktestRunDTO(
+        run_id="run-1",
+        status="succeeded",
+        started_at=run.started_at,
+        finished_at="2024-01-01T01:00:00Z",
+        input_symbols=["AAPL"],
+        mode="backtest",
+    )
+    repo.save(updated)
+
+    runs, total = repo.list()
+    assert total == 1
+    assert runs[0].status == "succeeded"

--- a/tests/unit/test_sse_stream.py
+++ b/tests/unit/test_sse_stream.py
@@ -1,0 +1,76 @@
+"""Unit tests for SSE /stream endpoint."""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+import trading_system.api.routes.dashboard as dashboard_module
+from trading_system.api.server import create_app
+
+_STREAM_PATH = "/api/v1/dashboard/stream"
+
+
+@pytest.fixture(autouse=True)
+def reset_sse_counter():
+    """Reset the SSE connection counter before each test."""
+    original = dashboard_module._active_sse_connections
+    dashboard_module._active_sse_connections = 0
+    yield
+    dashboard_module._active_sse_connections = original
+
+
+def _make_client(api_key: str = "") -> TestClient:
+    """Create a full app client with security middleware active."""
+    import os
+    import tempfile
+
+    empty_keys = tempfile.mktemp(suffix=".json")
+    with open(empty_keys, "w") as f:
+        f.write("[]")
+
+    os.environ["TRADING_SYSTEM_API_KEYS_PATH"] = empty_keys
+    os.environ["TRADING_SYSTEM_ALLOWED_API_KEYS"] = api_key
+    app = create_app()
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_sse_connection_limit_returns_429():
+    dashboard_module._active_sse_connections = dashboard_module._MAX_SSE_CONNECTIONS
+    client = _make_client(api_key="")
+    response = client.get(_STREAM_PATH)
+    assert response.status_code == 429
+
+
+def test_sse_unauthorized_with_api_key_set():
+    client = _make_client(api_key="secret-key")
+    # No api_key query param → middleware returns 401
+    response = client.get(_STREAM_PATH)
+    assert response.status_code == 401
+
+
+def test_sse_unauthorized_wrong_key():
+    client = _make_client(api_key="secret-key")
+    response = client.get(f"{_STREAM_PATH}?api_key=wrong-key")
+    assert response.status_code == 401
+
+
+def test_sse_valid_key_passes_auth():
+    """Valid query-param api_key should pass middleware auth."""
+    # Set connections to MAX so we get 429 instead of blocking on the stream.
+    # This confirms auth passed (would be 401 otherwise).
+    dashboard_module._active_sse_connections = dashboard_module._MAX_SSE_CONNECTIONS
+    client = _make_client(api_key="my-key")
+    response = client.get(f"{_STREAM_PATH}?api_key=my-key")
+    # Auth passed → gets to connection limit → 429 (not 401)
+    assert response.status_code == 429
+
+
+def test_sse_no_api_key_configured_allows_connection():
+    """No configured keys → no auth enforced → connection limit is the gate."""
+    # 0 connections, no key configured → would stream (but we can't easily
+    # test the infinite stream here; 429/401 absence confirms auth is open)
+    dashboard_module._active_sse_connections = dashboard_module._MAX_SSE_CONNECTIONS
+    client = _make_client(api_key="")
+    response = client.get(_STREAM_PATH)
+    # No auth gate → connection limit fires → 429 (not 401)
+    assert response.status_code == 429

--- a/tests/unit/test_webhook_notifier.py
+++ b/tests/unit/test_webhook_notifier.py
@@ -1,0 +1,162 @@
+"""Unit tests for WebhookNotifier."""
+from __future__ import annotations
+
+import asyncio
+import queue
+from unittest.mock import patch
+
+from trading_system.core.ops import EventRecord
+from trading_system.notifications.webhook import (
+    WebhookNotifier,
+    build_webhook_notifier,
+)
+
+
+def _make_record(event: str = "order.filled") -> EventRecord:
+    return EventRecord(
+        event=event,
+        severity="INFO",
+        correlation_id="test-corr",
+        timestamp="2024-01-01T00:00:00Z",
+        payload={"symbol": "AAPL"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_webhook_notifier
+# ---------------------------------------------------------------------------
+
+
+def test_build_webhook_notifier_no_url(monkeypatch):
+    monkeypatch.delenv("TRADING_SYSTEM_WEBHOOK_URL", raising=False)
+    assert build_webhook_notifier() is None
+
+
+def test_build_webhook_notifier_with_url(monkeypatch):
+    monkeypatch.setenv("TRADING_SYSTEM_WEBHOOK_URL", "http://example.com/hook")
+    notifier = build_webhook_notifier()
+    assert notifier is not None
+    assert notifier.url == "http://example.com/hook"
+    assert "order.filled" in notifier.events
+
+
+def test_build_webhook_notifier_custom_events(monkeypatch):
+    monkeypatch.setenv("TRADING_SYSTEM_WEBHOOK_URL", "http://example.com/hook")
+    monkeypatch.setenv("TRADING_SYSTEM_WEBHOOK_EVENTS", "order.filled,system.error")
+    notifier = build_webhook_notifier()
+    assert notifier is not None
+    assert notifier.events == frozenset({"order.filled", "system.error"})
+
+
+def test_build_webhook_notifier_custom_timeout(monkeypatch):
+    monkeypatch.setenv("TRADING_SYSTEM_WEBHOOK_URL", "http://example.com/hook")
+    monkeypatch.setenv("TRADING_SYSTEM_WEBHOOK_TIMEOUT", "10")
+    notifier = build_webhook_notifier()
+    assert notifier is not None
+    assert notifier.timeout_seconds == 10.0
+
+
+# ---------------------------------------------------------------------------
+# notify() — queue interaction (mock queue to avoid worker thread bleed)
+# ---------------------------------------------------------------------------
+
+
+def test_notify_skips_non_target_event():
+    notifier = WebhookNotifier(url="http://example.com/hook")
+    record = _make_record("some.other.event")
+    with patch.object(notifier._queue, "put_nowait") as mock_put:
+        notifier.notify(record)
+        mock_put.assert_not_called()
+
+
+def test_notify_target_event_enqueues_payload():
+    notifier = WebhookNotifier(url="http://example.com/hook")
+    record = _make_record("order.filled")
+    with patch.object(notifier._queue, "put_nowait") as mock_put:
+        notifier.notify(record)
+        mock_put.assert_called_once()
+        payload = mock_put.call_args[0][0]
+        assert payload["event"] == "order.filled"
+        assert payload["source"] == "trading-system"
+        assert "timestamp" in payload
+        assert "payload" in payload
+
+
+def test_notify_drops_when_queue_full():
+    """queue.Full should not propagate out of notify()."""
+    notifier = WebhookNotifier(url="http://example.com/hook")
+    with patch.object(notifier._queue, "put_nowait", side_effect=queue.Full):
+        notifier.notify(_make_record("order.filled"))  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _send() — async HTTP with retry
+# ---------------------------------------------------------------------------
+
+
+def test_send_retries_on_failure():
+    """_send() makes one initial attempt then exactly one retry on failure."""
+    import httpx
+
+    notifier = WebhookNotifier(url="http://example.com/hook", timeout_seconds=1.0)
+    call_count = 0
+
+    async def failing_post(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        raise httpx.ConnectError("connection refused")
+
+    # Patch put_nowait on ALL existing notifiers' queues so background workers
+    # never receive items and therefore never call _send during this test.
+    with patch.object(notifier._queue, "put_nowait"):
+        with patch.object(httpx.AsyncClient, "post", new=failing_post):
+            asyncio.run(
+                notifier._send({
+                    "event": "order.filled",
+                    "timestamp": "now",
+                    "payload": {},
+                    "source": "trading-system",
+                })
+            )
+
+    assert call_count == 2  # initial attempt + 1 retry
+
+
+def test_payload_structure():
+    """_send receives the expected payload shape."""
+    notifier = WebhookNotifier(url="http://example.com/hook")
+    record = _make_record("order.filled")
+
+    captured: list[dict] = []
+
+    async def capturing_send(payload: dict) -> None:
+        captured.append(payload)
+
+    # Replace the instance's _send for this test only
+    notifier._send = capturing_send  # type: ignore[method-assign]
+
+    payload = {
+        "event": record.event,
+        "timestamp": record.timestamp,
+        "payload": record.payload,
+        "source": "trading-system",
+    }
+    asyncio.run(notifier._send(payload))
+
+    assert captured[0]["event"] == "order.filled"
+    assert captured[0]["source"] == "trading-system"
+    assert "timestamp" in captured[0]
+    assert "payload" in captured[0]
+
+
+# ---------------------------------------------------------------------------
+# as_subscriber
+# ---------------------------------------------------------------------------
+
+
+def test_as_subscriber_returns_callable():
+    notifier = WebhookNotifier(url="http://example.com/hook")
+    subscriber = notifier.as_subscriber()
+    assert callable(subscriber)
+    # Should be the bound notify method
+    assert subscriber.__func__ is WebhookNotifier.notify  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- **파일 기반 런 영속화**: `FileBacktestRunRepository` (JSON + `_index.json` cache, `threading.Lock`, atomic write) + `GET /api/v1/backtests` 목록 API (pagination/filter)
- **SSE 실시간 스트리밍**: `GET /api/v1/dashboard/stream` (status/position/equity/event/heartbeat), security middleware에서 query param `api_key` 지원
- **서버 측 Equity 시계열**: `EquityWriter` JSONL append + `GET /api/v1/dashboard/equity`
- **Webhook 알림 채널**: `WebhookNotifier` (bounded queue worker, 1-retry fire-and-forget)
- **프론트엔드 통합**: `/runs` 서버 목록 API 전환 (runsStore fallback), `useDashboardStream` 훅 (SSE + polling fallback), equity history 서버 연동
- **Codex adversarial review 반영**: SSE auth 충돌 수정, index 동시성 Lock 추가, webhook 언바운드 thread → bounded queue

## Test plan

- [x] `pytest`: 221 passed
- [x] `ruff check src/ tests/` (Phase 8 파일): 0 errors
- [x] `npx tsc --noEmit`: PASS
- [x] `npm run lint`: PASS
- [x] `npm run build`: PASS
- [x] Phase 8 신규 단위 테스트 36개 (file_repository, equity_timeseries, sse_stream, webhook_notifier, core_ops subscriber)
- [x] 통합 테스트 5개 (server restart simulation, pagination, status filter, index rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)