### PR TITLE
[codex] Implement phase 15 operational hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,7 @@ This makes signal→risk→execution decisions inspectable, not just final PnL n
 - `TRADING_SYSTEM_KIS_BASE_URL` (optional): override KIS REST base URL
 - `TRADING_SYSTEM_KIS_PRICE_TR_ID` (optional): override domestic quote TR id for preflight quote checks
 - `TRADING_SYSTEM_KIS_BALANCE_TR_ID` (optional): override domestic balance inquiry TR id for reconciliation snapshots
+- `TRADING_SYSTEM_KIS_OPEN_ORDERS_TR_ID` (optional): override domestic open-order inquiry TR id for reconciliation pending-order authority
 - `TRADING_SYSTEM_KIS_MARKET_DIV` (optional): override quote market division code (`J` default for domestic stock)
 - `TRADING_SYSTEM_ALLOWED_API_KEYS`: comma-separated API keys accepted by HTTP middleware (`X-API-Key`)
 - `TRADING_SYSTEM_API_KEYS_PATH` (optional): file path for dynamic API key storage managed by `/api/v1/admin/keys` (default: `data/api_keys.json`)
@@ -760,6 +761,7 @@ This makes signal→risk→execution decisions inspectable, not just final PnL n
 - `TRADING_SYSTEM_KIS_BASE_URL` (선택): 한국투자 REST 기본 URL 재정의
 - `TRADING_SYSTEM_KIS_PRICE_TR_ID` (선택): 프리플라이트 현재가 조회용 TR ID 재정의
 - `TRADING_SYSTEM_KIS_BALANCE_TR_ID` (선택): reconciliation용 국내주식 잔고 조회 TR ID 재정의
+- `TRADING_SYSTEM_KIS_OPEN_ORDERS_TR_ID` (선택): reconciliation pending-order 판단용 국내주식 미체결 조회 TR ID 재정의
 - `TRADING_SYSTEM_KIS_MARKET_DIV` (선택): 현재가 조회 시장 구분 코드 재정의 (기본값 `J`, 국내주식)
 - `TRADING_SYSTEM_ALLOWED_API_KEYS`: HTTP 미들웨어가 허용할 API 키 목록(쉼표 구분, `X-API-Key`)
 - `TRADING_SYSTEM_API_KEYS_PATH` (선택): `/api/v1/admin/keys`가 관리하는 동적 API key 저장 파일 경로 (기본값: `data/api_keys.json`)
@@ -797,12 +799,13 @@ Required root sections:
 - `risk`: `max_position`, `max_notional`, `max_order_size` (Decimal, > 0)
 - `portfolio_risk` (optional): `max_daily_drawdown_pct` (Decimal, > 0 and < 1), `sl_pct`/`tp_pct` (optional Decimal, > 0)
 - `backtest`: `starting_cash` (> 0), `fee_bps` (0~1000), `trade_quantity` (> 0)
+- `strategy` (optional): `type: pattern_signal` with either `profile_id` or inline `pattern_set_id`, `label_to_side`, `trade_quantity`, and `threshold_overrides`
 - `api` (optional): `cors_allow_origins` (list[str], default `[*]`)
 
 All numeric amount/quantity fields are parsed as `Decimal`.
 
 Note:
-- `load_settings()` now covers the baseline YAML schema above, including `app.reconciliation_interval` and `portfolio_risk`.
+- `load_settings()` now covers the baseline YAML schema above, including `app.reconciliation_interval`, `portfolio_risk`, and pattern strategy configuration. CLI runs can also use `--config configs/base.yaml` or select a stored profile directly with `--strategy-profile-id`.
 - The live loop still uses `TRADING_SYSTEM_RECONCILIATION_INTERVAL` as the runtime env override; YAML provides the typed config baseline.
 - Config examples in `configs/base.yaml` and `examples/sample_live_kis.yaml` are active typed fields, not reference-only comments.
 
@@ -824,12 +827,13 @@ settings = load_settings("configs/base.yaml")
 - `risk`: `max_position`, `max_notional`, `max_order_size` (Decimal, > 0)
 - `portfolio_risk` (선택): `max_daily_drawdown_pct` (Decimal, 0 초과 1 미만), `sl_pct`/`tp_pct` (선택 Decimal, > 0)
 - `backtest`: `starting_cash` (> 0), `fee_bps` (0~1000), `trade_quantity` (> 0)
+- `strategy` (선택): `type: pattern_signal`과 함께 `profile_id` 또는 inline `pattern_set_id`, `label_to_side`, `trade_quantity`, `threshold_overrides`
 - `api` (선택): `cors_allow_origins` (list[str], 기본값 `[*]`)
 
 금액/수량 계열 숫자 필드는 모두 `Decimal`로 파싱됩니다.
 
 참고:
-- `load_settings()`는 이제 위 기본 YAML 스키마에 더해 `app.reconciliation_interval`과 `portfolio_risk`까지 타입 검증합니다.
+- `load_settings()`는 이제 위 기본 YAML 스키마에 더해 `app.reconciliation_interval`, `portfolio_risk`, pattern strategy 설정까지 타입 검증합니다. CLI는 `--config configs/base.yaml` 또는 `--strategy-profile-id`로 저장된 프로필을 선택할 수 있습니다.
 - 라이브 루프 런타임에서는 `TRADING_SYSTEM_RECONCILIATION_INTERVAL` 환경변수가 여전히 우선 override 역할을 하고, YAML은 typed baseline 설정값 역할을 합니다.
 - `configs/base.yaml`과 `examples/sample_live_kis.yaml`의 관련 필드는 이제 참고용 주석이 아니라 활성 typed 설정입니다.
 
@@ -897,7 +901,7 @@ settings = load_settings("configs/base.yaml")
 4. **Determinism first**: any backtest logic change should ship with deterministic regression tests.
 5. **Dashboard controls**: the live dashboard exposes `pause`, `resume`, `reset`, and `stop`. `GET /api/v1/dashboard/status` still returns controller/preflight context even when no loop is active, while loop-specific endpoints continue to fail with `503` until a loop is attached.
 6. **Portfolio-level risk (`portfolio_risk`)**: optional drawdown protection supports `max_daily_drawdown_pct`, `sl_pct`, and `tp_pct`. YAML configs loaded through `config.settings.load_settings()` now parse the same block, so config examples and loader behavior are aligned.
-7. **Persistence and reconciliation**: the live loop persists `PortfolioBook` after processed live cycles and reloads it on restart. The KIS adapter queries broker balance snapshots (cash, positions, average costs) and reconciles them with the local portfolio. Symbols with pending/unresolved orders are skipped to prevent in-transit corruption, and cash is frozen when any pending order exists. YAML configs may now declare `app.reconciliation_interval`, while `TRADING_SYSTEM_RECONCILIATION_INTERVAL` remains the runtime env override for the live loop.
+7. **Persistence and reconciliation**: the live loop persists `PortfolioBook` after processed live cycles and reloads it on restart. The KIS adapter queries open-order snapshots first, then broker balance snapshots (cash, positions, average costs), and reconciles them with the local portfolio. Symbols with pending/unresolved orders are skipped to prevent in-transit corruption, and cash is frozen when any pending order exists. YAML configs may now declare `app.reconciliation_interval`, while `TRADING_SYSTEM_RECONCILIATION_INTERVAL` remains the runtime env override for the live loop.
 8. **KRX market hours guard**: live order submission (`--live-execution live`) is blocked outside KRX trading hours (weekdays 09:00-15:30 KST). Preflight mode reports `market_closed` as a structured reason but does not block.
 9. **Structured preflight readiness**: `/api/v1/live/preflight` returns a structured result with `ready`, `reasons`, `blocking_reasons`, `warnings`, readiness `checks`, per-symbol `symbol_checks`, `next_allowed_actions`, `quote_summary` for the primary symbol, and `quote_summaries`/`symbol_count` for multi-symbol detail instead of a plain message.
 
@@ -909,7 +913,7 @@ settings = load_settings("configs/base.yaml")
 4. **결정성 우선**: 백테스트 로직 변경 시 결정성 회귀 테스트를 함께 추가하세요.
 5. **대시보드 제어**: 라이브 대시보드는 `pause`, `resume`, `reset`, `stop`을 공식 지원합니다. `GET /api/v1/dashboard/status`는 활성 루프가 없어도 controller/preflight 문맥을 반환하고, 루프 의존 엔드포인트만 활성 루프가 없을 때 `503`을 반환합니다.
 6. **포트폴리오 레벨 리스크 (`portfolio_risk`)**: `max_daily_drawdown_pct`, `sl_pct`, `tp_pct`를 지원하며, 이제 `config.settings.load_settings()` YAML 로더도 같은 블록을 파싱하므로 설정 예시와 로더 동작이 일치합니다.
-7. **영속화와 대사(Reconciliation)**: 라이브 루프는 처리된 라이브 사이클 이후 `PortfolioBook`을 저장하고 재시작 시 다시 로드합니다. KIS 어댑터는 브로커 잔고 스냅샷(현금, 포지션, 평균단가)을 조회하여 로컬 포트폴리오와 대사합니다. 미체결 주문이 있는 심볼은 건너뛰어 인트랜짓 데이터 손상을 방지하며, 미체결 주문 존재 시 현금도 동결됩니다. YAML 설정에서는 `app.reconciliation_interval`을 선언할 수 있고, 런타임에서는 `TRADING_SYSTEM_RECONCILIATION_INTERVAL` 환경변수가 여전히 우선 override 역할을 합니다.
+7. **영속화와 대사(Reconciliation)**: 라이브 루프는 처리된 라이브 사이클 이후 `PortfolioBook`을 저장하고 재시작 시 다시 로드합니다. KIS 어댑터는 미체결 주문 스냅샷을 먼저 조회한 뒤 브로커 잔고 스냅샷(현금, 포지션, 평균단가)을 조회하여 로컬 포트폴리오와 대사합니다. 미체결 주문이 있는 심볼은 건너뛰어 인트랜짓 데이터 손상을 방지하며, 미체결 주문 존재 시 현금도 동결됩니다. YAML 설정에서는 `app.reconciliation_interval`을 선언할 수 있고, 런타임에서는 `TRADING_SYSTEM_RECONCILIATION_INTERVAL` 환경변수가 여전히 우선 override 역할을 합니다.
 8. **KRX 장시간 가드**: 라이브 실주문(`--live-execution live`)은 KRX 거래 시간(평일 09:00-15:30 KST) 외에는 차단됩니다. Preflight 모드는 `market_closed`를 구조화 사유로 보고하지만 차단하지 않습니다.
 9. **구조화된 프리플라이트 결과**: `/api/v1/live/preflight`는 단순 메시지 대신 `ready`, `reasons`, `blocking_reasons`, `warnings`, readiness `checks`, 심볼별 `symbol_checks`, `next_allowed_actions`, 대표 심볼용 `quote_summary`, 그리고 다중 심볼 세부 상태용 `quote_summaries`/`symbol_count` 필드가 포함된 구조화된 결과를 반환합니다.
 

--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -22,6 +22,11 @@ backtest:
   fee_bps: 5.0
   trade_quantity: 0.1
 
+# Optional strategy configuration. Use either profile_id or inline pattern_signal fields.
+strategy:
+  type: pattern_signal
+  profile_id: sample_bullish_profile
+
 # Portfolio-level risk controls (optional).
 # When set, the runtime enforces drawdown protection and optional SL/TP exits.
 #

--- a/docs/architecture/overview.ko.md
+++ b/docs/architecture/overview.ko.md
@@ -31,6 +31,7 @@
 - 포트폴리오 상태는 라이브 세션 재시작 복구를 위해 `book.json`에 저장되며, 백테스트 런, run metadata, 대시보드 equity 이력, live runtime session history는 `DATABASE_URL` 유무에 따라 파일 기반 또는 Supabase PostgreSQL 기반으로 영속화된다.
 - 백테스트 런은 provider, broker, strategy profile, pattern set, source, notes 같은 운영 메타데이터를 함께 저장한다.
 - 백테스트 실행은 API-owned dispatcher를 통해 `queued`/`running`/terminal 상태로 관리되며, dispatcher 상태와 queue depth를 API에서 조회할 수 있다.
-- 주문 생성, 체결, 거절, 리스크 거절은 backtest run 또는 live session owner 기준의 durable order audit record로 저장하고 조회할 수 있다.
+- 주문 생성, 체결, 거절, 리스크 거절은 backtest run 또는 live session owner 기준의 durable order audit record로 저장하고 조회/export할 수 있으며, broker order id가 있으면 감사 record에 보존된다.
+- KIS reconciliation은 미체결/open-order snapshot을 pending authority로 우선 사용하고, 해당 capability가 없을 때만 잔고 스냅샷의 pending signal로 fallback한다.
 - 저장소 기반 API key는 disabled 상태와 last-used 추적 같은 기본 거버넌스 필드를 가진다.
 - 선택된 런타임 이벤트는 bounded worker 기반 webhook 알림으로 외부에 전달할 수 있다.

--- a/docs/architecture/overview.ko.md
+++ b/docs/architecture/overview.ko.md
@@ -30,5 +30,7 @@
 - 라이브 트레이딩은 상태 제어(`AppRunnerState`), heartbeat 로깅, 정상 종료를 포함한 `LiveTradingLoop`로 관리된다.
 - 포트폴리오 상태는 라이브 세션 재시작 복구를 위해 `book.json`에 저장되며, 백테스트 런, run metadata, 대시보드 equity 이력, live runtime session history는 `DATABASE_URL` 유무에 따라 파일 기반 또는 Supabase PostgreSQL 기반으로 영속화된다.
 - 백테스트 런은 provider, broker, strategy profile, pattern set, source, notes 같은 운영 메타데이터를 함께 저장한다.
+- 백테스트 실행은 API-owned dispatcher를 통해 `queued`/`running`/terminal 상태로 관리되며, dispatcher 상태와 queue depth를 API에서 조회할 수 있다.
+- 주문 생성, 체결, 거절, 리스크 거절은 backtest run 또는 live session owner 기준의 durable order audit record로 저장하고 조회할 수 있다.
 - 저장소 기반 API key는 disabled 상태와 last-used 추적 같은 기본 거버넌스 필드를 가진다.
 - 선택된 런타임 이벤트는 bounded worker 기반 webhook 알림으로 외부에 전달할 수 있다.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -30,5 +30,7 @@ Current implementation note:
 - Live trading is managed by `LiveTradingLoop` with state control (`AppRunnerState`), heartbeat logging, and graceful shutdown.
 - Portfolio state persists locally via `book.json`, while backtest runs, run metadata, dashboard equity history, and live runtime session history persist through file-based storage or Supabase-backed PostgreSQL depending on `DATABASE_URL`.
 - Backtest runs carry operator metadata such as provider, broker, strategy profile, pattern set, source, and optional notes.
+- Backtest execution is owned by an API dispatcher with `queued`/`running`/terminal states, and dispatcher status plus queue depth are queryable through the API.
+- Order creation, fills, rejections, and risk rejections can be stored and queried as durable order audit records owned by a backtest run or live session.
 - Repository-managed API keys expose governance fields such as disabled state and last-used tracking.
 - Webhook notifications provide bounded fire-and-forget outbound delivery for selected runtime events.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -31,6 +31,7 @@ Current implementation note:
 - Portfolio state persists locally via `book.json`, while backtest runs, run metadata, dashboard equity history, and live runtime session history persist through file-based storage or Supabase-backed PostgreSQL depending on `DATABASE_URL`.
 - Backtest runs carry operator metadata such as provider, broker, strategy profile, pattern set, source, and optional notes.
 - Backtest execution is owned by an API dispatcher with `queued`/`running`/terminal states, and dispatcher status plus queue depth are queryable through the API.
-- Order creation, fills, rejections, and risk rejections can be stored and queried as durable order audit records owned by a backtest run or live session.
+- Order creation, fills, rejections, and risk rejections can be stored, queried, and exported as durable order audit records owned by a backtest run or live session. Broker order ids are preserved when available.
+- KIS reconciliation uses open-order snapshots as the preferred pending-order authority and falls back to balance-snapshot pending signals only when the capability is unavailable.
 - Repository-managed API keys expose governance fields such as disabled state and last-used tracking.
 - Webhook notifications provide bounded fire-and-forget outbound delivery for selected runtime events.

--- a/docs/architecture/user-use-cases.ko.md
+++ b/docs/architecture/user-use-cases.ko.md
@@ -36,6 +36,9 @@ API/프론트엔드 사용자는 Python 모듈을 직접 다루지 않고도 HTT
 | --- | --- | --- |
 | `trading_system.app.main` | CLI에서 백테스트 또는 라이브 실행 | 운영자, 개발자 |
 | `/api/v1/backtests` | 결정적 백테스트를 시작하고 실행 결과 조회 | 프론트엔드, API 클라이언트 |
+| `/api/v1/backtests/dispatcher` | 백테스트 dispatcher worker와 queue 상태 조회 | 운영자 |
+| `/api/v1/backtests/retention/*` | 오래된 run 기록 preview/prune | 운영자, 통합 담당자 |
+| `/api/v1/order-audit` | backtest run 또는 live session 기준 주문 감사 record 조회 | 운영자, 리서처 |
 | `/api/v1/live/preflight` | 라이브 실행 전 또는 실행 모드 선택 시 런타임 경로 검증 | 운영자, 통합 담당자 |
 | `/api/v1/live/runtime/sessions` | 최근 live runtime session history 조회 | 운영자, 통합 담당자 |
 | `/api/v1/patterns` | 패턴 세트 학습, 저장, 목록 조회, 상세 조회 | 리서처 |
@@ -53,6 +56,7 @@ API/프론트엔드 사용자는 Python 모듈을 직접 다루지 않고도 HTT
 | 포트폴리오 스냅샷 | `data/portfolio/book.json` | 라이브 세션 재시작 시 복구 가능한 포트폴리오 상태 |
 | 백테스트 실행 결과 + metadata | 파일 저장소 또는 Supabase PostgreSQL | durable한 실행 조회, 운영 문맥, 애널리틱스 |
 | 라이브 runtime session history | 파일 저장소 또는 Supabase PostgreSQL | 최근 라이브 세션 조회와 사후 검토 |
+| 주문 감사 record | 파일 저장소 또는 Supabase PostgreSQL | run/session owner 기준 주문 생성, 체결, 거절, 리스크 거절 조회 |
 | 프론트엔드 실행 이력 fallback | 브라우저 로컬 스토리지 | 백엔드가 내려간 경우를 위한 보조 캐시 |
 
 ## 5. 엔드 투 엔드 사용자 여정
@@ -159,14 +163,15 @@ API/프론트엔드 사용자는 Python 모듈을 직접 다루지 않고도 HTT
   4. 각 bar는 통합 실행 스텝을 통과한다.
      strategy evaluation -> signal -> order mapping -> risk check -> broker fill -> portfolio update
   5. equity point, order, signal, risk rejection 이벤트를 수집한다.
-  6. API는 완료된 실행 결과를 현재 설정된 run repository에 저장하고 `succeeded`를 반환한다.
+  6. 주문 생성/체결/거절/리스크 거절은 run owner 기준 order audit record로 저장된다.
+  7. API dispatcher는 실행 상태를 `queued`, `running`, `succeeded` 또는 `failed`로 저장한다.
 - 산출물:
   - 수익률 요약 지표
   - equity curve
   - drawdown curve
   - signal, order, rejection 이벤트 스트림
 - 현재 제약:
-  - API는 백테스트를 백그라운드 작업이 아니라 동기 방식으로 실행한다
+  - API는 내부 dispatcher로 백테스트를 실행하지만, 외부 queue 서비스나 분산 worker는 아직 없다
   - 영속화 방식은 배포 설정에 따라 달라진다: 기본은 파일 기반, `DATABASE_URL` 설정 시 Supabase 기반
   - 프론트엔드의 새 실행 화면은 단일 심볼 입력만 받지만, 내부 백테스트 엔진은 다중 심볼 처리도 가능하다
   - 현재 CLI 경로에는 pattern profile 선택용 플래그가 노출되어 있지 않다
@@ -340,12 +345,11 @@ API/프론트엔드 사용자는 Python 모듈을 직접 다루지 않고도 HTT
 
 사용자가 감안해야 할 주요 갭은 다음과 같습니다.
 
-- 장시간 백테스트를 위한 비동기 job queue가 없음
+- 장시간 백테스트를 위한 외부 queue/분산 worker 모델이 없음
 - 공유 API key 검증 외의 다중 사용자 auth 모델이 없음
-- 고급 주문 수명주기 대시보드가 없음
+- 고급 주문 수명주기 대시보드와 broker별 미체결 주문 제어가 없음
 - 전략 마켓플레이스, 승인 워크플로, 승격 파이프라인이 없음
-- 프론트엔드에서 라이브 실행을 직접 시작하는 흐름이 없음
-- 현재 structured log와 analytics endpoint를 넘어서는 내장 감사/리포팅 패키지가 없음
+- 현재 order audit 조회를 넘어서는 내장 감사 리포팅/export 패키지가 없음
 
 ## 9. 권장 후속 문서
 

--- a/docs/architecture/user-use-cases.ko.md
+++ b/docs/architecture/user-use-cases.ko.md
@@ -39,6 +39,7 @@ API/프론트엔드 사용자는 Python 모듈을 직접 다루지 않고도 HTT
 | `/api/v1/backtests/dispatcher` | 백테스트 dispatcher worker와 queue 상태 조회 | 운영자 |
 | `/api/v1/backtests/retention/*` | 오래된 run 기록 preview/prune | 운영자, 통합 담당자 |
 | `/api/v1/order-audit` | backtest run 또는 live session 기준 주문 감사 record 조회 | 운영자, 리서처 |
+| `/api/v1/order-audit/export` | owner/time/status/broker id 기준 주문 감사 CSV/JSONL export | 운영자, 통합 담당자 |
 | `/api/v1/live/preflight` | 라이브 실행 전 또는 실행 모드 선택 시 런타임 경로 검증 | 운영자, 통합 담당자 |
 | `/api/v1/live/runtime/sessions` | 최근 live runtime session history 조회 | 운영자, 통합 담당자 |
 | `/api/v1/patterns` | 패턴 세트 학습, 저장, 목록 조회, 상세 조회 | 리서처 |
@@ -174,7 +175,7 @@ API/프론트엔드 사용자는 Python 모듈을 직접 다루지 않고도 HTT
   - API는 내부 dispatcher로 백테스트를 실행하지만, 외부 queue 서비스나 분산 worker는 아직 없다
   - 영속화 방식은 배포 설정에 따라 달라진다: 기본은 파일 기반, `DATABASE_URL` 설정 시 Supabase 기반
   - 프론트엔드의 새 실행 화면은 단일 심볼 입력만 받지만, 내부 백테스트 엔진은 다중 심볼 처리도 가능하다
-  - 현재 CLI 경로에는 pattern profile 선택용 플래그가 노출되어 있지 않다
+  - CLI 경로는 `--strategy-profile-id`와 `--config`로 저장된 pattern strategy profile을 선택할 수 있다
 
 ### UC-05. 백테스트 결과 및 거래 애널리틱스 검토
 
@@ -349,7 +350,7 @@ API/프론트엔드 사용자는 Python 모듈을 직접 다루지 않고도 HTT
 - 공유 API key 검증 외의 다중 사용자 auth 모델이 없음
 - 고급 주문 수명주기 대시보드와 broker별 미체결 주문 제어가 없음
 - 전략 마켓플레이스, 승인 워크플로, 승격 파이프라인이 없음
-- 현재 order audit 조회를 넘어서는 내장 감사 리포팅/export 패키지가 없음
+- 내장 order audit export는 bounded CSV/JSONL 응답이며, 대량 비동기 export pipeline은 없음
 
 ## 9. 권장 후속 문서
 

--- a/docs/architecture/user-use-cases.md
+++ b/docs/architecture/user-use-cases.md
@@ -36,6 +36,9 @@ The integrator connects the workspace to infrastructure, configures API keys/COR
 | --- | --- | --- |
 | `trading_system.app.main` | Run backtest or live execution from CLI | Operator, developer |
 | `/api/v1/backtests` | Start deterministic backtest and fetch run result | Frontend, API client |
+| `/api/v1/backtests/dispatcher` | Inspect backtest dispatcher worker and queue state | Operator |
+| `/api/v1/backtests/retention/*` | Preview and prune old run records | Operator, integrator |
+| `/api/v1/order-audit` | Query order audit records by backtest run or live session | Operator, researcher |
 | `/api/v1/live/preflight` | Validate live runtime path before or during execution mode selection | Operator, integrator |
 | `/api/v1/live/runtime/sessions` | Inspect recent live runtime session history | Operator, integrator |
 | `/api/v1/patterns` | Train, save, list, and inspect pattern sets | Researcher |
@@ -53,6 +56,7 @@ The integrator connects the workspace to infrastructure, configures API keys/COR
 | Portfolio snapshot | `data/portfolio/book.json` | Restart-safe live portfolio state |
 | Backtest run result + metadata | File repository or Supabase-backed PostgreSQL | Durable run lookup, review context, and analytics |
 | Live runtime session history | File repository or Supabase-backed PostgreSQL | Recent live session lookup and post-run review |
+| Order audit records | File repository or Supabase-backed PostgreSQL | Query order creation, fills, rejections, and risk rejections by run/session owner |
 | Frontend run history fallback | Browser local storage | Fallback cache when the backend is unavailable |
 
 ## 5. End-to-end user journey
@@ -159,14 +163,15 @@ The intended high-value workflow today is:
   4. Each bar runs through the unified execution step:
      strategy evaluation -> signal -> order mapping -> risk check -> broker fill -> portfolio update.
   5. Equity points, orders, signals, and risk rejections are collected.
-  6. The API stores the finished run in the configured run repository and returns `succeeded`.
+  6. Order creation, fills, rejections, and risk rejections are stored as order audit records owned by the run.
+  7. The API dispatcher stores the run as `queued`, `running`, `succeeded`, or `failed`.
 - Outputs:
   - summary return metrics
   - equity curve
   - drawdown curve
   - signal, order, and rejection event streams
 - Current constraints:
-  - the API executes backtests synchronously rather than as background jobs
+  - the API executes backtests through an internal dispatcher, but there is no external queue service or distributed worker model yet
   - persistence depends on deployment configuration: file-backed by default, Supabase-backed when `DATABASE_URL` is set
   - the frontend new-run page accepts a single symbol input even though backtest internals can handle multiple symbols
   - the CLI path does not currently expose pattern-profile selection flags
@@ -340,12 +345,11 @@ The current implementation is strong for research, controlled paper trading, and
 
 Key gaps users must account for:
 
-- no asynchronous job queue for long-running backtests
+- no external queue/distributed worker model for long-running backtests
 - no multi-user auth model beyond shared API key validation
-- no advanced order lifecycle dashboard
+- no advanced order lifecycle dashboard or broker-specific unresolved-order controls
 - no strategy marketplace, approval workflow, or promotion pipeline
-- no direct frontend flow for starting live execution
-- no built-in audit/reporting package beyond current structured logs and analytics endpoints
+- no built-in audit reporting/export package beyond current order-audit queries, structured logs, and analytics endpoints
 
 ## 9. Recommended documentation follow-ups
 

--- a/docs/architecture/user-use-cases.md
+++ b/docs/architecture/user-use-cases.md
@@ -39,6 +39,7 @@ The integrator connects the workspace to infrastructure, configures API keys/COR
 | `/api/v1/backtests/dispatcher` | Inspect backtest dispatcher worker and queue state | Operator |
 | `/api/v1/backtests/retention/*` | Preview and prune old run records | Operator, integrator |
 | `/api/v1/order-audit` | Query order audit records by backtest run or live session | Operator, researcher |
+| `/api/v1/order-audit/export` | Export order audit records by owner/time/status/broker id as CSV or JSONL | Operator, integrator |
 | `/api/v1/live/preflight` | Validate live runtime path before or during execution mode selection | Operator, integrator |
 | `/api/v1/live/runtime/sessions` | Inspect recent live runtime session history | Operator, integrator |
 | `/api/v1/patterns` | Train, save, list, and inspect pattern sets | Researcher |
@@ -349,7 +350,7 @@ Key gaps users must account for:
 - no multi-user auth model beyond shared API key validation
 - no advanced order lifecycle dashboard or broker-specific unresolved-order controls
 - no strategy marketplace, approval workflow, or promotion pipeline
-- no built-in audit reporting/export package beyond current order-audit queries, structured logs, and analytics endpoints
+- built-in order audit export is a bounded CSV/JSONL response, not a large asynchronous export pipeline
 
 ## 9. Recommended documentation follow-ups
 

--- a/docs/architecture/workspace-analysis.ko.md
+++ b/docs/architecture/workspace-analysis.ko.md
@@ -14,7 +14,7 @@
 - `backtest.engine.run_backtest`는 결정적 재생, 이벤트 수집, equity 추적, 다중 심볼 처리를 오케스트레이션합니다.
 - `api.server`는 API key, CORS, rate-limit 미들웨어 뒤에 백테스트, dispatcher 상태, retention preview/prune, order audit, 라이브 preflight, live runtime session history, 패턴, 전략, 애널리틱스, admin 키 관리, `/health`, 대시보드 라우트를 노출합니다.
 - `frontend/app/*`는 백테스트 실행, 패턴 관리, 전략 프로필, 실행 결과 검토, API key 관리, 라이브 대시보드 모니터링, 최근 live session 탐색을 위한 브라우저 워크플로를 제공하며, run review 화면은 이제 서버 저장 metadata를 함께 표시합니다.
-- `execution.reconciliation.reconcile`은 브로커가 잔고 스냅샷을 제공하는 경우 로컬 `PortfolioBook`을 브로커 상태와 맞출 수 있습니다.
+- `execution.reconciliation.reconcile`은 브로커가 잔고 스냅샷을 제공하는 경우 로컬 `PortfolioBook`을 브로커 상태와 맞출 수 있으며, live loop는 KIS open-order snapshot을 pending 판단의 우선 근거로 사용합니다.
 - `notifications.webhook`은 선택된 런타임 이벤트를 `httpx` 기반 bounded worker로 외부 webhook에 전달합니다.
 
 ## 레이어 분석
@@ -51,7 +51,7 @@
 - `strategy.factory`는 inline 전략 설정이나 `configs/strategies`에 저장된 전략 프로필을 해석합니다.
 
 현재 한계:
-- 일반화된 전략 플러그인 레지스트리와 저장된 전략 프로필을 선택하는 직접적인 CLI 플래그는 아직 없습니다.
+- 일반화된 전략 플러그인 레지스트리는 아직 없지만, 저장된 전략 프로필은 API/UI뿐 아니라 CLI `--strategy-profile-id`와 YAML `strategy.profile_id`로 선택할 수 있습니다.
 
 ### Risk
 
@@ -75,7 +75,7 @@
 - 브로커 잔고 스냅샷 기반 reconciliation helper
 
 현재 한계:
-- 주문 생성/체결/거절/리스크 거절은 durable order audit record로 저장할 수 있지만, KIS reconciliation은 아직 전용 unresolved-order API가 아니라 잔고 스냅샷의 pending-order 신호에 의존합니다.
+- 주문 생성/체결/거절/리스크 거절은 durable order audit record로 저장하고 CSV/JSONL로 export할 수 있습니다. KIS reconciliation은 전용 open-order snapshot을 우선 사용하지만, broker 응답 품질이 불충분하면 fail-closed로 대사를 건너뜁니다.
 
 ### Portfolio
 
@@ -139,7 +139,7 @@
 
 참고:
 
-- `configs/base.yaml`과 `examples/sample_live_kis.yaml`은 이제 `portfolio_risk`와 `app.reconciliation_interval`에 대한 활성 typed 예시를 포함합니다.
+- `configs/base.yaml`과 `examples/sample_live_kis.yaml`은 이제 `portfolio_risk`, `app.reconciliation_interval`, `strategy.profile_id`에 대한 활성 typed 예시를 포함합니다.
 - 전략 프로필과 패턴 세트 저장은 데이터베이스가 아니라 파일 기반입니다.
 
 ## 테스트 커버리지 스냅샷
@@ -155,13 +155,13 @@
 
 1. **분산 실행 모델**: 백테스트는 내부 dispatcher로 분리되었지만, 긴 실행을 여러 worker나 외부 queue로 분산하는 모델은 아직 없습니다.
 2. **Session history UX**: 최근 live runtime session은 dashboard에서 볼 수 있지만, 장기 검색과 export는 아직 없습니다.
-3. **Config parity**: 전략 선택과 일부 런타임 전용 필드는 아직 typed YAML loader에 완전히 반영되지 않았습니다.
-4. **Exchange snapshot integration**: 일반 reconciliation 경로와 KIS balance snapshot은 연결되었지만, pending-order authority는 아직 전용 unresolved-order API가 아니라 잔고 스냅샷 신호에 의존합니다.
+3. **Config parity**: 전략 프로필 선택은 CLI/YAML/API에 정렬되었지만, UI에서 YAML 전체를 편집하는 워크플로는 없습니다.
+4. **Exchange snapshot integration**: KIS open-order snapshot은 pending authority로 연결되었지만, 주문 취소/정정과 장기 order polling worker는 아직 없습니다.
 5. **Operational hardening**: 저장소 기반 API key는 disabled/last-used 추적을 지원하지만, 더 강한 auth, alerting, audit export, deployment guidance는 아직 완전 관리형 트레이딩 플랫폼 수준은 아닙니다.
 
 ## 권장 다음 백로그
 
 1. 외부 queue/worker 모델과 장시간 백테스트 운영 가시성을 강화합니다.
 2. 과거 live runtime session과 incident의 장기 검색/export 워크플로를 추가합니다.
-3. 특히 KIS를 포함한 브로커 연동에서 reconciliation용 unresolved/open-order source를 더 강하게 만듭니다.
-4. 추가 전략 런타임 설정을 YAML의 1급 필드로 만들지, API/runtime 전용으로 유지할지 결정합니다.
+3. KIS open-order source를 기반으로 한 주문 취소/정정 또는 장기 order polling workflow를 검토합니다.
+4. YAML 전체를 UI에서 관리할지, 파일 기반 운영자 워크플로로 유지할지 결정합니다.

--- a/docs/architecture/workspace-analysis.ko.md
+++ b/docs/architecture/workspace-analysis.ko.md
@@ -12,8 +12,8 @@
 - `app.services`는 전략 저장소, 패턴 저장소, 데이터 provider, 브로커 어댑터, 리스크 제어, 포트폴리오 영속화, 라이브 preflight 검사를 조립합니다.
 - `execution.step.execute_trading_step`은 백테스트와 라이브 런타임이 공통으로 사용하는 실행 코어입니다.
 - `backtest.engine.run_backtest`는 결정적 재생, 이벤트 수집, equity 추적, 다중 심볼 처리를 오케스트레이션합니다.
-- `api.server`는 API key, CORS, rate-limit 미들웨어 뒤에 백테스트, 라이브 preflight, live runtime session history, 패턴, 전략, 애널리틱스, admin 키 관리, `/health`, 대시보드 라우트를 노출합니다.
-- `frontend/app/*`는 백테스트 실행, 패턴 관리, 전략 프로필, 실행 결과 검토, API key 관리, 라이브 대시보드 모니터링을 위한 브라우저 워크플로를 제공하며, run review 화면은 이제 서버 저장 metadata를 함께 표시합니다.
+- `api.server`는 API key, CORS, rate-limit 미들웨어 뒤에 백테스트, dispatcher 상태, retention preview/prune, order audit, 라이브 preflight, live runtime session history, 패턴, 전략, 애널리틱스, admin 키 관리, `/health`, 대시보드 라우트를 노출합니다.
+- `frontend/app/*`는 백테스트 실행, 패턴 관리, 전략 프로필, 실행 결과 검토, API key 관리, 라이브 대시보드 모니터링, 최근 live session 탐색을 위한 브라우저 워크플로를 제공하며, run review 화면은 이제 서버 저장 metadata를 함께 표시합니다.
 - `execution.reconciliation.reconcile`은 브로커가 잔고 스냅샷을 제공하는 경우 로컬 `PortfolioBook`을 브로커 상태와 맞출 수 있습니다.
 - `notifications.webhook`은 선택된 런타임 이벤트를 `httpx` 기반 bounded worker로 외부 webhook에 전달합니다.
 
@@ -29,7 +29,7 @@
 - 대시보드 API는 이제 `LiveRuntimeController`를 통해 단일 live loop를 직접 시작하고 소유하며, 최근 session history도 durable하게 남깁니다.
 
 현재 한계:
-- live session history는 durable하고 API로 조회 가능하지만, 과거 세션을 전용으로 탐색하는 프런트엔드 화면은 아직 없습니다.
+- live session history는 dashboard의 최근 세션 패널에서 탐색 가능하지만, 장기 검색/필터/내보내기 전용 화면은 아직 없습니다.
 
 ### Data
 
@@ -75,7 +75,7 @@
 - 브로커 잔고 스냅샷 기반 reconciliation helper
 
 현재 한계:
-- durable order lifecycle store가 없고, KIS reconciliation은 아직 전용 unresolved-order API가 아니라 잔고 스냅샷의 pending-order 신호에 의존합니다.
+- 주문 생성/체결/거절/리스크 거절은 durable order audit record로 저장할 수 있지만, KIS reconciliation은 아직 전용 unresolved-order API가 아니라 잔고 스냅샷의 pending-order 신호에 의존합니다.
 
 ### Portfolio
 
@@ -99,7 +99,7 @@
 - API는 완료된 실행 결과를 provider/broker/strategy/source 같은 metadata와 함께 저장해 이후 조회 및 애널리틱스 검토에 사용합니다.
 
 현재 한계:
-- 백테스트는 여전히 요청 경로에서 동기 방식으로 실행되며, 결과와 metadata 영속화는 가능하지만 비동기 큐/잡 실행 모델은 아직 없습니다.
+- 백테스트는 API-owned dispatcher로 `queued`/`running` 상태를 거쳐 실행되며 결과와 metadata가 영속화됩니다. 다만 외부 queue 서비스나 분산 worker 모델은 아직 없습니다.
 
 ### Analytics
 
@@ -153,15 +153,15 @@
 
 ## 더 넓은 프로덕션 사용 전 남은 갭
 
-1. **비동기 실행 모델**: 백테스트 결과와 metadata 영속화는 가능해졌지만, 긴 실행은 여전히 요청 경로에서 동기적으로 수행됩니다.
-2. **Session history UX**: live runtime session history는 durable하고 API로 조회 가능하지만, 과거 세션을 전용으로 탐색하는 브라우저 워크플로는 아직 없습니다.
+1. **분산 실행 모델**: 백테스트는 내부 dispatcher로 분리되었지만, 긴 실행을 여러 worker나 외부 queue로 분산하는 모델은 아직 없습니다.
+2. **Session history UX**: 최근 live runtime session은 dashboard에서 볼 수 있지만, 장기 검색과 export는 아직 없습니다.
 3. **Config parity**: 전략 선택과 일부 런타임 전용 필드는 아직 typed YAML loader에 완전히 반영되지 않았습니다.
 4. **Exchange snapshot integration**: 일반 reconciliation 경로와 KIS balance snapshot은 연결되었지만, pending-order authority는 아직 전용 unresolved-order API가 아니라 잔고 스냅샷 신호에 의존합니다.
 5. **Operational hardening**: 저장소 기반 API key는 disabled/last-used 추적을 지원하지만, 더 강한 auth, alerting, audit export, deployment guidance는 아직 완전 관리형 트레이딩 플랫폼 수준은 아닙니다.
 
 ## 권장 다음 백로그
 
-1. 비동기 실행 모델, 보존(retention) 제어, 장시간 백테스트에 대한 운영 가시성을 강화합니다.
-2. 과거 live runtime session과 incident를 탐색하는 전용 브라우저 워크플로를 추가합니다.
+1. 외부 queue/worker 모델과 장시간 백테스트 운영 가시성을 강화합니다.
+2. 과거 live runtime session과 incident의 장기 검색/export 워크플로를 추가합니다.
 3. 특히 KIS를 포함한 브로커 연동에서 reconciliation용 unresolved/open-order source를 더 강하게 만듭니다.
 4. 추가 전략 런타임 설정을 YAML의 1급 필드로 만들지, API/runtime 전용으로 유지할지 결정합니다.

--- a/docs/architecture/workspace-analysis.md
+++ b/docs/architecture/workspace-analysis.md
@@ -14,7 +14,7 @@ Implemented behavior today:
 - `backtest.engine.run_backtest` orchestrates deterministic replay, event capture, equity tracking, and multi-symbol processing.
 - `api.server` exposes backtests, dispatcher status, retention preview/prune, order audit, live preflight, live runtime session history, patterns, strategies, analytics, admin key management, `/health`, and dashboard routes behind API key, CORS, and rate-limit middleware.
 - `frontend/app/*` provides browser workflows for backtest submission, pattern management, strategy profiles, run review, API key administration, live dashboard monitoring, and recent live session browsing, now with server-sourced run metadata shown in the review surface.
-- `execution.reconciliation.reconcile` can align a local `PortfolioBook` with broker snapshots when the broker supports balance snapshots.
+- `execution.reconciliation.reconcile` can align a local `PortfolioBook` with broker snapshots when the broker supports balance snapshots, and the live loop uses KIS open-order snapshots as the preferred pending-order authority.
 - `notifications.webhook` provides bounded fire-and-forget delivery for selected runtime events through `httpx`.
 
 ## Layer analysis
@@ -51,7 +51,7 @@ The strategy layer now supports both example and repository-backed flows:
 - `strategy.factory` resolves inline strategy settings or saved strategy profiles backed by `configs/strategies`
 
 Current limitation:
-- There is still no general strategy plugin registry or direct CLI flag set for selecting saved strategy profiles.
+- There is still no general strategy plugin registry, but saved strategy profiles can now be selected through the API/UI, CLI `--strategy-profile-id`, or YAML `strategy.profile_id`.
 
 ### Risk
 
@@ -75,7 +75,7 @@ Execution now has explicit, reusable boundaries:
 - reconciliation helper for broker balance snapshots
 
 Current limitation:
-- Order creation, fill, rejection, and risk-rejection events can be stored as durable order audit records, but KIS reconciliation still depends on balance-snapshot pending-order signals rather than a dedicated unresolved-order API.
+- Order creation, fill, rejection, and risk-rejection events can be stored and exported as durable order audit records. KIS reconciliation now prefers dedicated open-order snapshots and skips fail-closed when that source is unavailable or malformed.
 
 ### Portfolio
 
@@ -139,7 +139,7 @@ Examples and operator artifacts include:
 
 Notes:
 
-- `configs/base.yaml` and `examples/sample_live_kis.yaml` now contain active typed examples for `portfolio_risk` and `app.reconciliation_interval`.
+- `configs/base.yaml` and `examples/sample_live_kis.yaml` now contain active typed examples for `portfolio_risk`, `app.reconciliation_interval`, and `strategy.profile_id`.
 - Strategy/profile and pattern-set storage is file backed, not database backed.
 
 ## Test coverage snapshot
@@ -155,13 +155,13 @@ This gives a strong regression baseline for deterministic replay, runtime valida
 
 1. **Distributed run execution**: backtests are separated through the internal dispatcher, but there is still no external queue or multi-worker model for long-running workloads.
 2. **Session history UX**: recent live runtime sessions are visible in the dashboard, but long-term search and export are not yet implemented.
-3. **Config parity**: strategy selection and some runtime-only fields are still not fully represented in the typed YAML loader.
-4. **Exchange snapshot integration**: generic reconciliation exists and KIS balance snapshots are wired, but pending-order authority still depends on balance-snapshot signals rather than a dedicated unresolved-order API.
+3. **Config parity**: strategy profile selection is aligned across CLI/YAML/API, but there is still no UI workflow for editing a full YAML runtime config.
+4. **Exchange snapshot integration**: KIS open-order snapshots are wired as pending authority, but cancel/replace and long-running order polling workflows are still not implemented.
 5. **Operational hardening**: repository-managed API keys now track disabled/last-used state, but richer auth, alerting, audit export, and deployment guidance are still lighter than a fully managed trading platform would require.
 
 ## Recommended next backlog
 
 1. Add an external queue/worker model and clearer operator visibility around long-running backtests.
 2. Add long-term search/export for live runtime session history and historical incident review.
-3. Improve broker integrations, especially KIS, to expose a stronger unresolved/open-order source for reconciliation.
+3. Evaluate cancel/replace or long-running order polling workflows on top of the KIS open-order source.
 4. Decide whether additional strategy runtime settings should become first-class YAML fields or remain API/runtime-only inputs.

--- a/docs/architecture/workspace-analysis.md
+++ b/docs/architecture/workspace-analysis.md
@@ -12,8 +12,8 @@ Implemented behavior today:
 - `app.services` composes strategy repositories, pattern repositories, data providers, broker adapters, risk controls, portfolio persistence, and live preflight checks.
 - `execution.step.execute_trading_step` is the shared execution core across backtest and live runtime paths.
 - `backtest.engine.run_backtest` orchestrates deterministic replay, event capture, equity tracking, and multi-symbol processing.
-- `api.server` exposes backtests, live preflight, live runtime session history, patterns, strategies, analytics, admin key management, `/health`, and dashboard routes behind API key, CORS, and rate-limit middleware.
-- `frontend/app/*` provides browser workflows for backtest submission, pattern management, strategy profiles, run review, API key administration, and live dashboard monitoring, now with server-sourced run metadata shown in the review surface.
+- `api.server` exposes backtests, dispatcher status, retention preview/prune, order audit, live preflight, live runtime session history, patterns, strategies, analytics, admin key management, `/health`, and dashboard routes behind API key, CORS, and rate-limit middleware.
+- `frontend/app/*` provides browser workflows for backtest submission, pattern management, strategy profiles, run review, API key administration, live dashboard monitoring, and recent live session browsing, now with server-sourced run metadata shown in the review surface.
 - `execution.reconciliation.reconcile` can align a local `PortfolioBook` with broker snapshots when the broker supports balance snapshots.
 - `notifications.webhook` provides bounded fire-and-forget delivery for selected runtime events through `httpx`.
 
@@ -29,7 +29,7 @@ The app layer cleanly separates CLI argument handling (`app.main`) from service 
 - The dashboard API can now start and own one live loop process through `LiveRuntimeController`, while also persisting a durable session history.
 
 Current limitation:
-- Live session history is now durable and queryable, but there is not yet a dedicated frontend history screen for browsing past sessions.
+- Recent live session history is visible in the dashboard, but long-term search, filtering, and export are not yet implemented.
 
 ### Data
 
@@ -75,7 +75,7 @@ Execution now has explicit, reusable boundaries:
 - reconciliation helper for broker balance snapshots
 
 Current limitation:
-- There is no durable order lifecycle store, and KIS reconciliation still depends on balance-snapshot pending-order signals rather than a dedicated unresolved-order API.
+- Order creation, fill, rejection, and risk-rejection events can be stored as durable order audit records, but KIS reconciliation still depends on balance-snapshot pending-order signals rather than a dedicated unresolved-order API.
 
 ### Portfolio
 
@@ -99,7 +99,7 @@ Backtest orchestration is deterministic and uses the same trading-step core as l
 - The API stores completed runs for later fetch and analytics inspection, together with provider/broker/strategy/source metadata.
 
 Current limitation:
-- Backtest runs are still executed synchronously in-request; persistence and metadata are now durable through file storage or Supabase, but there is no asynchronous queue/job runner yet.
+- Backtest runs are executed by an API-owned dispatcher with `queued` and `running` states; persistence and metadata are durable through file storage or Supabase. There is still no external queue service or distributed worker model.
 
 ### Analytics
 
@@ -153,15 +153,15 @@ This gives a strong regression baseline for deterministic replay, runtime valida
 
 ## Remaining gaps before broader production use
 
-1. **Asynchronous run execution**: backtest results and metadata are now persistable, but long-running backtests still execute synchronously inside the request path.
-2. **Session history UX**: live runtime session history is durable and queryable, but there is no first-class browser workflow for browsing historical sessions yet.
+1. **Distributed run execution**: backtests are separated through the internal dispatcher, but there is still no external queue or multi-worker model for long-running workloads.
+2. **Session history UX**: recent live runtime sessions are visible in the dashboard, but long-term search and export are not yet implemented.
 3. **Config parity**: strategy selection and some runtime-only fields are still not fully represented in the typed YAML loader.
 4. **Exchange snapshot integration**: generic reconciliation exists and KIS balance snapshots are wired, but pending-order authority still depends on balance-snapshot signals rather than a dedicated unresolved-order API.
 5. **Operational hardening**: repository-managed API keys now track disabled/last-used state, but richer auth, alerting, audit export, and deployment guidance are still lighter than a fully managed trading platform would require.
 
 ## Recommended next backlog
 
-1. Add an asynchronous run execution model, retention controls, and clearer operator visibility around long-running backtests.
-2. Add a dedicated browser workflow for live runtime session history and historical incident review.
+1. Add an external queue/worker model and clearer operator visibility around long-running backtests.
+2. Add long-term search/export for live runtime session history and historical incident review.
 3. Improve broker integrations, especially KIS, to expose a stronger unresolved/open-order source for reconciliation.
 4. Decide whether additional strategy runtime settings should become first-class YAML fields or remain API/runtime-only inputs.

--- a/docs/runbooks/deploy-production.ko.md
+++ b/docs/runbooks/deploy-production.ko.md
@@ -85,6 +85,7 @@ export DATABASE_URL="postgresql://postgres:[password]@db.[ref].supabase.co:5432/
 psql "$DATABASE_URL" -f scripts/migrations/001_create_backtest_runs.sql
 psql "$DATABASE_URL" -f scripts/migrations/002_create_equity_snapshots.sql
 psql "$DATABASE_URL" -f scripts/migrations/003_add_backtest_metadata_and_live_runtime_sessions.sql
+psql "$DATABASE_URL" -f scripts/migrations/004_add_order_audit_records.sql
 ```
 
 `psql`을 사용할 수 없는 경우 **Supabase 대시보드 SQL Editor** 에서 직접 실행한다:
@@ -92,6 +93,7 @@ psql "$DATABASE_URL" -f scripts/migrations/003_add_backtest_metadata_and_live_ru
 2. `scripts/migrations/001_create_backtest_runs.sql` 내용을 붙여 넣고 **Run** 클릭.
 3. 동일하게 `002_create_equity_snapshots.sql` 실행.
 4. 동일하게 `003_add_backtest_metadata_and_live_runtime_sessions.sql` 실행.
+5. 동일하게 `004_add_order_audit_records.sql` 실행.
 
 ### 1-4. 테이블 생성 확인
 
@@ -99,6 +101,7 @@ Supabase 대시보드 → **Table Editor** 에서 다음 두 테이블이 보여
 - `backtest_runs`
 - `equity_snapshots`
 - `live_runtime_sessions`
+- `order_audit_records`
 
 또는 SQL Editor에서 확인:
 ```sql
@@ -106,7 +109,7 @@ SELECT table_name FROM information_schema.tables
 WHERE table_schema = 'public';
 ```
 
-**Exit criteria**: `backtest_runs`, `equity_snapshots` 테이블이 존재하고, `equity_snapshots`에 `idx_equity_snapshots_session_ts` 인덱스가 생성되어 있다.
+**Exit criteria**: `backtest_runs`, `equity_snapshots`, `live_runtime_sessions`, `order_audit_records` 테이블이 존재하고, `equity_snapshots`에 `idx_equity_snapshots_session_ts` 인덱스가 생성되어 있다.
 
 ---
 

--- a/docs/runbooks/deploy-production.md
+++ b/docs/runbooks/deploy-production.md
@@ -82,6 +82,7 @@ export DATABASE_URL="postgresql://postgres:[password]@db.[ref].supabase.co:5432/
 psql "$DATABASE_URL" -f scripts/migrations/001_create_backtest_runs.sql
 psql "$DATABASE_URL" -f scripts/migrations/002_create_equity_snapshots.sql
 psql "$DATABASE_URL" -f scripts/migrations/003_add_backtest_metadata_and_live_runtime_sessions.sql
+psql "$DATABASE_URL" -f scripts/migrations/004_add_order_audit_records.sql
 ```
 
 If `psql` is unavailable, use the **Supabase dashboard SQL Editor**:
@@ -89,6 +90,7 @@ If `psql` is unavailable, use the **Supabase dashboard SQL Editor**:
 2. Paste the contents of `scripts/migrations/001_create_backtest_runs.sql` and click **Run**.
 3. Repeat for `002_create_equity_snapshots.sql`.
 4. Repeat for `003_add_backtest_metadata_and_live_runtime_sessions.sql`.
+5. Repeat for `004_add_order_audit_records.sql`.
 
 ### 1-4. Verify table creation
 
@@ -96,6 +98,7 @@ In the Supabase dashboard → **Table Editor**, confirm these tables exist:
 - `backtest_runs`
 - `equity_snapshots`
 - `live_runtime_sessions`
+- `order_audit_records`
 
 Or verify via SQL Editor:
 ```sql
@@ -103,7 +106,7 @@ SELECT table_name FROM information_schema.tables
 WHERE table_schema = 'public';
 ```
 
-**Exit criteria**: Both `backtest_runs` and `equity_snapshots` tables exist.
+**Exit criteria**: `backtest_runs`, `equity_snapshots`, `live_runtime_sessions`, and `order_audit_records` tables exist.
 `idx_equity_snapshots_session_ts` index is present on `equity_snapshots`.
 
 ---

--- a/docs/runbooks/incident-response.ko.md
+++ b/docs/runbooks/incident-response.ko.md
@@ -63,7 +63,8 @@
 1. 현재 브로커가 계좌 스냅샷을 제공하는 경로인지 먼저 확인한다.
 2. `cash_frozen` 또는 `symbol_skipped`가 발생하면 `pending_symbols`에 기록된 심볼의 체결 중 상태를 우선 확인한다.
 3. 포지션 차이가 설명되지 않으면 루프를 `pause`한 뒤 로컬 `PortfolioBook`과 브로커 상태를 수동 대조한다.
-4. 현재 KIS 어댑터는 계좌 잔고 스냅샷을 제공한다. KIS 환경에서 자동 동기화가 건너뛰어졌다면, 우선 pending-order 신호가 누락되었거나 불완전한지부터 확인한다.
+4. 현재 KIS 어댑터는 미체결/open-order snapshot을 먼저 조회하고, 잔고 스냅샷을 이어서 조회한다. `pending_source=open_orders` 상태에서 건너뛰었다면 broker order id 기준으로 `/api/v1/order-audit/export` 결과와 KIS 주문 내역을 대조한다.
+5. open-order 조회 실패로 `portfolio.reconciliation.skipped`가 발생하면 포트폴리오를 자동 보정하지 않는다. KIS 응답 필드, TR ID, 네트워크 상태를 먼저 확인한다.
 
 ## 시크릿 운영 원칙
 

--- a/docs/runbooks/incident-response.md
+++ b/docs/runbooks/incident-response.md
@@ -71,7 +71,8 @@ Response:
 1. First confirm that the active broker path actually provides account balance snapshots.
 2. If `cash_frozen` or `symbol_skipped` appears, inspect the `pending_symbols` list for in-flight orders.
 3. If a position difference cannot be explained, `pause` the loop and compare the local `PortfolioBook` against broker state manually.
-4. The current KIS adapter does expose account balance snapshots. If automatic sync is skipped in a KIS environment, treat missing or incomplete pending-order signal data as the first thing to verify.
+4. The KIS adapter queries open-order snapshots before balance snapshots. If `pending_source=open_orders` is present, compare broker order ids from `/api/v1/order-audit/export` with KIS order history.
+5. If open-order lookup fails and `portfolio.reconciliation.skipped` is emitted, the portfolio is not adjusted. Check KIS response fields, TR id overrides, and network availability first.
 
 ## Secret-handling rules
 

--- a/docs/runbooks/kis-domestic-live-operations.ko.md
+++ b/docs/runbooks/kis-domestic-live-operations.ko.md
@@ -122,6 +122,8 @@ TRADING_SYSTEM_ENABLE_LIVE_ORDERS=true TRADING_SYSTEM_LIVE_BAR_SAMPLES=2 TRADING
 - [ ] `last_heartbeat`가 장시간 멈추지 않고 갱신된다
 - [ ] session active 동안 `positions`, `events`, `equity` 응답이 정상적으로 갱신된다
 - [ ] `portfolio.reconciliation.*` 이벤트가 비정상적으로 `skipped`에만 고정되지 않는다
+- [ ] `portfolio.reconciliation.pending_source`가 기록되고, KIS 경로에서는 가능한 경우 `open_orders` source가 사용된다
+- [ ] `/api/v1/order-audit/export?scope=live_session&owner_id=<session_id>&format=csv`로 session 주문 감사 기록을 export할 수 있다
 - [ ] `pause`가 실제로 상태를 `paused`로 바꾼다
 - [ ] `resume`이 실제로 상태를 다시 `running`으로 바꾼다
 - [ ] `stop` 후 dashboard가 clean disconnected/stopped 상태로 돌아간다
@@ -156,6 +158,7 @@ paper 리허설이 안정적인 경우에만 진행한다.
 - `portfolio.reconciliation.symbol_skipped` — 미체결 주문으로 심볼 건너뜀
 - `portfolio.reconciliation.cash_frozen` — 미체결 심볼로 인한 현금 동결
 - `portfolio.reconciliation.skipped` — 전체 대사 건너뜀 (스냅샷 불가)
+- `portfolio.reconciliation.pending_source` — pending 판단 근거 (`open_orders`, `balance_snapshot`, `unavailable`)
 
 ## 대시보드 모니터링
 

--- a/docs/runbooks/kis-domestic-live-operations.md
+++ b/docs/runbooks/kis-domestic-live-operations.md
@@ -122,6 +122,8 @@ Run at least one full paper session before enabling real order submission.
 - [ ] Confirm `last_heartbeat` advances without long gaps
 - [ ] Confirm `positions`, `events`, and `equity` endpoints return live data while the session is active
 - [ ] Confirm reconciliation events are reasonable and not permanently stuck on `portfolio.reconciliation.skipped`
+- [ ] Confirm `portfolio.reconciliation.pending_source` is emitted and uses `open_orders` when KIS provides that source
+- [ ] Export session order audit records through `/api/v1/order-audit/export?scope=live_session&owner_id=<session_id>&format=csv`
 - [ ] Confirm `pause` changes state to `paused`
 - [ ] Confirm `resume` changes state back to `running`
 - [ ] Confirm `stop` returns the dashboard to a clean disconnected/stopped state
@@ -156,6 +158,7 @@ The live loop reconciles the local `PortfolioBook` with KIS broker balance every
 - `portfolio.reconciliation.symbol_skipped` — symbol skipped due to pending order
 - `portfolio.reconciliation.cash_frozen` — cash frozen due to pending symbols
 - `portfolio.reconciliation.skipped` — entire reconciliation skipped (snapshot unavailable)
+- `portfolio.reconciliation.pending_source` — pending-order authority used for the reconciliation attempt (`open_orders`, `balance_snapshot`, `unavailable`)
 
 ## Monitoring via Dashboard
 

--- a/docs/runbooks/release-gate-checklist.md
+++ b/docs/runbooks/release-gate-checklist.md
@@ -34,6 +34,8 @@ The KIS live-order path exists, but it is explicitly gated behind `TRADING_SYSTE
 - [ ] Risk rejection / emergency scenario reviewed (incident-response scenario B)
 - [ ] Order failure / broker error scenario reviewed (incident-response scenario C)
 - [ ] If the environment uses broker snapshots, reconciliation mismatch scenario reviewed (incident-response scenario D)
+- [ ] Live order audit is verified without relying on `TestClient(create_app())` lifespan startup (`pytest tests/integration/test_order_audit_integration.py -q`)
+- [ ] KIS open-order pending authority is covered by parser and reconciliation tests
 
 ## Gate 5: Sign-off
 
@@ -44,4 +46,4 @@ The KIS live-order path exists, but it is explicitly gated behind `TRADING_SYSTE
 ## Notes
 
 - Even though the KIS live-order path exists, do not enable `TRADING_SYSTEM_ENABLE_LIVE_ORDERS=true` until all gates are complete.
-- Generic reconciliation only works when the broker exposes account balance snapshots. The current KIS adapter does expose balance snapshots, and reconciliation will skip fail-closed if the pending-order signal is incomplete.
+- Generic reconciliation works when the broker exposes account balance snapshots. The KIS adapter now prefers open-order snapshots for pending authority and skips fail-closed if that source is unavailable or malformed.

--- a/examples/sample_backtest.yaml
+++ b/examples/sample_backtest.yaml
@@ -13,10 +13,8 @@ timeframe: 1m
 start: 2024-01-01T00:00:00Z
 end: 2024-01-07T00:00:00Z
 strategy:
-  kind: mean_reversion
-  lookback: 20
-  zscore_entry: 2.0
-  zscore_exit: 0.5
+  type: pattern_signal
+  profile_id: sample_bullish_profile
 risk:
   max_position: 1.0
   max_notional: 100000.0

--- a/examples/sample_backtest_krx.yaml
+++ b/examples/sample_backtest_krx.yaml
@@ -13,10 +13,8 @@ timeframe: 1d
 start: 2024-01-01T00:00:00Z
 end: 2024-01-31T00:00:00Z
 strategy:
-  kind: mean_reversion
-  lookback: 20
-  zscore_entry: 2.0
-  zscore_exit: 0.5
+  type: pattern_signal
+  profile_id: sample_bullish_profile
 risk:
   max_position: 10
   max_notional: 100000000

--- a/examples/sample_live_kis.yaml
+++ b/examples/sample_live_kis.yaml
@@ -25,6 +25,9 @@ backtest:
   starting_cash: 10000000
   fee_bps: 5
   trade_quantity: 1
+strategy:
+  type: pattern_signal
+  profile_id: sample_bullish_profile
 
 portfolio_risk:
   max_daily_drawdown_pct: 0.05

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { Activity, ShieldCheck, Siren, TimerReset } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { RuntimeLaunchForm } from '@/components/dashboard/RuntimeLaunchForm'
+import { SessionHistoryPanel } from '@/components/dashboard/SessionHistoryPanel'
 import { DashboardMetrics } from '@/components/dashboard/DashboardMetrics'
 import { DashboardPanel } from '@/components/dashboard/DashboardPanel'
 import { ControlButtons } from '@/components/dashboard/ControlButtons'
@@ -72,6 +73,7 @@ export default function DashboardPage() {
       />
 
       {!hasActiveRuntime ? <RuntimeLaunchForm /> : null}
+      <SessionHistoryPanel />
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.95fr)]">
         <div className="space-y-4">

--- a/frontend/app/runs/[runId]/page.tsx
+++ b/frontend/app/runs/[runId]/page.tsx
@@ -1,13 +1,15 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
+import { Download } from 'lucide-react'
 import { use, useEffect } from 'react'
 import { PageHeader } from '@/components/layout/PageHeader'
 import { SurfacePanel } from '@/components/layout/SurfacePanel'
 import { StatusBadge } from '@/components/domain/StatusBadge'
 import { ErrorBanner } from '@/components/domain/ErrorBanner'
 import { RunDetailTabs } from '@/components/runs/RunDetailTabs'
-import { getBacktestRun } from '@/lib/api/backtests'
+import { Button } from '@/components/ui/button'
+import { exportOrderAudit, getBacktestRun } from '@/lib/api/backtests'
 import { getBacktestTradeAnalytics } from '@/lib/api/analytics'
 import { useRunsStore } from '@/store/runsStore'
 
@@ -55,13 +57,36 @@ export default function RunDetailPage({
   if (runQuery.error) return <ErrorBanner error={runQuery.error} />
 
   const run = runQuery.data!
+  const handleExportAudit = async () => {
+    const body = await exportOrderAudit({
+      scope: 'backtest',
+      owner_id: runId,
+      format: 'csv',
+      limit: 5000,
+    })
+    const blob = new Blob([body], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = `${runId}-order-audit.csv`
+    anchor.click()
+    URL.revokeObjectURL(url)
+  }
 
   return (
     <div className="space-y-6">
       <PageHeader
         title="Run Detail"
         description={runId}
-        actions={<StatusBadge state={run.status} />}
+        actions={
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" onClick={handleExportAudit}>
+              <Download aria-hidden="true" />
+              Export audit CSV
+            </Button>
+            <StatusBadge state={run.status} />
+          </div>
+        }
       />
 
       {run.metadata ? (

--- a/frontend/app/runs/page.tsx
+++ b/frontend/app/runs/page.tsx
@@ -1,17 +1,25 @@
 'use client'
 
 import Link from 'next/link'
+import { useMemo, useState, useTransition } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Clock3, RefreshCw, Rows3, Zap } from 'lucide-react'
+import { Clock3, RefreshCw, Rows3, Trash2, Zap } from 'lucide-react'
 import { DataTable, type Column } from '@/components/domain/DataTable'
 import { StatusBadge } from '@/components/domain/StatusBadge'
 import { PageHeader } from '@/components/layout/PageHeader'
 import { SurfacePanel } from '@/components/layout/SurfacePanel'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { listBacktestRuns } from '@/lib/api/backtests'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  getBacktestDispatcherStatus,
+  listBacktestRuns,
+  previewBacktestRetention,
+  pruneBacktestRetention,
+} from '@/lib/api/backtests'
 import { formatUtcTimestamp } from '@/lib/formatters'
-import type { BacktestRunListItem } from '@/lib/api/types'
+import type { BacktestRetentionPreview, BacktestRunListItem } from '@/lib/api/types'
 import { useRunsStore, type RunRecord } from '@/store/runsStore'
 
 const ACTIVE_STATUSES = new Set(['queued', 'running'])
@@ -70,6 +78,10 @@ const columns: Column<RunRecord>[] = [
 
 export default function RunsPage() {
   const { runs: localRuns } = useRunsStore()
+  const [retentionCutoff, setRetentionCutoff] = useState('')
+  const [retentionPreview, setRetentionPreview] = useState<BacktestRetentionPreview | null>(null)
+  const [retentionMessage, setRetentionMessage] = useState<string | null>(null)
+  const [isRetentionPending, startRetentionTransition] = useTransition()
 
   const serverQuery = useQuery({
     queryKey: ['backtests', 'list'],
@@ -83,6 +95,14 @@ export default function RunsPage() {
     },
   })
 
+  const dispatcherQuery = useQuery({
+    queryKey: ['backtests', 'dispatcher'],
+    queryFn: getBacktestDispatcherStatus,
+    staleTime: 5_000,
+    refetchInterval: 5_000,
+    retry: 1,
+  })
+
   const rows: RunRecord[] = serverQuery.isError
     ? localRuns
     : serverQuery.data?.runs.map(serverItemToRunRecord) ?? localRuns
@@ -90,6 +110,46 @@ export default function RunsPage() {
   const queuedCount = rows.filter((row) => row.status === 'queued').length
   const runningCount = rows.filter((row) => row.status === 'running').length
   const succeededCount = rows.filter((row) => row.status === 'succeeded').length
+  const dispatcher = dispatcherQuery.data
+  const defaultCutoff = useMemo(() => {
+    const date = new Date()
+    date.setUTCDate(date.getUTCDate() - 30)
+    return date.toISOString().slice(0, 10)
+  }, [])
+
+  function previewRetention() {
+    const cutoffDate = retentionCutoff || defaultCutoff
+    startRetentionTransition(async () => {
+      try {
+        const preview = await previewBacktestRetention({
+          cutoff: `${cutoffDate}T00:00:00Z`,
+          status: 'succeeded',
+        })
+        setRetentionPreview(preview)
+        setRetentionMessage(`${preview.candidate_count} completed run(s) match the cutoff.`)
+      } catch {
+        setRetentionMessage('Retention preview failed.')
+      }
+    })
+  }
+
+  function pruneRetention() {
+    if (!retentionPreview) return
+    startRetentionTransition(async () => {
+      try {
+        const result = await pruneBacktestRetention({
+          cutoff: retentionPreview.cutoff,
+          status: retentionPreview.status ?? undefined,
+          confirm: 'DELETE',
+        })
+        setRetentionMessage(`${result.deleted_count} run(s) were pruned.`)
+        setRetentionPreview(null)
+        await serverQuery.refetch()
+      } catch {
+        setRetentionMessage('Retention prune failed.')
+      }
+    })
+  }
 
   return (
     <div className="space-y-6">
@@ -129,6 +189,90 @@ export default function RunsPage() {
           action={<Rows3 className="h-4 w-4 text-muted-foreground" />}
         >
           <p className="font-mono text-3xl font-semibold">{succeededCount}</p>
+        </SurfacePanel>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.8fr)]">
+        <SurfacePanel
+          eyebrow="Dispatcher"
+          title="Worker status"
+          description="Current API-owned backtest dispatcher capacity and queue depth."
+          action={<RefreshCw className="h-4 w-4 text-muted-foreground" />}
+        >
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-xl border border-border/80 bg-muted/20 p-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                Worker
+              </p>
+              <p className="mt-2 text-sm font-medium">
+                {dispatcher?.running ? 'running' : 'stopped'}
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/80 bg-muted/20 p-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                Queue depth
+              </p>
+              <p className="mt-2 font-mono text-2xl font-semibold">
+                {dispatcher?.queue_depth ?? '-'}
+              </p>
+            </div>
+            <div className="rounded-xl border border-border/80 bg-muted/20 p-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                Capacity
+              </p>
+              <p className="mt-2 font-mono text-2xl font-semibold">
+                {dispatcher?.max_queue_size ?? '-'}
+              </p>
+            </div>
+          </div>
+        </SurfacePanel>
+
+        <SurfacePanel
+          eyebrow="Retention"
+          title="Prune completed runs"
+          description="Preview completed runs older than a UTC cutoff before deleting."
+          action={<Trash2 className="h-4 w-4 text-muted-foreground" />}
+        >
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <Label htmlFor="retention-cutoff">Cutoff date</Label>
+              <Input
+                id="retention-cutoff"
+                type="date"
+                value={retentionCutoff || defaultCutoff}
+                onChange={(event) => {
+                  setRetentionCutoff(event.target.value)
+                  setRetentionPreview(null)
+                  setRetentionMessage(null)
+                }}
+              />
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={previewRetention}
+                disabled={isRetentionPending}
+              >
+                Preview
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={pruneRetention}
+                disabled={
+                  isRetentionPending ||
+                  retentionPreview == null ||
+                  retentionPreview.candidate_count === 0
+                }
+              >
+                Prune
+              </Button>
+            </div>
+            {retentionMessage ? (
+              <p className="text-sm text-muted-foreground">{retentionMessage}</p>
+            ) : null}
+          </div>
         </SurfacePanel>
       </div>
 

--- a/frontend/components/dashboard/SessionDetailDialog.tsx
+++ b/frontend/components/dashboard/SessionDetailDialog.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import { Badge } from '@/components/ui/badge'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { formatUtcTimestamp } from '@/lib/formatters'
+import type { LiveRuntimeSessionRecord } from '@/lib/api/types'
+
+interface SessionDetailDialogProps {
+  session: LiveRuntimeSessionRecord | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function SessionDetailDialog({
+  session,
+  open,
+  onOpenChange,
+}: SessionDetailDialogProps) {
+  const preflight = session?.preflight_summary
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Session detail</DialogTitle>
+          <DialogDescription>
+            {session ? session.session_id : 'No session selected.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {session ? (
+          <div className="space-y-4">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <InfoTile label="Started" value={formatUtcTimestamp(session.started_at)} />
+              <InfoTile
+                label="Ended"
+                value={session.ended_at ? formatUtcTimestamp(session.ended_at) : 'active'}
+              />
+              <InfoTile
+                label="Route"
+                value={`${session.provider} / ${session.broker} / ${session.live_execution}`}
+              />
+              <InfoTile label="Final state" value={session.last_state} />
+            </div>
+
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                Symbols
+              </p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {session.symbols.map((symbol) => (
+                  <Badge key={symbol} variant="outline">
+                    {symbol}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+
+            {session.last_error ? (
+              <div className="rounded-xl border border-danger/20 bg-danger/10 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-danger">
+                  Last error
+                </p>
+                <p className="mt-2 text-sm">{session.last_error}</p>
+              </div>
+            ) : null}
+
+            <div className="rounded-xl border border-border/80 bg-muted/20 p-4">
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                  Preflight
+                </p>
+                {preflight ? (
+                  <Badge variant={preflight.ready ? 'default' : 'destructive'}>
+                    {preflight.ready ? 'ready' : 'blocked'}
+                  </Badge>
+                ) : (
+                  <Badge variant="outline">not recorded</Badge>
+                )}
+              </div>
+              {preflight ? (
+                <div className="mt-3 space-y-3">
+                  <p className="text-sm leading-6 text-muted-foreground">
+                    {preflight.message ?? 'No preflight message recorded.'}
+                  </p>
+                  <BadgeList
+                    label="Blocking reasons"
+                    values={preflight.blocking_reasons ?? []}
+                    destructive
+                  />
+                  <BadgeList label="Warnings" values={preflight.warnings ?? []} />
+                </div>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function InfoTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-border/80 bg-muted/20 p-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-2 break-words text-sm font-medium">{value}</p>
+    </div>
+  )
+}
+
+function BadgeList({
+  label,
+  values,
+  destructive = false,
+}: {
+  label: string
+  values: string[]
+  destructive?: boolean
+}) {
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+        {label}
+      </p>
+      <div className="mt-2 flex flex-wrap gap-2">
+        {values.length > 0 ? (
+          values.map((value) => (
+            <Badge key={value} variant={destructive ? 'destructive' : 'secondary'}>
+              {value}
+            </Badge>
+          ))
+        ) : (
+          <Badge variant="outline">none</Badge>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/dashboard/SessionDetailDialog.tsx
+++ b/frontend/components/dashboard/SessionDetailDialog.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import {
   Dialog,
   DialogContent,
@@ -8,7 +9,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import { exportLiveSessionOrderAudit } from '@/lib/api/dashboard'
 import { formatUtcTimestamp } from '@/lib/formatters'
+import { Download } from 'lucide-react'
 import type { LiveRuntimeSessionRecord } from '@/lib/api/types'
 
 interface SessionDetailDialogProps {
@@ -23,15 +26,40 @@ export function SessionDetailDialog({
   onOpenChange,
 }: SessionDetailDialogProps) {
   const preflight = session?.preflight_summary
+  const handleExportAudit = async () => {
+    if (!session) return
+    const body = await exportLiveSessionOrderAudit({
+      owner_id: session.session_id,
+      format: 'csv',
+      limit: 5000,
+    })
+    const blob = new Blob([body], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = `${session.session_id}-order-audit.csv`
+    anchor.click()
+    URL.revokeObjectURL(url)
+  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-2xl">
         <DialogHeader>
-          <DialogTitle>Session detail</DialogTitle>
-          <DialogDescription>
-            {session ? session.session_id : 'No session selected.'}
-          </DialogDescription>
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <DialogTitle>Session detail</DialogTitle>
+              <DialogDescription>
+                {session ? session.session_id : 'No session selected.'}
+              </DialogDescription>
+            </div>
+            {session ? (
+              <Button variant="outline" size="sm" onClick={handleExportAudit}>
+                <Download aria-hidden="true" />
+                Export audit CSV
+              </Button>
+            ) : null}
+          </div>
         </DialogHeader>
 
         {session ? (

--- a/frontend/components/dashboard/SessionHistoryPanel.tsx
+++ b/frontend/components/dashboard/SessionHistoryPanel.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { History, RefreshCw } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { DataTable, type Column } from '@/components/domain/DataTable'
+import { DashboardPanel } from '@/components/dashboard/DashboardPanel'
+import { SessionDetailDialog } from '@/components/dashboard/SessionDetailDialog'
+import { listLiveRuntimeSessions } from '@/lib/api/dashboard'
+import { formatUtcTimestamp } from '@/lib/formatters'
+import type { LiveRuntimeSessionRecord } from '@/lib/api/types'
+
+const columns: Column<LiveRuntimeSessionRecord>[] = [
+  {
+    key: 'session',
+    header: 'Session',
+    cell: (row) => <span className="font-mono text-xs">{row.session_id}</span>,
+  },
+  {
+    key: 'route',
+    header: 'Route',
+    cell: (row) => (
+      <span className="text-xs text-muted-foreground">
+        {row.provider} / {row.broker} / {row.live_execution}
+      </span>
+    ),
+  },
+  {
+    key: 'state',
+    header: 'State',
+    cell: (row) => (
+      <Badge variant={row.last_state === 'error' ? 'destructive' : 'outline'}>
+        {row.last_state}
+      </Badge>
+    ),
+  },
+  {
+    key: 'started',
+    header: 'Started',
+    cell: (row) => <span className="text-xs">{formatUtcTimestamp(row.started_at)}</span>,
+  },
+]
+
+export function SessionHistoryPanel() {
+  const [selected, setSelected] = useState<LiveRuntimeSessionRecord | null>(null)
+  const sessionsQuery = useQuery({
+    queryKey: ['live-runtime', 'sessions'],
+    queryFn: () => listLiveRuntimeSessions(10),
+    staleTime: 15_000,
+    retry: 1,
+  })
+
+  const sessions = sessionsQuery.data?.sessions ?? []
+
+  return (
+    <>
+      <DashboardPanel
+        eyebrow="Session history"
+        title="Recent sessions"
+        description="Durable live runtime sessions recorded by the API process."
+        action={
+          <div className="flex items-center gap-2">
+            <History className="h-4 w-4 text-muted-foreground" />
+            <Button variant="outline" size="sm" onClick={() => sessionsQuery.refetch()}>
+              <RefreshCw className="mr-1 h-3 w-3" />
+              Refresh
+            </Button>
+          </div>
+        }
+      >
+        {sessionsQuery.isError ? (
+          <div className="rounded-xl border border-danger/20 bg-danger/10 p-4 text-sm">
+            Session history could not be loaded.
+          </div>
+        ) : (
+          <DataTable
+            columns={columns}
+            data={sessions}
+            keyExtractor={(row) => row.session_id}
+            loading={sessionsQuery.isLoading}
+            loadingRows={3}
+            emptyMessage="No live runtime sessions have been recorded yet."
+            onRowClick={(row) => setSelected(row)}
+          />
+        )}
+      </DashboardPanel>
+
+      <SessionDetailDialog
+        session={selected}
+        open={selected != null}
+        onOpenChange={(open) => {
+          if (!open) setSelected(null)
+        }}
+      />
+    </>
+  )
+}

--- a/frontend/e2e/mocks/handlers.ts
+++ b/frontend/e2e/mocks/handlers.ts
@@ -6,6 +6,8 @@ import type {
   BacktestRunStatusDTO,
   TradeAnalyticsResponse,
   StrategyProfileDTO,
+  LiveRuntimeSessionList,
+  EquityTimeseriesResponse,
 } from '../../lib/api/types'
 
 // ── Fixture data ──
@@ -41,6 +43,37 @@ export const dashboardEvents: EventFeed = {
       correlation_id: 'corr-001',
       timestamp: '2026-04-07T11:30:00Z',
       payload: { symbol: '005930', side: 'buy', quantity: 10 },
+    },
+  ],
+  total: 1,
+}
+
+export const dashboardEquity: EquityTimeseriesResponse = {
+  session_id: 'live-test-001',
+  points: [],
+  total: 0,
+}
+
+export const liveRuntimeSessions: LiveRuntimeSessionList = {
+  sessions: [
+    {
+      session_id: 'live-test-001',
+      started_at: '2026-04-07T10:00:00Z',
+      ended_at: '2026-04-07T11:00:00Z',
+      provider: 'kis',
+      broker: 'kis',
+      live_execution: 'paper',
+      symbols: ['005930'],
+      last_state: 'stopped',
+      last_error: null,
+      preflight_summary: {
+        checked_at: '2026-04-07T09:59:00Z',
+        ready: true,
+        message: 'Ready',
+        blocking_reasons: [],
+        warnings: [],
+        next_allowed_actions: ['paper'],
+      },
     },
   ],
   total: 1,
@@ -125,6 +158,29 @@ export async function setupMockRoutes(page: Page) {
 
   await page.route('**/api/v1/dashboard/events**', (route) =>
     route.fulfill({ json: dashboardEvents }),
+  )
+
+  await page.route('**/api/v1/dashboard/equity**', (route) =>
+    route.fulfill({ json: dashboardEquity }),
+  )
+
+  await page.route('**/api/v1/live/runtime/sessions**', (route) =>
+    route.fulfill({ json: liveRuntimeSessions }),
+  )
+
+  await page.route('**/api/v1/backtests/dispatcher', (route) =>
+    route.fulfill({ json: { running: true, queue_depth: 0, max_queue_size: 32 } }),
+  )
+
+  await page.route('**/api/v1/backtests/retention/preview**', (route) =>
+    route.fulfill({
+      json: {
+        cutoff: '2026-03-01T00:00:00Z',
+        status: 'succeeded',
+        candidate_count: 0,
+        run_ids: [],
+      },
+    }),
   )
 
   await page.route('**/api/v1/backtests/*', (route) =>

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -16,8 +16,8 @@ test('home page loads with navigation links', async ({ page }) => {
 
 test('dashboard page loads with MetricCard containers', async ({ page }) => {
   await page.goto('/dashboard')
-  await expect(page.getByText('Live Dashboard')).toBeVisible()
-  await expect(page.locator('[data-slot="card"]').first()).toBeVisible()
+  await expect(page.getByText('Operations Console')).toBeVisible()
+  await expect(page.getByText('Recent sessions')).toBeVisible()
 })
 
 test('run detail page loads with run content', async ({ page }) => {

--- a/frontend/lib/api/backtests.ts
+++ b/frontend/lib/api/backtests.ts
@@ -1,4 +1,4 @@
-import { requestJson } from './client'
+import { requestJson, requestText } from './client'
 import type {
   BacktestRunRequestDTO,
   BacktestRunAcceptedDTO,
@@ -7,6 +7,7 @@ import type {
   BacktestDispatcherStatus,
   BacktestRetentionPreview,
   BacktestRetentionPruneResponse,
+  OrderAuditExportParams,
 } from './types'
 
 export const createBacktestRun = (payload: BacktestRunRequestDTO) =>
@@ -49,3 +50,17 @@ export const pruneBacktestRetention = (payload: {
     method: 'POST',
     body: JSON.stringify(payload),
   })
+
+export const exportOrderAudit = (params: OrderAuditExportParams) => {
+  const qs = new URLSearchParams()
+  qs.set('scope', params.scope)
+  qs.set('owner_id', params.owner_id)
+  qs.set('format', params.format ?? 'csv')
+  if (params.start) qs.set('start', params.start)
+  if (params.end) qs.set('end', params.end)
+  if (params.status) qs.set('status', params.status)
+  if (params.side) qs.set('side', params.side)
+  if (params.broker_order_id) qs.set('broker_order_id', params.broker_order_id)
+  if (params.limit != null) qs.set('limit', String(params.limit))
+  return requestText(`/order-audit/export?${qs.toString()}`)
+}

--- a/frontend/lib/api/backtests.ts
+++ b/frontend/lib/api/backtests.ts
@@ -4,6 +4,9 @@ import type {
   BacktestRunAcceptedDTO,
   BacktestRunStatusDTO,
   BacktestRunListResponse,
+  BacktestDispatcherStatus,
+  BacktestRetentionPreview,
+  BacktestRetentionPruneResponse,
 } from './types'
 
 export const createBacktestRun = (payload: BacktestRunRequestDTO) =>
@@ -26,3 +29,23 @@ export const listBacktestRuns = (params?: {
   const query = qs.toString()
   return requestJson<BacktestRunListResponse>(`/backtests${query ? `?${query}` : ''}`)
 }
+
+export const getBacktestDispatcherStatus = () =>
+  requestJson<BacktestDispatcherStatus>('/backtests/dispatcher')
+
+export const previewBacktestRetention = (params: { cutoff: string; status?: string }) => {
+  const qs = new URLSearchParams()
+  qs.set('cutoff', params.cutoff)
+  if (params.status) qs.set('status', params.status)
+  return requestJson<BacktestRetentionPreview>(`/backtests/retention/preview?${qs.toString()}`)
+}
+
+export const pruneBacktestRetention = (payload: {
+  cutoff: string
+  status?: string
+  confirm: 'DELETE'
+}) =>
+  requestJson<BacktestRetentionPruneResponse>('/backtests/retention/prune', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -70,3 +70,35 @@ export function userMessageForError(error: unknown): string {
   if (error.kind === 'server') return `Server error (5xx): ${error.message}`
   return `HTTP error: ${error.message}`
 }
+
+export async function requestText(path: string, options: RequestInit = {}): Promise<string> {
+  const { baseUrl, apiKey } = useApiStore.getState()
+  const url = `${baseUrl}${path}`
+
+  const headers: Record<string, string> = {}
+  if (apiKey) headers['X-API-Key'] = apiKey
+
+  let response: Response
+  try {
+    const { headers: callerHeaders, ...restOptions } = options
+    response = await fetch(url, {
+      headers: { ...headers, ...(callerHeaders as Record<string, string>) },
+      ...restOptions,
+    })
+  } catch {
+    throw new ApiError(
+      'network',
+      `Cannot reach backend API at ${url}. Check that the backend is running and the API base URL is correct.`,
+    )
+  }
+
+  const rawBody = await response.text()
+  if (response.ok) return rawBody
+  if (response.status >= 400 && response.status < 500) {
+    throw new ApiError('validation', rawBody || 'Validation error.', response.status, rawBody)
+  }
+  if (response.status >= 500) {
+    throw new ApiError('server', rawBody || 'Server error.', response.status, rawBody)
+  }
+  throw new ApiError('http', `Unexpected HTTP status: ${response.status}`, response.status, rawBody)
+}

--- a/frontend/lib/api/dashboard.ts
+++ b/frontend/lib/api/dashboard.ts
@@ -1,4 +1,4 @@
-import { requestJson } from './client'
+import { requestJson, requestText } from './client'
 import { useApiStore } from '@/store/apiStore'
 import type {
   DashboardStatus,
@@ -11,6 +11,7 @@ import type {
   LiveRuntimeStartResponseDTO,
   LiveRuntimeSessionList,
   LiveRuntimeSessionRecord,
+  OrderAuditExportParams,
 } from './types'
 
 export const getDashboardStatus = () => requestJson<DashboardStatus>('/dashboard/status')
@@ -53,3 +54,17 @@ export const getLiveRuntimeSession = (sessionId: string) =>
   requestJson<LiveRuntimeSessionRecord>(
     `/live/runtime/sessions/${encodeURIComponent(sessionId)}`,
   )
+
+export const exportLiveSessionOrderAudit = (params: Omit<OrderAuditExportParams, 'scope'>) => {
+  const qs = new URLSearchParams()
+  qs.set('scope', 'live_session')
+  qs.set('owner_id', params.owner_id)
+  qs.set('format', params.format ?? 'csv')
+  if (params.start) qs.set('start', params.start)
+  if (params.end) qs.set('end', params.end)
+  if (params.status) qs.set('status', params.status)
+  if (params.side) qs.set('side', params.side)
+  if (params.broker_order_id) qs.set('broker_order_id', params.broker_order_id)
+  if (params.limit != null) qs.set('limit', String(params.limit))
+  return requestText(`/order-audit/export?${qs.toString()}`)
+}

--- a/frontend/lib/api/dashboard.ts
+++ b/frontend/lib/api/dashboard.ts
@@ -9,6 +9,8 @@ import type {
   LivePreflightResponseDTO,
   LiveRuntimeStartRequestDTO,
   LiveRuntimeStartResponseDTO,
+  LiveRuntimeSessionList,
+  LiveRuntimeSessionRecord,
 } from './types'
 
 export const getDashboardStatus = () => requestJson<DashboardStatus>('/dashboard/status')
@@ -43,3 +45,11 @@ export const postLiveRuntimeStart = (payload: LiveRuntimeStartRequestDTO) =>
     method: 'POST',
     body: JSON.stringify({ mode: 'live', ...payload }),
   })
+
+export const listLiveRuntimeSessions = (limit = 20) =>
+  requestJson<LiveRuntimeSessionList>(`/live/runtime/sessions?limit=${limit}`)
+
+export const getLiveRuntimeSession = (sessionId: string) =>
+  requestJson<LiveRuntimeSessionRecord>(
+    `/live/runtime/sessions/${encodeURIComponent(sessionId)}`,
+  )

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -123,6 +123,31 @@ export interface LiveRuntimeStartResponseDTO {
   preflight?: LivePreflightResponseDTO | null
 }
 
+export interface LiveRuntimeSessionRecord {
+  session_id: string
+  started_at: string
+  ended_at: string | null
+  provider: string
+  broker: string
+  live_execution: string
+  symbols: string[]
+  last_state: string
+  last_error?: string | null
+  preflight_summary?: {
+    checked_at?: string
+    ready?: boolean
+    message?: string
+    blocking_reasons?: string[]
+    warnings?: string[]
+    next_allowed_actions?: string[]
+  } | null
+}
+
+export interface LiveRuntimeSessionList {
+  sessions: LiveRuntimeSessionRecord[]
+  total: number
+}
+
 // Backtests
 export interface RiskDTO {
   max_position: number
@@ -180,6 +205,24 @@ export interface BacktestRunRequestDTO {
 export interface BacktestRunAcceptedDTO {
   run_id: string
   status: BacktestRunStatus
+}
+
+export interface BacktestDispatcherStatus {
+  running: boolean
+  queue_depth: number
+  max_queue_size: number
+}
+
+export interface BacktestRetentionPreview {
+  cutoff: string
+  status?: string | null
+  candidate_count: number
+  run_ids: string[]
+}
+
+export interface BacktestRetentionPruneResponse {
+  deleted_count: number
+  run_ids: string[]
 }
 
 export interface EquityPoint {

--- a/frontend/lib/api/types.ts
+++ b/frontend/lib/api/types.ts
@@ -261,6 +261,40 @@ export interface BacktestRunStatusDTO {
   error?: string | null
 }
 
+export interface OrderAuditRecordDTO {
+  record_id: string
+  scope: string
+  owner_id: string
+  event: string
+  symbol?: string | null
+  side?: string | null
+  requested_quantity?: string | null
+  filled_quantity?: string | null
+  price?: string | null
+  status?: string | null
+  reason?: string | null
+  timestamp: string
+  payload: Record<string, unknown>
+  broker_order_id?: string | null
+}
+
+export interface OrderAuditListDTO {
+  records: OrderAuditRecordDTO[]
+  total: number
+}
+
+export interface OrderAuditExportParams {
+  scope: 'backtest' | 'live_session'
+  owner_id: string
+  format?: 'csv' | 'jsonl'
+  start?: string
+  end?: string
+  status?: string
+  side?: string
+  broker_order_id?: string
+  limit?: number
+}
+
 // Backtest run list (Phase 8)
 export interface BacktestRunListItem {
   run_id: string

--- a/prd/phase_14_implementation_plan.md
+++ b/prd/phase_14_implementation_plan.md
@@ -1,0 +1,304 @@
+# Phase 14 Implementation Plan
+
+## Goal
+
+Phase 14의 구현 목표는 Phase 13까지 추가된 운영 기록을 실제 운영 워크플로로 완성하는 것이다. live session history는 브라우저에서 탐색 가능하게 만들고, 주문 lifecycle은 durable audit record로 남기며, backtest queue와 retention 상태는 API/UI에서 운영자가 확인하고 제어할 수 있게 한다.
+
+핵심 구현 원칙:
+
+1. trading semantics와 리스크 판정은 변경하지 않는다.
+2. 감사 저장 실패가 백테스트/라이브 실행 결과를 바꾸지 않게 한다.
+3. file/Supabase 저장소 contract를 함께 구현한다.
+4. 삭제성 작업은 preview와 confirm 실행을 분리한다.
+5. 문서는 구현 범위의 일부로 업데이트한다.
+
+## Preconditions
+
+- `BacktestRunDispatcher`는 현재 baseline으로 유지하며, 외부 queue 인프라는 도입하지 않는다.
+- `LiveRuntimeSessionRecord`와 `/api/v1/live/runtime/sessions`는 이미 존재하므로, backend session API는 확장보다 frontend 소비가 중심이다.
+- 주문 감사 record는 기존 structured event payload에서 파생하며, `execute_trading_step`의 반환 결과와 포트폴리오 mutation 순서는 바꾸지 않는다.
+- Supabase 변경은 additive migration으로만 수행한다.
+- retention prune은 기본 비활성 동작이며, 명시 confirm이 없으면 삭제하지 않는다.
+
+## Locked Design Decisions
+
+### 1. Session history는 dashboard 패널로 구현한다
+
+- `frontend/app/dashboard/page.tsx`에 session history 패널을 추가한다.
+- 세션 상세는 페이지 전환이 아니라 dialog로 제공한다.
+- 초기 필터는 limit 기반 최근 목록으로 제한한다.
+
+### 2. Order audit 저장은 owner scope 기반으로 설계한다
+
+- `scope`는 `backtest` 또는 `live_session`으로 고정한다.
+- `owner_id`는 backtest `run_id` 또는 live `session_id`를 의미한다.
+- 조회 API는 `/api/v1/order-audit` 계열로 두고, frontend는 run/session 화면에서 owner 기준으로 호출한다.
+
+### 3. Audit append는 best-effort boundary에서 처리한다
+
+- 저장소 장애가 주문 실행 결과를 바꾸면 안 된다.
+- audit repository가 없거나 저장에 실패하면 structured logger에 warning을 남기고 trading step은 계속 진행한다.
+
+### 4. Retention은 repository protocol의 선택적 확장으로 구현한다
+
+- 기존 `delete`, `clear`는 유지한다.
+- cutoff/status 기반 preview/prune 메서드를 repository contract에 추가하거나 별도 retention service가 repository list/delete를 조합한다.
+- Supabase는 SQL cutoff delete를 사용하고, file repo는 index를 기준으로 후보를 산정한다.
+
+## Contract Deltas
+
+## A. Live session frontend contract
+
+대상:
+- `frontend/lib/api/types.ts`
+- `frontend/lib/api/dashboard.ts`
+- `frontend/app/dashboard/page.tsx`
+- 신규 `frontend/components/dashboard/SessionHistoryPanel.tsx`
+- 신규 `frontend/components/dashboard/SessionDetailDialog.tsx`
+
+필수 변화:
+- `LiveRuntimeSessionRecord`와 `LiveRuntimeSessionList` 타입 추가
+- `/live/runtime/sessions`와 `/live/runtime/sessions/{session_id}` client 함수 추가
+- dashboard에서 최근 session 목록, final state, last error, preflight summary 표시
+
+비고:
+- backend DTO shape는 Phase 13 contract를 우선 재사용한다.
+
+## B. Order audit persistence contract
+
+대상:
+- 신규 `src/trading_system/execution/order_audit.py`
+- `src/trading_system/api/schemas.py`
+- 신규 `src/trading_system/api/routes/order_audit.py`
+- `src/trading_system/api/server.py`
+- 신규 `scripts/migrations/004_add_order_audit_records.sql`
+
+필수 변화:
+- `OrderAuditRecord` DTO와 repository protocol 정의
+- file/Supabase repository 구현
+- list API에 `scope`, `owner_id`, `symbol`, `event`, `limit` 필터 추가
+- Supabase migration과 index 추가
+
+비고:
+- record payload는 원본 event payload를 보존하되, 조회 필드는 별도 컬럼/필드로 승격한다.
+
+## C. Trading runtime audit wiring
+
+대상:
+- `src/trading_system/execution/step.py`
+- `src/trading_system/backtest/engine.py`
+- `src/trading_system/app/loop.py`
+- `src/trading_system/app/services.py`
+
+필수 변화:
+- `TradingContext` 또는 호출 경계에 audit sink 추가
+- 백테스트 실행 시 `scope=backtest`, `owner_id=run_id`로 record 저장
+- 라이브 실행 시 `scope=live_session`, `owner_id=session_id`로 record 저장
+- risk rejection, order rejection, fill event를 audit record로 정규화
+
+비고:
+- backtest engine이 run_id를 모르던 경로는 optional owner id를 주입받도록 additive하게 확장한다.
+
+## D. Queue and retention operations
+
+대상:
+- `src/trading_system/backtest/dispatcher.py`
+- `src/trading_system/backtest/repository.py`
+- `src/trading_system/backtest/file_repository.py`
+- `src/trading_system/backtest/supabase_repository.py`
+- `src/trading_system/api/routes/backtest.py`
+- `frontend/app/runs/page.tsx`
+- `frontend/lib/api/backtests.ts`
+
+필수 변화:
+- dispatcher status snapshot에 `running`, `queue_depth`, `max_queue_size` 추가
+- `/api/v1/backtests/dispatcher` 또는 동등한 status endpoint 추가
+- retention preview/prune endpoint 추가
+- runs UI에 queue status와 retention preview/action 최소 표면 추가
+
+비고:
+- prune API는 `confirm="DELETE"` 또는 동등한 explicit confirmation을 요구한다.
+
+## Sequenced Implementation
+
+### Step 0. Live session history UX
+
+목적:
+- 저장된 live runtime session history를 운영자가 dashboard에서 탐색하게 한다.
+
+파일:
+- `frontend/lib/api/types.ts`
+- `frontend/lib/api/dashboard.ts`
+- `frontend/app/dashboard/page.tsx`
+- 신규 `frontend/components/dashboard/SessionHistoryPanel.tsx`
+- 신규 `frontend/components/dashboard/SessionDetailDialog.tsx`
+- `frontend/e2e/smoke.spec.ts`
+
+구체 작업:
+- session list/detail 타입과 client 함수를 추가한다.
+- React Query로 최근 session list를 dashboard에서 조회한다.
+- session row에 state, duration, provider/broker, symbols, error badge를 표시한다.
+- detail dialog에 preflight summary, warnings, blocking reasons, timestamps를 표시한다.
+- 빈 목록, loading, API error 상태를 처리한다.
+
+종료 조건:
+- dashboard에서 최근 live session 목록을 볼 수 있고, 하나를 선택해 detail을 확인할 수 있다.
+
+### Step 1. Order audit DTO/repository/migration 추가
+
+목적:
+- 주문 lifecycle 감사 record를 저장하고 조회하는 독립 contract를 만든다.
+
+파일:
+- 신규 `src/trading_system/execution/order_audit.py`
+- `src/trading_system/api/schemas.py`
+- 신규 `src/trading_system/api/routes/order_audit.py`
+- `src/trading_system/api/server.py`
+- 신규 `scripts/migrations/004_add_order_audit_records.sql`
+- 신규 `tests/unit/test_order_audit_repository.py`
+- 신규 `tests/unit/test_order_audit_routes.py`
+
+구체 작업:
+- `OrderAuditRecord`와 `OrderAuditRepository` protocol을 정의한다.
+- file repository와 Supabase repository를 구현한다.
+- `create_order_audit_repository()` factory를 추가한다.
+- API DTO와 list endpoint를 추가한다.
+- Supabase table/index migration을 작성한다.
+
+종료 조건:
+- file/Supabase mocked repository 테스트와 order audit route 테스트가 통과한다.
+
+### Step 2. Backtest/live audit wiring
+
+목적:
+- 실제 백테스트와 라이브 실행에서 audit record가 owner 기준으로 남게 한다.
+
+파일:
+- `src/trading_system/execution/step.py`
+- `src/trading_system/backtest/engine.py`
+- `src/trading_system/app/loop.py`
+- `src/trading_system/app/services.py`
+- `src/trading_system/api/routes/backtest.py`
+- `tests/unit/test_backtest_engine.py`
+- `tests/unit/test_live_loop.py`
+- 신규 `tests/integration/test_order_audit_integration.py`
+
+구체 작업:
+- audit sink interface를 `TradingContext` 또는 실행 호출 경계에 추가한다.
+- order/risk event를 `OrderAuditRecord`로 변환하는 helper를 만든다.
+- backtest create 경로가 run_id를 engine/services로 전달하게 한다.
+- live runtime controller가 session_id를 live loop audit owner로 전달하게 한다.
+- 저장 실패가 실행 결과를 바꾸지 않는지 regression test를 추가한다.
+
+종료 조건:
+- 백테스트 run과 live session owner id로 order audit record를 조회할 수 있다.
+
+### Step 3. Queue status와 retention operations 추가
+
+목적:
+- 운영자가 queue 상태와 저장소 누적 기록을 보고 안전하게 정리할 수 있게 한다.
+
+파일:
+- `src/trading_system/backtest/dispatcher.py`
+- `src/trading_system/backtest/repository.py`
+- `src/trading_system/backtest/file_repository.py`
+- `src/trading_system/backtest/supabase_repository.py`
+- `src/trading_system/api/routes/backtest.py`
+- `frontend/lib/api/backtests.ts`
+- `frontend/app/runs/page.tsx`
+- `tests/unit/test_backtest_dispatcher.py`
+- `tests/unit/test_file_repository.py`
+- `tests/unit/test_supabase_repository.py`
+- `tests/integration/test_backtest_run_api_integration.py`
+
+구체 작업:
+- dispatcher snapshot 메서드와 API endpoint를 추가한다.
+- retention preview service를 구현한다.
+- retention prune endpoint는 explicit confirm 없이는 400을 반환하게 한다.
+- runs 화면에 queue status와 retention preview/action 최소 UI를 추가한다.
+- cutoff/status 필터별 preview/prune 테스트를 추가한다.
+
+종료 조건:
+- dispatcher 상태가 API/UI에 표시되고, retention preview/prune이 안전장치와 함께 동작한다.
+
+### Step 4. Docs and runbook alignment
+
+목적:
+- architecture docs와 운영 runbook이 실제 구현 상태를 설명하게 한다.
+
+파일:
+- `docs/architecture/overview.ko.md`
+- `docs/architecture/overview.md`
+- `docs/architecture/workspace-analysis.ko.md`
+- `docs/architecture/workspace-analysis.md`
+- `docs/architecture/user-use-cases.ko.md`
+- `docs/architecture/user-use-cases.md`
+- `docs/runbooks/deploy-production.ko.md`
+- `docs/runbooks/deploy-production.md`
+
+구체 작업:
+- 백테스트 async dispatcher 상태를 현재 코드 기준으로 정정한다.
+- session history UX와 order audit API를 사용자 유즈케이스에 추가한다.
+- retention preview/prune 운영 절차를 runbook에 추가한다.
+- Supabase migration 적용 순서에 `004_add_order_audit_records.sql`을 추가한다.
+
+종료 조건:
+- docs가 Phase 14 구현 후 API/UI/storage contract와 충돌하지 않는다.
+
+## Validation Matrix
+
+### Required unit tests
+- `pytest tests/unit/test_order_audit_repository.py -q`
+- `pytest tests/unit/test_order_audit_routes.py -q`
+- `pytest tests/unit/test_backtest_dispatcher.py -q`
+- `pytest tests/unit/test_file_repository.py -q`
+- `pytest tests/unit/test_supabase_repository.py -q`
+- `pytest tests/unit/test_backtest_engine.py -q`
+- `pytest tests/unit/test_live_loop.py -q`
+
+### Required integration tests
+- `pytest tests/integration/test_order_audit_integration.py -q`
+- `pytest tests/integration/test_backtest_run_api_integration.py -q`
+- `pytest tests/integration/test_live_runtime_api_integration.py -q`
+
+### Frontend validation
+- `cd frontend && npm run lint`
+- `cd frontend && npm run build`
+- `cd frontend && npm run test:e2e`
+
+### Manual verification
+- dashboard에서 recent live session 목록과 detail dialog 확인
+- 백테스트 실행 후 `/api/v1/order-audit?scope=backtest&owner_id={run_id}` 조회
+- live paper session start/stop 후 `/api/v1/order-audit?scope=live_session&owner_id={session_id}` 조회
+- retention preview가 삭제 후보만 반환하고 실제 파일/row를 삭제하지 않는지 확인
+- confirm 없는 prune 요청이 거절되는지 확인
+
+## Recommended PR Slices
+
+1. Session history frontend UX
+2. Order audit repository, migration, route
+3. Backtest/live audit wiring
+4. Queue status, retention operations, runs UI
+5. Architecture docs and runbook alignment
+
+## Risks and Fallbacks
+
+- Audit sink가 trading step 내부에 과도하게 침투할 수 있다.
+
+대응:
+- event-to-record 변환 helper와 optional sink를 사용하고, core order/risk 로직은 변경하지 않는다.
+
+- Supabase migration 적용 전 API가 order audit table을 찾지 못할 수 있다.
+
+대응:
+- repository factory는 명확한 오류를 반환하고, deploy runbook에 migration 순서를 추가한다.
+
+- retention prune이 운영 데이터를 삭제할 위험이 있다.
+
+대응:
+- preview와 prune을 분리하고, prune에는 explicit confirm과 cutoff/status 조건을 요구한다.
+
+- frontend dashboard가 과밀해질 수 있다.
+
+대응:
+- session history는 접이식 패널 또는 compact table로 제한하고, order audit 상세는 run/session detail에서 조회한다.

--- a/prd/phase_14_prd.md
+++ b/prd/phase_14_prd.md
@@ -1,0 +1,228 @@
+# Phase 14 PRD
+
+관련 문서:
+- 이전 phase 범위/결과: `prd/phase_13_prd.md`
+- 이전 phase 실행 검증: `prd/phase_13_task.md`
+- 아키텍처 개요: `docs/architecture/overview.ko.md`
+- 워크스페이스 분석: `docs/architecture/workspace-analysis.ko.md`
+- 사용자 유즈케이스: `docs/architecture/user-use-cases.ko.md`
+- 상세 구현 계획: `prd/phase_14_implementation_plan.md`
+- 실행 추적: `prd/phase_14_task.md`
+
+## 문서 목적
+
+Phase 13까지의 구현으로 백테스트 run metadata, live runtime session history, API key governance, 운영 콘솔이 기본적으로 연결되었다. 코드를 다시 보면 백테스트 실행은 이미 `BacktestRunDispatcher`와 `queued/running/succeeded/failed` 상태를 통해 요청 경로에서 분리되었고, live session history도 파일 또는 Supabase 저장소에 남는다. 따라서 다음 구현 공백은 단순히 "비동기 실행 모델 추가"가 아니라, 이미 생긴 운영 기록을 운영자가 신뢰할 수 있는 표면으로 만들고 주문 단위 감사 가능성을 보강하는 것이다.
+
+`docs/architecture/*`는 아직 과거 세션 탐색 UX, 주문 lifecycle 저장소 부재, run 보존 정책 부재, queue 운영 가시성 부족을 주요 갭으로 남기고 있다. Phase 14는 이 갭을 하나의 운영 관점으로 묶는다. 목표는 live session history를 브라우저에서 탐색 가능하게 만들고, 백테스트/라이브 주문 이벤트를 durable audit record로 남기며, run/session/order 기록에 대한 보존과 운영 가시성을 최소 제품 수준으로 끌어올리는 것이다.
+
+## Goal
+
+1. 운영자가 프론트엔드에서 과거 live runtime session을 조회하고, preflight/종료 상태/오류를 빠르게 확인할 수 있게 한다.
+2. `execute_trading_step`에서 발생하는 주문 생성/체결/거절 이벤트를 백테스트와 라이브가 공유하는 durable order audit contract로 저장할 수 있게 한다.
+3. backtest run queue와 저장소 보존(retention)에 대한 API와 운영자 UI를 추가해 장시간/누적 실행의 운영 부담을 낮춘다.
+4. `docs/architecture/*`와 runbook을 새 운영 기록 모델에 맞춰 다시 정렬한다.
+
+이번 phase는 다음 원칙을 따른다.
+
+- trading semantics, 주문 수량 계산, 리스크 판정 결과는 바꾸지 않는다.
+- 기존 event log를 대체하지 않고, 감사와 조회에 필요한 최소 order record만 별도로 추가한다.
+- file repository와 Supabase repository가 같은 contract를 구현해야 한다.
+- UI는 운영자가 실제로 탐색해야 하는 정보만 먼저 노출하고, 대형 리포팅/검색 플랫폼은 도입하지 않는다.
+
+## Current Baseline
+
+- `BacktestRunDispatcher`는 queued/running/final 상태를 저장하지만, queue depth, worker 상태, 보존 정책, 운영자용 정리 API는 없다.
+- `LiveRuntimeSessionRecord`는 durable하게 저장되고 API로 조회되지만, 프론트엔드에는 과거 세션 전용 탐색 화면이 없다.
+- `execute_trading_step`은 `order.created`, `order.filled`, `order.rejected`, `risk.rejected` 이벤트를 emit하지만, 주문 단위 durable store는 없다.
+- KIS 실주문 경로는 `KisBrokerAdapter`를 통해 fill event로 정규화되지만, broker order id나 주문 lifecycle 감사 record를 보존하는 contract가 없다.
+- `FileBacktestRunRepository`와 `SupabaseBacktestRunRepository`는 delete/clear를 지원하지만, retention dry-run, cutoff 기반 pruning, admin API는 없다.
+- 프론트엔드 `dashboard`는 active runtime 모니터링에 강하지만, 종료된 session과 과거 order audit을 탐색하지 못한다.
+- `docs/architecture/workspace-analysis.ko.md`는 백테스트 실행이 동기 실행이라고 설명하는 부분이 남아 있어 현재 코드와 맞지 않는다.
+
+## Non-Goals
+
+- 외부 queue 서비스, Celery, Redis, Kafka 같은 신규 인프라 도입
+- 완전한 OMS(order management system) 구현
+- broker별 미체결 주문 취소/정정 워크플로
+- 다중 사용자 RBAC, SSO, 고객별 테넌트 분리
+- full-text audit search 또는 대규모 리포팅 warehouse
+- 전략 promotion/approval workflow
+- 주문 체결 알고리즘 또는 리스크 정책 변경
+
+## Hard Decisions
+
+### D-1. Session history UX는 dashboard 안의 운영 패널로 시작한다
+
+별도 대형 운영 앱을 만들지 않고 `frontend/app/dashboard/page.tsx` 안에 최근 세션 패널과 상세 dialog를 추가한다. 현재 dashboard가 active runtime의 진실 원천이므로, 과거 session 진입점도 같은 운영 콘솔에 두는 것이 사용자의 mental model과 맞다.
+
+### D-2. Order audit은 trading step 이벤트에서 파생하되 별도 저장소에 보존한다
+
+기존 structured logger는 실시간 이벤트 전달과 화면 표시에 적합하지만, 주문 감사에는 조회 가능한 안정 contract가 필요하다. 따라서 `OrderAuditRecord`를 새로 정의하고, `execute_trading_step` 또는 그 호출 경계에서 order/risk 이벤트를 append한다. 기존 이벤트 payload는 유지하되, audit record에는 `scope`, `run_id/session_id`, `symbol`, `side`, `quantity`, `status`, `reason`, `timestamp`, `broker_order_id` 같은 조회 필드를 1급화한다.
+
+### D-3. Retention은 삭제 실행과 dry-run을 분리한다
+
+운영 기록 삭제는 되돌리기 어렵다. cutoff 기반 retention API는 먼저 삭제 대상과 개수를 preview할 수 있어야 하며, 실제 prune은 명시적인 confirm payload를 요구한다.
+
+### D-4. Supabase schema 변화는 additive migration으로만 수행한다
+
+Phase 14는 운영 기록을 추가하는 단계이므로 기존 `backtest_runs`, `live_runtime_sessions`, API key schema를 깨지 않는다. 새 order audit table과 선택적 index를 additive하게 추가하고, 파일 저장소도 같은 shape로 직렬화한다.
+
+## Product Requirements
+
+### PR-1. Live session history browser workflow
+
+- dashboard에서 최근 live runtime session 목록을 조회할 수 있어야 한다.
+- 각 session은 `session_id`, 시작/종료 시각, provider, broker, live execution, symbols, final state, last error를 표시해야 한다.
+- session detail은 preflight summary와 warning/blocking reason을 보여줘야 한다.
+- API 호출 실패, 빈 목록, loading 상태가 모두 UI에서 명확히 처리되어야 한다.
+
+### PR-2. Durable order audit record
+
+- 백테스트와 라이브 실행에서 발생한 주문 생성/체결/거절/리스크 거절을 durable record로 저장할 수 있어야 한다.
+- record는 최소한 `record_id`, `scope`, `owner_id`, `event`, `symbol`, `side`, `requested_quantity`, `filled_quantity`, `price`, `status`, `reason`, `timestamp`, `payload`를 포함해야 한다.
+- list API는 `scope`, `owner_id`, `symbol`, `event`, `limit` 필터를 지원해야 한다.
+- 백테스트 run detail과 live session detail에서 해당 owner의 order audit을 조회할 수 있어야 한다.
+
+### PR-3. Backtest run queue and retention visibility
+
+- API는 dispatcher worker 상태와 현재 queue depth를 반환해야 한다.
+- run list UI는 queued/running 상태를 운영자가 이해할 수 있게 표시하고, 필요 시 polling cadence를 유지해야 한다.
+- retention preview API는 cutoff/status 기준 삭제 대상 개수를 반환해야 한다.
+- retention prune API는 명시 confirm 값이 있을 때만 삭제를 수행해야 한다.
+
+### PR-4. Documentation alignment
+
+- `docs/architecture/workspace-analysis.ko.md`와 영문본은 현재 async dispatcher 상태를 반영해야 한다.
+- user use case 문서는 session history UX, order audit, retention workflow를 새 진입점으로 설명해야 한다.
+- 운영 runbook은 retention/prune과 order audit 조회 절차를 포함해야 한다.
+
+## Scope By Epic
+
+### Epic A. Session history UX
+
+목표:
+- 이미 저장되는 live runtime session history를 운영자가 브라우저에서 탐색하게 만든다.
+
+포함:
+- frontend API 타입/client 추가
+- dashboard session history panel
+- session detail dialog
+- loading/empty/error 상태
+- e2e 또는 component-level smoke 검증
+
+제외:
+- 고급 검색, CSV export, incident timeline full drill-down
+
+### Epic B. Order audit persistence
+
+목표:
+- 주문 lifecycle과 리스크 거절을 run/session owner 기준으로 durable하게 조회하게 만든다.
+
+포함:
+- order audit DTO/protocol/repository
+- file/Supabase 저장소
+- trading step 호출 경계에서 audit append
+- list/detail API
+- 백테스트 run/live session detail 연결
+
+제외:
+- 주문 취소/정정 명령
+- broker별 order status polling
+- 외부 감사 export
+
+### Epic C. Queue visibility, retention, docs
+
+목표:
+- 운영자가 run queue와 저장소 누적 상태를 이해하고, 오래된 기록을 안전하게 정리할 수 있게 한다.
+
+포함:
+- dispatcher status API
+- retention preview/prune service
+- admin 또는 runs UI의 최소 retention control
+- architecture docs/runbook 업데이트
+
+제외:
+- cron scheduler
+- 자동 삭제 기본 활성화
+- multi-tenant quota
+
+## Impacted Files
+
+### Runtime/session frontend
+- `frontend/lib/api/types.ts`
+- `frontend/lib/api/dashboard.ts`
+- `frontend/app/dashboard/page.tsx`
+- 신규 `frontend/components/dashboard/SessionHistoryPanel.tsx`
+- 신규 `frontend/components/dashboard/SessionDetailDialog.tsx`
+- `frontend/e2e/smoke.spec.ts`
+
+### Order audit domain and repositories
+- 신규 `src/trading_system/execution/order_audit.py`
+- `src/trading_system/execution/step.py`
+- `src/trading_system/backtest/engine.py`
+- `src/trading_system/app/loop.py`
+- `src/trading_system/app/services.py`
+- `src/trading_system/api/server.py`
+- 신규 `src/trading_system/api/routes/order_audit.py`
+- `src/trading_system/api/schemas.py`
+- 신규 `scripts/migrations/004_add_order_audit_records.sql`
+
+### Queue, retention, and admin surfaces
+- `src/trading_system/backtest/dispatcher.py`
+- `src/trading_system/backtest/repository.py`
+- `src/trading_system/backtest/file_repository.py`
+- `src/trading_system/backtest/supabase_repository.py`
+- `src/trading_system/api/routes/backtest.py`
+- `frontend/app/runs/page.tsx`
+- `frontend/lib/api/backtests.ts`
+
+### Validation and docs
+- `tests/unit/test_backtest_dispatcher.py`
+- 신규 `tests/unit/test_order_audit_repository.py`
+- 신규 `tests/unit/test_order_audit_routes.py`
+- `tests/unit/test_backtest_engine.py`
+- `tests/unit/test_live_loop.py`
+- `tests/integration/test_backtest_run_api_integration.py`
+- `tests/integration/test_live_runtime_api_integration.py`
+- 신규 `tests/integration/test_order_audit_integration.py`
+- `docs/architecture/overview.ko.md`
+- `docs/architecture/overview.md`
+- `docs/architecture/workspace-analysis.ko.md`
+- `docs/architecture/workspace-analysis.md`
+- `docs/architecture/user-use-cases.ko.md`
+- `docs/architecture/user-use-cases.md`
+- `docs/runbooks/deploy-production.ko.md`
+- `docs/runbooks/deploy-production.md`
+
+## Delivery Slices
+
+### Slice 0. Live session history UX
+- dashboard에서 최근 session 목록과 detail dialog를 제공한다.
+
+### Slice 1. Order audit contract and repository
+- order audit DTO/protocol/file/Supabase repository와 migration을 추가한다.
+
+### Slice 2. Backtest/live order audit wiring and API
+- 백테스트와 라이브 실행 경계에서 audit record를 저장하고 조회 API를 추가한다.
+
+### Slice 3. Queue/retention operations
+- dispatcher status, retention preview/prune, UI 최소 제어를 구현한다.
+
+### Slice 4. Docs and runbook alignment
+- architecture docs와 운영 runbook을 새 session history/order audit/retention contract에 맞춰 정렬한다.
+
+## Success Metrics
+
+- dashboard에서 최근 live session 목록과 preflight/오류 상세를 확인할 수 있다.
+- 백테스트 run 또는 live session owner id로 주문 감사 record를 조회할 수 있다.
+- file 저장소와 Supabase 저장소 모두 order audit record 저장/조회 테스트를 통과한다.
+- dispatcher status API가 worker running 여부와 queue depth를 반환한다.
+- retention preview/prune은 dry-run과 confirm 실행이 분리되어 있다.
+- `docs/architecture/*`가 async dispatcher, session history UX, order audit, retention 상태를 실제 코드와 충돌 없이 설명한다.
+
+## Risks and Follow-up
+
+- order audit wiring이 trading step에 직접 결합되면 백테스트 결정성을 해칠 수 있으므로, 저장 실패는 기본적으로 trading result를 바꾸지 않는 best-effort 경계에서 처리해야 한다.
+- KIS broker order id가 현재 adapter contract에 없으므로 초기 phase에서는 optional field로 두고, KIS client가 제공하는 값만 채운다.
+- retention prune은 운영 데이터 삭제 위험이 있으므로 API key 보호와 confirm payload를 필수로 둔다.
+- session history UI가 커질 경우 별도 `/sessions` 라우트로 분리할 수 있지만, 초기에는 dashboard 내 패널로 제한한다.

--- a/prd/phase_14_task.md
+++ b/prd/phase_14_task.md
@@ -1,0 +1,181 @@
+# Phase 14 Task Breakdown
+
+## Usage
+
+- 이 파일은 Phase 14 구현 진행 상황과 검증 증적을 기록한다.
+- 체크박스는 실제 구현 작업과 검증 기준을 뜻한다.
+- 각 slice가 끝날 때 `Execution Log`를 갱신한다.
+- PRD 수준 범위는 `phase_14_prd.md`를 기준으로 한다.
+- 상세 설계와 순서는 `phase_14_implementation_plan.md`를 기준으로 한다.
+
+## Status Note
+
+- 이 문서는 `prd/phase_14_prd.md`의 실행 추적 문서다.
+- 현재 체크박스는 active backlog를 slice 단위로 분해한 것이며, 아직 구현 완료를 의미하지 않는다.
+- 이번 phase의 핵심은 session history UX, order audit persistence, queue/retention 운영 가시성이다.
+
+## Phase 14-0. Live session history UX
+
+- [x] `frontend/lib/api/types.ts`에 live runtime session list/detail 타입 추가
+- [x] `frontend/lib/api/dashboard.ts`에 session list/detail client 함수 추가
+- [x] `frontend/components/dashboard/SessionHistoryPanel.tsx` 신규 작성
+- [x] `frontend/components/dashboard/SessionDetailDialog.tsx` 신규 작성
+- [x] `frontend/app/dashboard/page.tsx`에 session history panel 연결
+- [x] session history loading/empty/error 상태 처리
+- [x] frontend smoke/e2e mock에 session history 응답 추가
+
+Exit criteria:
+- dashboard에서 최근 live session 목록을 볼 수 있고, session detail dialog에서 preflight summary와 종료 상태를 확인할 수 있다.
+
+## Phase 14-1. Order audit DTO/repository/migration 추가
+
+- [x] `src/trading_system/execution/order_audit.py`에 `OrderAuditRecord`와 repository protocol 정의
+- [x] file 기반 order audit repository 구현
+- [x] Supabase 기반 order audit repository 구현
+- [x] `create_order_audit_repository()` factory 추가
+- [x] `src/trading_system/api/schemas.py`에 order audit DTO 추가
+- [x] `src/trading_system/api/routes/order_audit.py` 신규 route 추가
+- [x] `src/trading_system/api/server.py`에 order audit repository와 router 연결
+- [x] `scripts/migrations/004_add_order_audit_records.sql` 작성
+
+Exit criteria:
+- order audit record를 file/Supabase 저장소에 저장하고 API로 필터 조회할 수 있다.
+
+## Phase 14-2. Backtest/live audit wiring
+
+- [x] audit sink interface 또는 optional callback을 trading 실행 경계에 추가
+- [x] `execute_trading_step`의 order/risk event를 audit record로 변환하는 helper 추가
+- [x] 백테스트 실행 경로가 `run_id`를 audit owner id로 전달
+- [x] live runtime 실행 경로가 `session_id`를 audit owner id로 전달
+- [x] audit 저장 실패가 백테스트 결과와 live loop 상태를 바꾸지 않도록 처리
+- [x] backtest owner 기준 order audit integration test 추가
+- [ ] live session owner 기준 order audit integration test 추가
+
+Exit criteria:
+- 백테스트 run과 live session에서 발생한 주문 생성/체결/거절/리스크 거절이 owner id 기준으로 조회된다.
+
+## Phase 14-3. Queue status와 retention operations 추가
+
+- [x] `BacktestRunDispatcher`에 status snapshot 추가
+- [x] dispatcher status API endpoint 추가
+- [x] file/Supabase repository의 `list/delete` contract를 조합하는 retention preview/prune API 구현
+- [x] prune API가 explicit confirm 없이는 거절되도록 구현
+- [x] `frontend/lib/api/backtests.ts`에 dispatcher/retention client 추가
+- [x] `frontend/app/runs/page.tsx`에 queue status와 retention 최소 UI 추가
+- [x] cutoff/status 기준 preview/prune 테스트 추가
+
+Exit criteria:
+- 운영자가 run queue 상태를 확인하고, preview 후 confirm을 통해 오래된 run 기록을 정리할 수 있다.
+
+## Phase 14-4. Docs and runbook alignment
+
+- [x] `docs/architecture/overview.ko.md`와 `overview.md` 업데이트
+- [x] `docs/architecture/workspace-analysis.ko.md`와 `workspace-analysis.md` 업데이트
+- [x] `docs/architecture/user-use-cases.ko.md`와 `user-use-cases.md` 업데이트
+- [x] `docs/runbooks/deploy-production.ko.md`와 `deploy-production.md`에 migration 절차 추가
+- [x] architecture docs에서 백테스트 실행 모델을 current async dispatcher 기준으로 정정
+
+Exit criteria:
+- architecture docs와 runbook이 Phase 14의 session history UX, order audit, queue/retention contract를 실제 코드와 일치하게 설명한다.
+
+## Verification Checklist
+
+### Required unit tests
+
+- [x] `pytest tests/unit/test_order_audit_repository.py -q`
+- [x] `pytest tests/unit/test_order_audit_routes.py -q`
+- [x] `pytest tests/unit/test_backtest_dispatcher.py -q`
+- [x] `pytest tests/unit/test_backtest_retention_routes.py -q`
+- [x] `pytest tests/unit/test_file_repository.py -q`
+- [x] `pytest tests/unit/test_supabase_repository.py -q`
+- [x] `pytest tests/unit/test_backtest_engine.py -q`
+- [x] `pytest tests/test_live_loop.py -q`
+
+### Required integration tests
+
+- [x] `pytest tests/integration/test_order_audit_integration.py -q`
+- [ ] `pytest tests/integration/test_backtest_run_api_integration.py -q`
+- [ ] `pytest tests/integration/test_live_runtime_api_integration.py -q`
+
+### Broader regression
+
+- [x] touched backend 범위 `ruff check`
+- [ ] `pytest --tb=short -q`
+- [x] `cd frontend && npm run lint`
+- [x] `cd frontend && npm run build`
+- [x] `cd frontend && npm run test:e2e`
+
+### Manual verification
+
+- [ ] dashboard에서 recent live session 목록과 detail dialog 확인
+- [ ] 백테스트 실행 후 backtest owner 기준 order audit 조회
+- [ ] live paper session start/stop 후 live session owner 기준 order audit 조회
+- [ ] retention preview가 실제 삭제 없이 후보만 반환하는지 확인
+- [ ] confirm 없는 prune 요청이 거절되는지 확인
+- [ ] confirm 있는 prune 요청이 cutoff/status 조건에 맞는 대상만 삭제하는지 확인
+
+## Execution Log
+
+### Date
+- 2026-04-27
+
+### Owner
+- Codex
+
+### Slice completed
+- Phase 14-0: live session history UX
+- Phase 14-1: order audit DTO/repository/migration
+- Phase 14-2: backtest/live audit wiring, except live-session integration evidence
+- Phase 14-3: dispatcher status and retention operations
+- Phase 14-4: architecture docs and deploy runbook alignment
+
+### Scope implemented
+- Dashboard recent live session panel and detail dialog.
+- Durable order audit repository for file/Supabase, API route, migration, and backtest/live audit owner wiring.
+- Backtest dispatcher status endpoint and cutoff/status retention preview/prune endpoint with explicit `DELETE` confirmation.
+- Runs page dispatcher and retention controls.
+- Architecture docs and deployment migration notes updated for dispatcher/order audit/session history.
+
+### Files changed
+- `src/trading_system/execution/order_audit.py`
+- `src/trading_system/api/routes/order_audit.py`
+- `src/trading_system/api/routes/backtest.py`
+- `src/trading_system/api/schemas.py`
+- `src/trading_system/api/server.py`
+- `src/trading_system/app/services.py`
+- `src/trading_system/app/loop.py`
+- `src/trading_system/backtest/engine.py`
+- `src/trading_system/backtest/dispatcher.py`
+- `src/trading_system/execution/step.py`
+- `frontend/app/dashboard/page.tsx`
+- `frontend/app/runs/page.tsx`
+- `frontend/components/dashboard/SessionHistoryPanel.tsx`
+- `frontend/components/dashboard/SessionDetailDialog.tsx`
+- `frontend/lib/api/backtests.ts`
+- `frontend/lib/api/dashboard.ts`
+- `frontend/lib/api/types.ts`
+- `scripts/migrations/004_add_order_audit_records.sql`
+- `docs/architecture/*.md`
+- `docs/runbooks/deploy-production*.md`
+- order audit and retention related tests
+
+### Commands run
+- `ruff check ...` touched backend/test files -> passed
+- `pytest tests/unit/test_order_audit_repository.py tests/unit/test_order_audit_routes.py tests/unit/test_backtest_engine.py -q` -> `12 passed`
+- `pytest tests/unit/test_order_audit_repository.py tests/unit/test_order_audit_routes.py tests/unit/test_backtest_engine.py tests/unit/test_backtest_dispatcher.py tests/unit/test_backtest_retention_routes.py tests/unit/test_file_repository.py tests/unit/test_supabase_repository.py tests/integration/test_order_audit_integration.py tests/test_live_loop.py -q` -> `53 passed, 1 skipped`
+- `pytest tests/unit/test_backtest_retention_routes.py -q` -> `2 passed`
+- `pytest tests/test_live_loop.py -q` -> `2 passed`
+- `cd frontend && npm run lint` -> passed
+- `cd frontend && npm run build` -> passed
+- `cd frontend && npm run test:e2e` -> `3 passed`
+- `timeout 20s pytest tests/integration/test_order_audit_integration.py -q` before rewriting TestClient usage -> timed out due `TestClient(create_app())` environment hang
+
+### Validation results
+- Backend lint and focused unit/integration tests passed after replacing the new order-audit integration test with direct route/repository boundary verification.
+- Frontend lint, production build, and Playwright smoke tests passed.
+- `TestClient(create_app())` still hangs in this environment at app lifespan entry, matching prior Phase 13 validation risk; TestClient-heavy integration suites were not re-run successfully.
+
+### Risks / follow-up
+- live session owner audit wiring is implemented via `LiveTradingLoop.audit_owner_id`, but a live-session order audit integration test remains open because `TestClient(create_app())` hangs in this environment.
+- Retention is implemented as an API service over repository `list/delete`, not as dedicated repository pruning methods.
+- Order audit captures step-level order/risk events; broker-specific unresolved-order polling and cancel/replace workflows remain out of scope.

--- a/prd/phase_15_implementation_plan.md
+++ b/prd/phase_15_implementation_plan.md
@@ -1,0 +1,351 @@
+# Phase 15 Implementation Plan
+
+## Goal
+
+Phase 15의 구현 목표는 Phase 14에서 추가된 운영 기록을 live 운영에서 신뢰 가능한 근거와 검증 가능한 contract로 보강하는 것이다. 핵심은 broker open-order authority, broker order id audit propagation, audit search/export, strategy config parity다.
+
+핵심 구현 원칙:
+
+1. trading decision과 risk semantics는 변경하지 않는다.
+2. broker 상태가 불확실하면 포트폴리오를 조정하지 않는 fail-closed 동작을 유지한다.
+3. 신규 broker capability는 optional로 두어 simulator/backtest 경로를 깨지 않는다.
+4. audit export는 bounded API response로 제한한다.
+5. config shape 변경은 코드, 예시, README, architecture docs를 함께 갱신한다.
+
+## Preconditions
+
+- Phase 14의 `OrderAuditRecord`, file/Supabase repository, `/api/v1/order-audit` route가 baseline이다.
+- `LiveTradingLoop.audit_owner_id`와 `AppServices.build_live_loop(session_id=...)`는 이미 live session owner id 전달을 지원한다.
+- `KisOrderResult.order_id`는 이미 존재하지만 `FillEvent`와 step audit payload에는 optional broker id 전달 경로가 없다.
+- KIS 미체결 주문 조회는 실제 API 응답 차이가 있을 수 있으므로 transport fixture 기반 parser 테스트를 먼저 고정한다.
+- `TestClient(create_app())` lifespan hang은 known validation risk로 취급하고, live audit 검증은 route-service boundary와 direct loop 테스트를 우선한다.
+
+## Locked Design Decisions
+
+### 1. Open order는 `AccountBalanceSnapshot`과 분리된 broker capability다
+
+`AccountBalanceSnapshot`에 많은 필드를 더하지 않고, `OpenOrder`와 `OpenOrderSnapshot` DTO를 `execution.broker`에 추가한다. `BrokerSimulator` protocol에는 `get_open_orders()`를 optional capability로 추가하고, `ResilientBroker`는 delegate가 메서드를 제공할 때만 호출한다.
+
+### 2. Reconciliation pending source 우선순위는 open orders -> balance pending signal이다
+
+`LiveTradingLoop._maybe_reconcile()` 또는 reconciliation service 경계에서 open-order snapshot을 먼저 조회한다. open orders가 있으면 pending symbols는 open orders에서 계산한다. open-order 조회가 unsupported면 balance snapshot의 `pending_symbols`를 사용한다. open-order 조회가 supported지만 실패하면 reconciliation은 skip한다.
+
+### 3. Broker order id는 optional `FillEvent.broker_order_id`로 전달한다
+
+KIS adapter는 `KisOrderResult.order_id`를 `FillEvent.broker_order_id`에 넣는다. simulator는 기본 `None`을 사용한다. `execute_trading_step`의 fill event payload와 `OrderAuditRecord.broker_order_id`는 이 값을 보존한다.
+
+### 4. Audit export는 repository list contract 확장 위에 얹는다
+
+file/Supabase repository의 `list()` 필터를 확장하고, API route에서 CSV/JSONL 직렬화를 담당한다. DB-specific export SQL을 먼저 만들지 않는다.
+
+### 5. YAML strategy config는 app runtime settings로 변환한다
+
+`config.settings`는 typed YAML schema를 검증하고, 별도 helper가 `trading_system.app.settings.AppSettings`로 변환한다. CLI는 `--strategy-profile-id`를 우선 추가하고, 복잡한 inline strategy는 `--config` 또는 YAML path 흐름으로 유도한다.
+
+## Contract Deltas
+
+## A. Broker open-order contract
+
+대상:
+- `src/trading_system/execution/broker.py`
+- `src/trading_system/execution/kis_adapter.py`
+- `src/trading_system/integrations/kis.py`
+
+필수 변화:
+- `OpenOrder`와 `OpenOrderSnapshot` DTO 추가
+- `get_open_orders()` optional broker capability 추가
+- KIS open/unresolved order query와 parser 추가
+- `ResilientBroker.get_open_orders()` resilience wrapper 추가
+
+비고:
+- KIS API 세부 응답은 fixture로 고정하고, 필수 필드가 없으면 `KisResponseError`를 발생시킨다.
+
+## B. Reconciliation pending authority
+
+대상:
+- `src/trading_system/execution/reconciliation.py`
+- `src/trading_system/app/loop.py`
+
+필수 변화:
+- reconciliation 호출 경계에 pending source metadata를 전달하거나, snapshot의 pending symbols를 open-order 결과로 대체한다.
+- open-order 조회 실패 시 `portfolio.reconciliation.skipped` 또는 전용 event를 남기고 book mutation을 하지 않는다.
+- open-order source와 fallback source를 structured logger payload에 포함한다.
+
+비고:
+- `reconcile()` 자체는 가능한 한 pure mutation 함수로 유지하고, broker 조회 orchestration은 live loop에 둔다.
+
+## C. Broker order id audit propagation
+
+대상:
+- `src/trading_system/execution/broker.py`
+- `src/trading_system/execution/kis_adapter.py`
+- `src/trading_system/execution/step.py`
+- `src/trading_system/execution/order_audit.py`
+
+필수 변화:
+- `FillEvent`에 optional `broker_order_id` 추가
+- KIS fill conversion에서 order id 보존
+- step fill payload에 `broker_order_id` 포함
+- order audit record 변환이 해당 값을 보존
+
+비고:
+- 기존 simulator fixture는 broker id 없이 계속 통과해야 한다.
+
+## D. Order audit filter and export contract
+
+대상:
+- `src/trading_system/execution/order_audit.py`
+- `src/trading_system/api/routes/order_audit.py`
+- `src/trading_system/api/schemas.py`
+- `frontend/lib/api/types.ts`
+- `frontend/lib/api/backtests.ts`
+- `frontend/lib/api/dashboard.ts`
+- `frontend/app/runs/[runId]/page.tsx`
+- `frontend/components/dashboard/SessionDetailDialog.tsx`
+
+필수 변화:
+- list 필터에 `start`, `end`, `status`, `side`, `broker_order_id`, `sort` 추가
+- CSV/JSONL export route 추가
+- frontend owner 기준 export action 추가
+- API 상한과 invalid filter validation 추가
+
+비고:
+- export는 API key middleware 뒤에 남고, public unauthenticated download URL은 만들지 않는다.
+
+## E. Strategy config parity
+
+대상:
+- `src/trading_system/config/settings.py`
+- `src/trading_system/app/settings.py`
+- `src/trading_system/app/main.py`
+- `src/trading_system/app/services.py`
+- `configs/base.yaml`
+- `examples/sample_backtest.yaml`
+- `examples/sample_backtest_krx.yaml`
+- `examples/sample_live_kis.yaml`
+- `README.md`
+
+필수 변화:
+- YAML `strategy` section typed parser 추가
+- YAML-to-runtime `AppSettings` adapter 추가
+- CLI `--strategy-profile-id`와 선택적 `--config` 진입점 추가
+- API와 동일한 validation semantics 재사용
+- config/examples/docs 업데이트
+
+비고:
+- inline pattern strategy의 복잡한 label mapping은 YAML을 primary path로 둔다.
+
+## Sequenced Implementation
+
+### Step 0. Open-order contract and KIS parser
+
+목적:
+- broker가 미체결 주문을 명시적으로 제공할 수 있는 최소 contract를 만든다.
+
+파일:
+- `src/trading_system/execution/broker.py`
+- `src/trading_system/execution/kis_adapter.py`
+- `src/trading_system/integrations/kis.py`
+- `tests/unit/test_kis_integration.py`
+
+구체 작업:
+- `OpenOrder`와 `OpenOrderSnapshot` dataclass를 추가한다.
+- `ResilientBroker.get_open_orders()`를 optional delegate method로 구현한다.
+- `KisApiClient.inquire_open_orders()`와 parser helper를 추가한다.
+- KIS 정상 응답, 빈 응답, 필수 필드 누락, API error 테스트를 작성한다.
+
+종료 조건:
+- KIS open-order parser와 broker adapter가 fixture 기반 unit test를 통과한다.
+
+### Step 1. Reconciliation pending authority hardening
+
+목적:
+- pending symbol 판단을 open-order source 우선으로 강화하고 불확실한 상태에서는 mutation을 막는다.
+
+파일:
+- `src/trading_system/app/loop.py`
+- `src/trading_system/execution/reconciliation.py`
+- `tests/unit/test_reconciliation.py`
+- `tests/integration/test_kis_reconciliation_integration.py`
+
+구체 작업:
+- live loop reconciliation 전에 open-order snapshot을 조회한다.
+- open orders가 있으면 balance snapshot의 pending symbols를 open-order symbols로 대체하거나 merge policy를 명시한다.
+- open-order 조회 실패 시 reconciliation skip event를 남기고 book을 수정하지 않는다.
+- logger payload에 `pending_source=open_orders|balance_snapshot|unsupported`를 포함한다.
+- open-order source 우선순위와 fail-closed regression test를 추가한다.
+
+종료 조건:
+- pending order가 있는 심볼은 open-order source 기준으로 조정되지 않고, 조회 실패 시 cash/position이 변경되지 않는다.
+
+### Step 2. Broker order id audit propagation and live audit verification
+
+목적:
+- 실제 broker order id가 order audit record까지 도달하고 live session owner audit이 검증되게 한다.
+
+파일:
+- `src/trading_system/execution/broker.py`
+- `src/trading_system/execution/kis_adapter.py`
+- `src/trading_system/execution/step.py`
+- `src/trading_system/execution/order_audit.py`
+- `tests/unit/test_kis_integration.py`
+- `tests/unit/test_live_loop.py`
+- `tests/integration/test_order_audit_integration.py`
+
+구체 작업:
+- `FillEvent.broker_order_id` optional 필드를 추가한다.
+- KIS `_to_fill_event()`가 `result.order_id`를 전달하게 한다.
+- step fill payload와 order audit conversion에 broker order id를 포함한다.
+- direct `LiveTradingLoop` 또는 service-boundary 테스트로 `scope=live_session`, `owner_id=session_id` record 생성을 검증한다.
+- audit append 실패가 live tick을 실패시키지 않는 regression test를 추가한다.
+
+종료 조건:
+- KIS order id가 audit record의 `broker_order_id`에 보존되고, live session owner audit 테스트가 TestClient 없이 통과한다.
+
+### Step 3. Order audit filter/export
+
+목적:
+- 운영자가 owner, 시간, 상태, broker id 기준으로 audit record를 좁히고 export할 수 있게 한다.
+
+파일:
+- `src/trading_system/execution/order_audit.py`
+- `src/trading_system/api/routes/order_audit.py`
+- `src/trading_system/api/schemas.py`
+- `frontend/lib/api/types.ts`
+- `frontend/lib/api/backtests.ts`
+- `frontend/lib/api/dashboard.ts`
+- `frontend/app/runs/[runId]/page.tsx`
+- `frontend/components/dashboard/SessionDetailDialog.tsx`
+- `tests/unit/test_order_audit_repository.py`
+- `tests/unit/test_order_audit_routes.py`
+
+구체 작업:
+- repository list signature와 file/Supabase filtering을 확장한다.
+- API query validation과 sort direction을 추가한다.
+- `/api/v1/order-audit/export` route를 CSV/JSONL bounded response로 구현한다.
+- frontend API client와 owner 기준 export button/action을 추가한다.
+- export content type, 필터 적용, limit 상한 테스트를 작성한다.
+
+종료 조건:
+- API가 필터링된 audit record를 CSV/JSONL로 반환하고, run/session UI에서 owner 기준 export를 요청할 수 있다.
+
+### Step 4. Strategy config parity
+
+목적:
+- 전략 설정을 YAML/CLI/API에서 같은 의미로 사용할 수 있게 한다.
+
+파일:
+- `src/trading_system/config/settings.py`
+- `src/trading_system/app/settings.py`
+- `src/trading_system/app/main.py`
+- `src/trading_system/app/services.py`
+- `configs/base.yaml`
+- `examples/sample_backtest.yaml`
+- `examples/sample_backtest_krx.yaml`
+- `examples/sample_live_kis.yaml`
+- `README.md`
+- `tests/unit/test_config_settings.py`
+- `tests/unit/test_app_main.py`
+- `tests/unit/test_strategy_factory.py`
+
+구체 작업:
+- YAML `strategy` section parser를 추가한다.
+- parsed config를 `AppSettings`로 변환하는 helper를 추가한다.
+- CLI에 `--config`와 `--strategy-profile-id`를 추가하고 우선순위를 문서화한다.
+- invalid profile id, inline mapping 누락, threshold 범위 오류 테스트를 추가한다.
+- config/examples/README에 strategy 설정 예시를 반영한다.
+
+종료 조건:
+- YAML과 CLI가 저장된 strategy profile을 선택할 수 있고, API runtime setting과 같은 validation 오류를 낸다.
+
+### Step 5. Docs and verification alignment
+
+목적:
+- 새 operational contract와 검증 방식을 문서에 반영한다.
+
+파일:
+- `docs/architecture/overview.ko.md`
+- `docs/architecture/overview.md`
+- `docs/architecture/workspace-analysis.ko.md`
+- `docs/architecture/workspace-analysis.md`
+- `docs/architecture/user-use-cases.ko.md`
+- `docs/architecture/user-use-cases.md`
+- `docs/runbooks/kis-domestic-live-operations.ko.md`
+- `docs/runbooks/kis-domestic-live-operations.md`
+- `docs/runbooks/incident-response.ko.md`
+- `docs/runbooks/incident-response.md`
+- `docs/runbooks/release-gate-checklist.md`
+
+구체 작업:
+- architecture docs에 open-order authority와 fallback policy를 설명한다.
+- user use cases에 audit export와 strategy config parity를 추가한다.
+- KIS runbook에 open-order query 실패 시 운영 대응을 추가한다.
+- incident response에 broker id 기반 audit 조회 절차를 추가한다.
+- release gate checklist에 TestClient-independent live audit 검증 항목을 추가한다.
+
+종료 조건:
+- 문서가 Phase 15의 broker pending-order, audit export, strategy config contract를 코드와 일치하게 설명한다.
+
+## Validation Matrix
+
+### Required unit tests
+- `pytest tests/unit/test_kis_integration.py -q`
+- `pytest tests/unit/test_reconciliation.py -q`
+- `pytest tests/unit/test_order_audit_repository.py -q`
+- `pytest tests/unit/test_order_audit_routes.py -q`
+- `pytest tests/unit/test_live_loop.py -q`
+- `pytest tests/unit/test_config_settings.py -q`
+- `pytest tests/unit/test_app_main.py -q`
+- `pytest tests/unit/test_strategy_factory.py -q`
+
+### Required integration tests
+- `pytest tests/integration/test_kis_reconciliation_integration.py -q`
+- `pytest tests/integration/test_order_audit_integration.py -q`
+
+### Frontend validation
+- `cd frontend && npm run lint`
+- `cd frontend && npm run build`
+- `cd frontend && npm run test:e2e`
+
+### Manual verification
+- KIS fixture 또는 sandbox 응답으로 open-order snapshot이 pending symbols를 만드는지 확인
+- live paper session에서 `scope=live_session&owner_id={session_id}` audit record 조회
+- KIS stub order id가 `/api/v1/order-audit` 응답의 `broker_order_id`에 나타나는지 확인
+- order audit CSV/JSONL export가 owner/time/status 필터를 적용하는지 확인
+- YAML config와 CLI `--strategy-profile-id`가 같은 strategy profile을 선택하는지 확인
+
+## Recommended PR Slices
+
+1. Open-order contract + KIS parser
+2. Reconciliation pending authority hardening
+3. Broker order id audit propagation + live audit tests
+4. Order audit search/export + frontend owner actions
+5. Strategy config parity + config/examples/README
+6. Architecture docs and runbook alignment
+
+## Risks and Fallbacks
+
+- KIS open-order endpoint shape가 문서 또는 계좌 유형별로 다를 수 있다.
+
+대응:
+- parser를 좁고 명시적으로 작성하고, 누락 필드는 fail-closed 오류로 처리한다. 운영 확인 전에는 fallback balance pending signal을 유지한다.
+
+- `FillEvent` optional field 추가가 많은 테스트 fixture에 영향을 줄 수 있다.
+
+대응:
+- dataclass field default를 `None`으로 두고, 기존 positional 생성 호출을 점검한다. 필요한 경우 keyword-only 전환 대신 최소 수정으로 유지한다.
+
+- audit export가 너무 많은 데이터를 메모리에 올릴 수 있다.
+
+대응:
+- API limit 상한을 두고, 대량 export는 후속 phase의 background job으로 넘긴다.
+
+- YAML strategy parser와 app runtime settings가 중복 검증을 만들 수 있다.
+
+대응:
+- YAML parser는 타입/shape 검증만 하고, runtime 의미 검증은 `AppSettings.validate()`를 재사용한다.
+
+- TestClient hang으로 HTTP integration evidence가 다시 부족할 수 있다.
+
+대응:
+- live audit과 export 핵심은 route function, repository, service-boundary 테스트로 검증하고, TestClient smoke는 별도 residual risk로 기록한다.

--- a/prd/phase_15_prd.md
+++ b/prd/phase_15_prd.md
@@ -1,0 +1,273 @@
+# Phase 15 PRD
+
+관련 문서:
+- 이전 phase 범위/결과: `prd/phase_14_prd.md`
+- 이전 phase 실행 검증: `prd/phase_14_task.md`
+- 아키텍처 개요: `docs/architecture/overview.ko.md`
+- 워크스페이스 분석: `docs/architecture/workspace-analysis.ko.md`
+- 사용자 유즈케이스: `docs/architecture/user-use-cases.ko.md`
+- 상세 구현 계획: `prd/phase_15_implementation_plan.md`
+- 실행 추적: `prd/phase_15_task.md`
+
+## 문서 목적
+
+Phase 14까지의 코드는 live session history, durable order audit, dispatcher status, retention preview/prune을 구현했다. `docs/architecture/*`도 이 상태를 반영하지만, 더 깊게 보면 다음 구현 공백은 "기록을 남기는 것"이 아니라 "운영 중 기록을 신뢰하고 재사용하는 것"이다.
+
+현재 KIS reconciliation은 잔고 스냅샷의 `ord_psbl_qty < hldg_qty` 신호로 pending symbol을 추론한다. 이는 fail-closed 경계로는 유효하지만, 주문 감사 record와 broker order id가 생긴 현재 기준으로는 broker-side unresolved/open order authority가 부족하다. 또한 live order audit wiring은 구현되어 있으나, Phase 14 task에 live session owner 기준 integration evidence가 아직 남아 있다.
+
+Phase 15는 live 운영 신뢰도를 높이는 보강 phase다. 목표는 KIS 미체결 주문 근거를 별도 contract로 승격하고, order audit export/search를 최소 운영 도구로 확장하며, CLI/YAML/API 사이의 전략 설정 parity를 정리하고, TestClient hang에 취약하지 않은 live audit 검증 경계를 만드는 것이다.
+
+## Goal
+
+1. KIS 또는 broker adapter가 미체결/open order snapshot을 제공할 수 있는 contract를 추가하고, reconciliation pending 판단의 근거를 잔고 휴리스틱보다 명시적인 source로 강화한다.
+2. live session owner 기준 order audit 생성/조회가 통합 테스트 또는 route-service 경계 테스트로 검증되게 한다.
+3. order audit을 운영자가 사건 조사에 사용할 수 있도록 시간 범위 필터와 CSV/JSONL export contract를 추가한다.
+4. `strategy.profile_id`와 inline pattern strategy 설정을 YAML/CLI/API에서 일관되게 사용할 수 있도록 config parity를 정리한다.
+5. architecture docs와 runbook을 새 broker pending-order authority, audit export, config parity 기준으로 갱신한다.
+
+이번 phase는 다음 원칙을 따른다.
+
+- trading decision, sizing, risk rule semantics는 변경하지 않는다.
+- 불확실한 broker 상태에서는 기존처럼 fail-closed 한다.
+- broker별 미체결 주문 API가 없을 때도 잔고 기반 fallback은 명시적으로 남긴다.
+- 감사 export는 운영 보조 기능이며, 외부 warehouse나 BI 파이프라인을 도입하지 않는다.
+- config shape 변경은 `configs/`, `examples/`, `README.md`, architecture docs를 함께 갱신한다.
+
+## Current Baseline
+
+- `OrderAuditRecord`는 file/Supabase repository와 `/api/v1/order-audit` 조회 API를 갖는다.
+- `LiveTradingLoop.audit_owner_id`는 live session id를 audit owner로 전달한다.
+- Phase 14 task에는 live session owner 기준 order audit integration test가 미완료로 남아 있다.
+- `KisApiClient.inquire_balance()`는 cash, positions, average costs, `pending_symbols`를 반환하지만, pending source는 `ord_psbl_qty` 기반 휴리스틱이다.
+- `KisOrderResult.order_id`는 존재하지만 `FillEvent`에는 broker order id가 없어 step-level fill audit payload가 broker id를 안정적으로 보존하지 못한다.
+- `app.settings.AppSettings`는 `strategy.profile_id`와 inline strategy 설정을 표현할 수 있지만, CLI parser는 strategy profile 선택 플래그를 제공하지 않는다.
+- `config.settings.load_settings()`의 typed YAML loader는 runtime strategy 설정을 아직 1급 필드로 파싱하지 않는다.
+- `/api/v1/order-audit`는 `scope`, `owner_id`, `symbol`, `event`, `limit` 필터만 제공하며 시간 범위, 정렬 방향, export format은 없다.
+- `docs/architecture/workspace-analysis.ko.md`의 권장 다음 백로그는 외부 queue, session export, unresolved/open-order source, config parity, operational hardening을 남은 갭으로 둔다.
+
+## Non-Goals
+
+- Redis/Celery/Kafka 같은 외부 queue 또는 분산 worker 도입
+- 완전한 OMS, cancel/replace, bracket order, order status polling daemon 구현
+- KIS 외 다른 broker의 실제 미체결 주문 API 연동
+- 다중 사용자 RBAC, SSO, tenant 분리
+- 감사 데이터를 외부 warehouse로 적재하는 managed export pipeline
+- 전략 승인/promotion workflow
+- 백테스트 성능 최적화 또는 analytics 지표 확장
+
+## Hard Decisions
+
+### D-1. Pending order authority는 broker capability로 추가한다
+
+`AccountBalanceSnapshot.pending_symbols`는 유지하되, 새 `OpenOrderSnapshot` 또는 동등한 DTO를 broker capability로 추가한다. reconciliation은 open-order snapshot을 우선 사용하고, broker가 제공하지 못하거나 조회 실패하면 기존 balance snapshot의 pending signal을 fallback으로 사용한다. 조회 실패는 포트폴리오를 수정하지 않는 fail-closed 경계로 처리한다.
+
+### D-2. Broker order id는 fill event의 optional metadata로 승격한다
+
+`KisOrderResult.order_id`가 audit record까지 도달하려면 `FillEvent` 또는 execution event payload에 optional `broker_order_id`가 필요하다. 필드는 optional로 두어 simulator와 기존 테스트를 깨지 않으며, KIS adapter만 값을 채운다.
+
+### D-3. Audit export는 API-level streaming이 아니라 bounded response로 시작한다
+
+초기 export는 `limit <= 5000` 같은 상한을 둔 CSV/JSONL response로 제한한다. 대량 감사 로그를 위한 object storage, background export job, signed URL은 이번 phase 범위에서 제외한다.
+
+### D-4. Config parity는 typed YAML을 runtime settings로 변환하는 단일 helper로 맞춘다
+
+`config.settings`와 `app.settings`를 무리하게 합치지 않는다. 대신 YAML loader가 strategy section을 typed하게 파싱하고, CLI/API가 쓰는 `AppSettings`로 변환하는 작은 adapter를 둔다. CLI에는 `--strategy-profile-id`와 최소 inline pattern strategy 옵션을 추가하되, 복잡한 JSON 입력은 config file 경로를 권장한다.
+
+### D-5. TestClient hang을 우회하는 검증 경계를 공식화한다
+
+Phase 13/14에서 `TestClient(create_app())` lifespan hang이 반복되었다. Phase 15의 live audit 검증은 route handler + repository + live loop service boundary를 직접 조합하는 테스트를 우선 작성하고, TestClient 기반 통합 테스트는 별도 smoke로 유지한다.
+
+## Product Requirements
+
+### PR-1. Broker open-order authority
+
+- broker adapter contract는 open/unresolved order snapshot을 optional로 제공할 수 있어야 한다.
+- snapshot은 최소 `broker_order_id`, `symbol`, `side`, `requested_quantity`, `remaining_quantity`, `status`, `submitted_at`을 표현해야 한다.
+- KIS adapter는 가능한 KIS 응답을 통해 open order snapshot을 구성해야 한다.
+- KIS open-order 조회 실패 또는 필수 필드 누락 시 reconciliation은 포트폴리오를 조정하지 않고 skip/fail-closed 이벤트를 남겨야 한다.
+- open-order snapshot이 제공되면 pending symbols는 이 snapshot을 우선 기준으로 계산해야 한다.
+
+### PR-2. Broker order id audit propagation
+
+- KIS order submission 결과의 `order_id`가 fill event 또는 audit payload로 보존되어야 한다.
+- `/api/v1/order-audit` 응답의 `broker_order_id`는 KIS 주문 감사 record에서 채워져야 한다.
+- simulator와 기존 backtest path는 broker order id가 없어도 동일하게 동작해야 한다.
+
+### PR-3. Live session audit verification
+
+- live paper 또는 stubbed live loop 실행에서 `scope=live_session`, `owner_id=session_id` audit record가 생성되는 테스트가 있어야 한다.
+- 테스트는 `TestClient(create_app())` lifespan에 의존하지 않아야 한다.
+- audit repository append 실패가 live loop tick 상태와 portfolio persistence를 깨지 않는 regression test가 있어야 한다.
+
+### PR-4. Order audit search and export
+
+- audit list API는 `start`, `end`, `status`, `side`, `broker_order_id`, `sort` 필터를 지원해야 한다.
+- export API는 owner/scope/time filter를 적용한 CSV와 JSONL 중 하나를 요청할 수 있어야 한다.
+- export 응답은 record count와 applied filter를 알 수 있어야 한다.
+- frontend는 run detail 또는 dashboard session detail에서 owner 기준 audit export action을 제공해야 한다.
+
+### PR-5. Strategy config parity
+
+- typed YAML config는 `strategy.profile_id` 또는 inline pattern strategy section을 파싱할 수 있어야 한다.
+- YAML config에서 읽은 strategy 설정은 `AppSettings.strategy`와 같은 validation semantics를 사용해야 한다.
+- CLI는 저장된 strategy profile을 선택하는 플래그를 제공해야 한다.
+- `configs/base.yaml`, `examples/*.yaml`, `README.md`는 새 설정 shape와 우선순위를 설명해야 한다.
+
+## Scope By Epic
+
+### Epic A. Broker open-order and reconciliation authority
+
+목표:
+- reconciliation pending 판단을 broker-side open order source로 강화한다.
+
+포함:
+- open order DTO/protocol
+- `BrokerSimulator` optional capability
+- KIS open/unresolved order 조회 구현
+- reconciliation 우선순위 변경
+- KIS parser/fail-closed 테스트
+
+제외:
+- 주문 취소/정정 실행
+- long-running order polling worker
+- KIS 외 broker의 실제 open order API
+
+### Epic B. Audit propagation, search, and export
+
+목표:
+- order audit이 live 사건 조사와 운영 리포팅에 바로 쓸 수 있는 최소 표면을 갖게 한다.
+
+포함:
+- broker order id propagation
+- audit repository 필터 확장
+- CSV/JSONL export API
+- run/session owner 기준 frontend export action
+- live session owner audit regression test
+
+제외:
+- 대량 비동기 export job
+- 외부 object storage upload
+- full-text search
+
+### Epic C. Strategy configuration parity
+
+목표:
+- CLI, YAML, API에서 strategy profile/inline strategy 설정 의미가 갈라지지 않게 한다.
+
+포함:
+- YAML strategy section parser
+- YAML-to-`AppSettings` adapter
+- CLI strategy profile flag
+- config/examples/README 업데이트
+- validation regression test
+
+제외:
+- 전략 approval/promotion workflow
+- plugin registry
+- UI strategy editor 확장
+
+### Epic D. Docs and verification baseline
+
+목표:
+- 반복된 TestClient hang 리스크와 새 운영 contract를 문서와 테스트 기준에 반영한다.
+
+포함:
+- route-service boundary integration test pattern 문서화
+- architecture docs 업데이트
+- KIS/live runbook 업데이트
+- release gate checklist 업데이트
+
+제외:
+- 전체 테스트 인프라 교체
+- CI provider 변경
+
+## Impacted Files
+
+### Broker and reconciliation
+- `src/trading_system/execution/broker.py`
+- `src/trading_system/execution/kis_adapter.py`
+- `src/trading_system/execution/reconciliation.py`
+- `src/trading_system/integrations/kis.py`
+- `src/trading_system/app/loop.py`
+
+### Order audit API, repository, and frontend
+- `src/trading_system/execution/order_audit.py`
+- `src/trading_system/api/routes/order_audit.py`
+- `src/trading_system/api/schemas.py`
+- `src/trading_system/api/server.py`
+- `frontend/lib/api/types.ts`
+- `frontend/lib/api/backtests.ts`
+- `frontend/lib/api/dashboard.ts`
+- `frontend/app/runs/[runId]/page.tsx`
+- `frontend/components/dashboard/SessionDetailDialog.tsx`
+
+### Configuration and CLI
+- `src/trading_system/config/settings.py`
+- `src/trading_system/app/settings.py`
+- `src/trading_system/app/main.py`
+- `src/trading_system/app/services.py`
+- `configs/base.yaml`
+- `examples/sample_backtest.yaml`
+- `examples/sample_backtest_krx.yaml`
+- `examples/sample_live_kis.yaml`
+- `README.md`
+
+### Validation and docs
+- `tests/unit/test_kis_integration.py`
+- `tests/unit/test_kis_reconciliation_integration.py`
+- `tests/unit/test_reconciliation.py`
+- `tests/unit/test_order_audit_repository.py`
+- `tests/unit/test_order_audit_routes.py`
+- `tests/unit/test_live_loop.py`
+- `tests/unit/test_config_settings.py`
+- `tests/unit/test_app_main.py`
+- `tests/integration/test_order_audit_integration.py`
+- `docs/architecture/overview.ko.md`
+- `docs/architecture/overview.md`
+- `docs/architecture/workspace-analysis.ko.md`
+- `docs/architecture/workspace-analysis.md`
+- `docs/architecture/user-use-cases.ko.md`
+- `docs/architecture/user-use-cases.md`
+- `docs/runbooks/kis-domestic-live-operations.ko.md`
+- `docs/runbooks/kis-domestic-live-operations.md`
+- `docs/runbooks/incident-response.ko.md`
+- `docs/runbooks/incident-response.md`
+- `docs/runbooks/release-gate-checklist.md`
+
+## Delivery Slices
+
+### Slice 0. Open-order contract and KIS parser
+- broker open-order DTO/protocol과 KIS 응답 parser를 추가한다.
+
+### Slice 1. Reconciliation pending authority hardening
+- reconciliation이 open-order snapshot을 우선 사용하고 fallback/fail-closed 이벤트를 명확히 남기게 한다.
+
+### Slice 2. Broker order id audit propagation and live audit verification
+- KIS order id를 audit record까지 전달하고 live session owner 기준 regression test를 추가한다.
+
+### Slice 3. Order audit filter/export
+- audit repository/API/frontend에 시간 범위, 상태, broker id 필터와 CSV/JSONL export를 추가한다.
+
+### Slice 4. Strategy config parity
+- YAML/CLI/API strategy 설정 의미를 정렬하고 config/examples/README를 갱신한다.
+
+### Slice 5. Docs and verification alignment
+- architecture docs, KIS runbook, incident response, release gate checklist를 새 contract에 맞춘다.
+
+## Success Metrics
+
+- KIS open-order snapshot parser가 정상/누락/오류 응답을 테스트로 검증한다.
+- reconciliation은 open-order snapshot이 있을 때 해당 source로 pending symbols를 계산하고, 조회 실패 시 포트폴리오를 수정하지 않는다.
+- KIS order id가 `broker_order_id`로 order audit record에 보존된다.
+- live session owner 기준 order audit 생성 테스트가 TestClient lifespan 없이 통과한다.
+- `/api/v1/order-audit`는 시간 범위/status/side/broker_order_id 필터와 bounded CSV/JSONL export를 제공한다.
+- YAML config와 CLI가 저장된 strategy profile을 선택할 수 있고, validation 오류가 API runtime 설정과 일관된다.
+- `docs/architecture/*`와 runbook이 pending-order authority, audit export, config parity 상태를 실제 코드와 충돌 없이 설명한다.
+
+## Risks and Follow-up
+
+- KIS open-order API 응답 shape가 운영 계좌/모의 계좌에서 다를 수 있다. parser는 fixture 기반으로 보수적으로 시작하고, 불확실하면 fail-closed 해야 한다.
+- broker order id를 `FillEvent`에 추가하면 테스트 fixture 수정 범위가 넓어질 수 있다. optional field와 default 값으로 blast radius를 제한한다.
+- CSV/JSONL export는 개인정보나 계좌 정보를 포함할 수 있으므로 API key 보호와 필터 상한을 유지해야 한다.
+- YAML strategy parity는 설정 shape 변경이므로 `configs/`, `examples/`, `README.md`를 같은 변경에 포함해야 한다.
+- 외부 queue/분산 worker는 여전히 후속 대형 phase로 남는다.

--- a/prd/phase_15_task.md
+++ b/prd/phase_15_task.md
@@ -1,0 +1,204 @@
+# Phase 15 Task Breakdown
+
+## Usage
+
+- 이 파일은 Phase 15 구현 진행 상황과 검증 증적을 기록한다.
+- 체크박스는 실제 구현 작업과 검증 기준을 뜻한다.
+- 각 slice가 끝날 때 `Execution Log`를 갱신한다.
+- PRD 수준 범위는 `phase_15_prd.md`를 기준으로 한다.
+- 상세 설계와 순서는 `phase_15_implementation_plan.md`를 기준으로 한다.
+
+## Status Note
+
+- 이 문서는 `prd/phase_15_prd.md`의 실행 추적 문서다.
+- 현재 체크박스는 active backlog를 slice 단위로 분해한 것이며, 아직 구현 완료를 의미하지 않는다.
+- 이번 phase의 핵심은 broker open-order authority, live order audit 검증, audit search/export, strategy config parity다.
+
+## Phase 15-0. Open-order contract and KIS parser
+
+- [x] `src/trading_system/execution/broker.py`에 `OpenOrder`와 `OpenOrderSnapshot` DTO 추가
+- [x] broker protocol에 optional `get_open_orders()` capability 추가
+- [x] `ResilientBroker.get_open_orders()` resilience wrapper 추가
+- [x] `src/trading_system/integrations/kis.py`에 KIS open/unresolved order 조회 메서드 추가
+- [x] KIS open-order 응답 parser에서 필수 필드 누락을 fail-closed 오류로 처리
+- [x] `src/trading_system/execution/kis_adapter.py`가 open-order snapshot을 반환하도록 연결
+- [x] `tests/unit/test_kis_integration.py`에 정상/빈/누락/error 응답 케이스 추가
+
+Exit criteria:
+- KIS open-order parser와 adapter capability가 fixture 기반 unit test를 통과한다.
+
+## Phase 15-1. Reconciliation pending authority hardening
+
+- [x] live loop reconciliation 전에 open-order snapshot을 우선 조회
+- [x] open-order snapshot이 있으면 pending symbols를 open-order source 기준으로 계산
+- [x] open-order unsupported 상태에서는 기존 balance snapshot `pending_symbols` fallback 유지
+- [x] open-order 조회 실패 시 portfolio book mutation 없이 reconciliation skip event 기록
+- [x] logger payload에 `pending_source`와 pending symbol 수 포함
+- [x] `tests/unit/test_reconciliation.py`에 pending source priority regression 추가
+- [x] `tests/integration/test_kis_reconciliation_integration.py`에 open-order fail-closed 케이스 추가
+
+Exit criteria:
+- open-order source가 있는 경우 해당 source가 pending 판단의 우선 근거가 되고, 조회 실패 시 cash/position이 변경되지 않는다.
+
+## Phase 15-2. Broker order id audit propagation and live audit verification
+
+- [x] `FillEvent`에 optional `broker_order_id` 추가
+- [x] KIS `_to_fill_event()`가 `KisOrderResult.order_id`를 `broker_order_id`로 전달
+- [x] `execute_trading_step` fill event payload에 `broker_order_id` 포함
+- [x] `OrderAuditRecord` 변환이 broker order id를 보존하는지 테스트 추가
+- [x] direct live loop/service-boundary 테스트로 `scope=live_session`, `owner_id=session_id` audit record 생성 검증
+- [x] audit append 실패가 live loop tick과 portfolio persistence를 깨지 않는 regression test 추가
+- [x] `tests/integration/test_order_audit_integration.py`가 TestClient lifespan 없이 live owner audit을 검증하도록 정리
+
+Exit criteria:
+- KIS order id가 audit record의 `broker_order_id`에 보존되고, live session owner 기준 audit 생성 테스트가 통과한다.
+
+## Phase 15-3. Order audit filter/export
+
+- [x] `OrderAuditRepository.list()`에 `start`, `end`, `status`, `side`, `broker_order_id`, `sort` 필터 추가
+- [x] file repository index/read path가 새 필터를 적용하도록 구현
+- [x] Supabase repository SQL where/order 조건 확장
+- [x] order audit list API query validation 추가
+- [x] `/api/v1/order-audit/export` CSV/JSONL bounded response 추가
+- [x] export 응답에 applied filter와 record count를 확인할 수 있는 header 또는 metadata 제공
+- [x] frontend API client에 audit export 함수 추가
+- [x] run detail 또는 session detail에 owner 기준 export action 추가
+- [x] repository/route/export 테스트 추가
+
+Exit criteria:
+- API가 owner/time/status/broker id 기준 audit record를 필터링하고 CSV/JSONL export로 반환한다.
+
+## Phase 15-4. Strategy config parity
+
+- [x] `src/trading_system/config/settings.py`에 YAML `strategy` section typed parser 추가
+- [x] YAML config를 `AppSettings`로 변환하는 helper 추가
+- [x] CLI parser에 `--config`와 `--strategy-profile-id` 추가
+- [x] CLI/config/API strategy validation semantics를 `AppSettings.validate()` 기준으로 정렬
+- [x] `configs/base.yaml`에 strategy 설정 예시 추가
+- [x] `examples/sample_backtest.yaml`, `sample_backtest_krx.yaml`, `sample_live_kis.yaml` 업데이트
+- [x] `README.md`에 config 우선순위와 strategy profile 선택 방법 추가
+- [x] `tests/unit/test_config_settings.py`, `test_app_main.py`, `test_strategy_factory.py` regression 추가
+
+Exit criteria:
+- YAML과 CLI에서 저장된 strategy profile을 선택할 수 있고, invalid strategy 설정은 API runtime 설정과 같은 의미로 거절된다.
+
+## Phase 15-5. Docs and verification alignment
+
+- [x] `docs/architecture/overview.ko.md`와 `overview.md`에 open-order authority와 audit export 상태 반영
+- [x] `docs/architecture/workspace-analysis.ko.md`와 `workspace-analysis.md`의 남은 갭/권장 백로그 갱신
+- [x] `docs/architecture/user-use-cases.ko.md`와 `user-use-cases.md`에 audit export와 strategy config parity 유즈케이스 추가
+- [x] KIS live operations runbook에 open-order 조회 실패 대응 추가
+- [x] incident response runbook에 broker order id 기반 audit 조회 절차 추가
+- [x] release gate checklist에 TestClient-independent live audit 검증 항목 추가
+
+Exit criteria:
+- architecture docs와 runbook이 Phase 15 구현 후 broker pending-order, audit export, strategy config contract를 실제 코드와 일치하게 설명한다.
+
+## Verification Checklist
+
+### Required unit tests
+
+- [x] `pytest tests/unit/test_kis_integration.py -q`
+- [x] `pytest tests/unit/test_reconciliation.py -q`
+- [x] `pytest tests/unit/test_order_audit_repository.py -q`
+- [x] `pytest tests/unit/test_order_audit_routes.py -q`
+- [x] `pytest tests/test_live_loop.py -q`
+- [x] `pytest tests/unit/test_config_settings.py -q`
+- [x] `pytest tests/unit/test_app_main.py -q`
+- [x] `pytest tests/unit/test_strategy_factory.py -q`
+
+### Required integration tests
+
+- [x] `pytest tests/integration/test_kis_reconciliation_integration.py -q`
+- [x] `pytest tests/integration/test_order_audit_integration.py -q`
+
+### Frontend validation
+
+- [x] `cd frontend && npm run lint`
+- [x] `cd frontend && npm run build`
+- [x] `cd frontend && npm run test:e2e`
+
+### Broader regression
+
+- [x] touched backend 범위 `ruff check`
+- [x] 관련 API/config/live loop 회귀 테스트 실행
+- [x] config shape 변경 후 `configs/`, `examples/`, `README.md` 동시 갱신 확인
+
+### Manual verification
+
+- [ ] KIS fixture 또는 sandbox 응답에서 open-order snapshot이 pending symbols를 만드는지 확인
+- [ ] open-order 조회 실패 시 reconciliation이 cash/position을 변경하지 않는지 확인
+- [ ] live paper session 후 `scope=live_session&owner_id={session_id}` audit record 조회
+- [ ] KIS stub order id가 `/api/v1/order-audit` 응답의 `broker_order_id`에 표시되는지 확인
+- [ ] audit CSV/JSONL export가 owner/time/status/broker id 필터를 적용하는지 확인
+- [ ] YAML config와 CLI `--strategy-profile-id`가 같은 strategy profile을 선택하는지 확인
+
+## Execution Log
+
+### Date
+- 2026-04-27
+
+### Owner
+- Codex
+
+### Slice completed
+- Phase 15-0: open-order contract and KIS parser
+- Phase 15-1: reconciliation pending authority hardening
+- Phase 15-2: broker order id audit propagation and live audit verification
+- Phase 15-3: order audit filter/export
+- Phase 15-4: strategy config parity
+- Phase 15-5: docs and verification alignment
+
+### Scope implemented
+- Added broker open-order DTO/capability, KIS open-order query/parser, and live-loop pending-source priority.
+- Propagated KIS broker order ids into fill events and order audit records.
+- Extended order audit repository/API filtering and added bounded CSV/JSONL export.
+- Added frontend owner-based audit export actions for run detail and live session detail.
+- Added YAML strategy parser, YAML-to-AppSettings adapter, CLI `--config`, and CLI `--strategy-profile-id`.
+- Updated configs, examples, README, architecture docs, KIS runbook, incident response, and release gate checklist.
+
+### Files changed
+- `src/trading_system/execution/broker.py`
+- `src/trading_system/integrations/kis.py`
+- `src/trading_system/execution/kis_adapter.py`
+- `src/trading_system/execution/step.py`
+- `src/trading_system/execution/order_audit.py`
+- `src/trading_system/api/routes/order_audit.py`
+- `src/trading_system/app/loop.py`
+- `src/trading_system/app/main.py`
+- `src/trading_system/app/settings.py`
+- `src/trading_system/config/settings.py`
+- `frontend/lib/api/client.ts`
+- `frontend/lib/api/types.ts`
+- `frontend/lib/api/backtests.ts`
+- `frontend/lib/api/dashboard.ts`
+- `frontend/app/runs/[runId]/page.tsx`
+- `frontend/components/dashboard/SessionDetailDialog.tsx`
+- `configs/base.yaml`
+- `examples/sample_backtest.yaml`
+- `examples/sample_backtest_krx.yaml`
+- `examples/sample_live_kis.yaml`
+- `README.md`
+- `docs/architecture/*`
+- `docs/runbooks/*` touched for KIS/order-audit/release-gate updates
+- related tests under `tests/`
+
+### Commands run
+- `python -m compileall -q src/trading_system` -> passed
+- `pytest tests/unit/test_kis_integration.py tests/unit/test_order_audit_repository.py tests/unit/test_order_audit_routes.py tests/test_live_loop.py tests/integration/test_order_audit_integration.py tests/unit/test_config_settings.py tests/unit/test_app_main.py -q` -> `59 passed`
+- `ruff check src/trading_system tests --fix` -> fixed import formatting, then remaining long lines patched
+- `ruff check src/trading_system tests` -> passed
+- `pytest tests/integration/test_kis_reconciliation_integration.py tests/integration/test_order_audit_integration.py tests/test_live_loop.py -q` -> `11 passed`
+- `pytest tests/unit/test_kis_integration.py tests/unit/test_reconciliation.py tests/test_live_loop.py tests/unit/test_order_audit_repository.py tests/unit/test_order_audit_routes.py tests/integration/test_kis_reconciliation_integration.py tests/integration/test_order_audit_integration.py tests/unit/test_config_settings.py tests/unit/test_app_main.py tests/unit/test_strategy_factory.py -q` -> `70 passed`
+- `cd frontend && npm run lint` -> passed
+- `cd frontend && npm run build` -> passed
+- `cd frontend && npm run test:e2e` -> `3 passed`
+
+### Validation results
+- Backend lint, focused unit/integration tests, frontend lint/build, and Playwright smoke tests passed.
+- Live owner audit is verified through direct live-loop/service-boundary integration, avoiding `TestClient(create_app())` lifespan startup.
+
+### Risks / follow-up
+- KIS open-order parser is fixture-backed and may need field mapping adjustment against a real KIS account response.
+- Order audit export is bounded API response, not a background export pipeline.
+- Cancel/replace and long-running open-order polling remain out of scope.

--- a/scripts/migrations/004_add_order_audit_records.sql
+++ b/scripts/migrations/004_add_order_audit_records.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS order_audit_records (
+    record_id          TEXT PRIMARY KEY,
+    scope              TEXT NOT NULL,
+    owner_id           TEXT NOT NULL,
+    event              TEXT NOT NULL,
+    symbol             TEXT,
+    side               TEXT,
+    requested_quantity TEXT,
+    filled_quantity    TEXT,
+    price              TEXT,
+    status             TEXT,
+    reason             TEXT,
+    timestamp          TIMESTAMPTZ NOT NULL,
+    payload            JSONB NOT NULL DEFAULT '{}'::jsonb,
+    broker_order_id    TEXT,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_order_audit_scope_owner_timestamp
+    ON order_audit_records (scope, owner_id, timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS idx_order_audit_symbol_timestamp
+    ON order_audit_records (symbol, timestamp DESC);
+
+ALTER TABLE order_audit_records ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon')
+       AND EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+        EXECUTE 'DROP POLICY IF EXISTS order_audit_records_deny_api_roles ON order_audit_records';
+        EXECUTE '
+            CREATE POLICY order_audit_records_deny_api_roles
+            ON order_audit_records
+            FOR ALL
+            TO anon, authenticated
+            USING (false)
+            WITH CHECK (false)
+        ';
+    END IF;
+END $$;

--- a/src/trading_system/api/routes/backtest.py
+++ b/src/trading_system/api/routes/backtest.py
@@ -8,7 +8,11 @@ from fastapi import APIRouter, HTTPException, Request, status
 
 from trading_system.api.errors import RequestValidationError
 from trading_system.api.schemas import (
+    BacktestDispatcherStatusDTO,
     BacktestResultDTO,
+    BacktestRetentionPreviewDTO,
+    BacktestRetentionPruneRequestDTO,
+    BacktestRetentionPruneResponseDTO,
     BacktestRunAcceptedDTO,
     BacktestRunListItemDTO,
     BacktestRunListResponseDTO,
@@ -43,6 +47,10 @@ from trading_system.backtest.engine import BacktestResult
 from trading_system.backtest.file_repository import FileBacktestRunRepository
 from trading_system.backtest.repository import BacktestRunRepository
 from trading_system.core.compat import UTC
+from trading_system.execution.order_audit import (
+    OrderAuditRepository,
+    create_order_audit_repository,
+)
 from trading_system.strategy.base import SignalSide
 
 router = APIRouter(prefix="/api/v1", tags=["runtime"])
@@ -59,6 +67,7 @@ def _create_run_repository() -> BacktestRunRepository:
 
 
 _RUN_REPOSITORY = _create_run_repository()
+_ORDER_AUDIT_REPOSITORY: OrderAuditRepository | None = create_order_audit_repository()
 _MAX_FEE_BPS = Decimal("1000")
 
 
@@ -286,8 +295,11 @@ def _execute_backtest_run(item: QueuedBacktestRun) -> BacktestRunDTO:
     finished_at = datetime.now(UTC)
     try:
         assert isinstance(item.payload, AppSettings)
-        services = build_services(item.payload)
-        result = services.run()
+        services = build_services(
+            item.payload,
+            order_audit_repository=_ORDER_AUDIT_REPOSITORY,
+        )
+        result = services.run(audit_owner_id=item.run_id)
         return BacktestRunDTO.succeeded(
             run_id=item.run_id,
             started_at=item.started_at,
@@ -340,6 +352,53 @@ def list_backtest_runs(
     return BacktestRunListResponseDTO(runs=items, total=total, page=page, page_size=page_size)
 
 
+@router.get("/backtests/dispatcher", response_model=BacktestDispatcherStatusDTO)
+def get_backtest_dispatcher_status(request: Request) -> BacktestDispatcherStatusDTO:
+    dispatcher = getattr(request.app.state, "backtest_dispatcher", None)
+    if dispatcher is None:
+        return BacktestDispatcherStatusDTO(running=False, queue_depth=0, max_queue_size=0)
+    snapshot = dispatcher.snapshot()
+    return BacktestDispatcherStatusDTO(
+        running=snapshot.running,
+        queue_depth=snapshot.queue_depth,
+        max_queue_size=snapshot.max_queue_size,
+    )
+
+
+@router.get("/backtests/retention/preview", response_model=BacktestRetentionPreviewDTO)
+def preview_backtest_retention(
+    cutoff: str,
+    status: str | None = None,
+) -> BacktestRetentionPreviewDTO:
+    candidate_ids = _retention_candidate_ids(cutoff=cutoff, status=status)
+    return BacktestRetentionPreviewDTO(
+        cutoff=cutoff,
+        status=status,
+        candidate_count=len(candidate_ids),
+        run_ids=candidate_ids,
+    )
+
+
+@router.post("/backtests/retention/prune", response_model=BacktestRetentionPruneResponseDTO)
+def prune_backtest_retention(
+    payload: BacktestRetentionPruneRequestDTO,
+) -> BacktestRetentionPruneResponseDTO:
+    if payload.confirm != "DELETE":
+        raise RequestValidationError(
+            error_code="retention_confirmation_required",
+            message="confirm must be DELETE before pruning backtest runs.",
+        )
+    candidate_ids = _retention_candidate_ids(cutoff=payload.cutoff, status=payload.status)
+    deleted_ids: list[str] = []
+    for run_id in candidate_ids:
+        if _RUN_REPOSITORY.delete(run_id):
+            deleted_ids.append(run_id)
+    return BacktestRetentionPruneResponseDTO(
+        deleted_count=len(deleted_ids),
+        run_ids=deleted_ids,
+    )
+
+
 def create_backtest_run(
     payload: BacktestRunRequestDTO,
     request: Request | None = None,
@@ -373,6 +432,38 @@ def create_backtest_run(
 
     dispatcher.submit(item)
     return BacktestRunAcceptedDTO(run_id=run_id, status="queued")
+
+
+def _retention_candidate_ids(*, cutoff: str, status: str | None) -> list[str]:
+    cutoff_dt = _parse_cutoff(cutoff)
+    candidates: list[str] = []
+    page = 1
+    while True:
+        runs, total = _RUN_REPOSITORY.list(page=page, page_size=100, status=status)
+        if not runs:
+            break
+        for run in runs:
+            run_dt = _parse_cutoff(run.started_at)
+            if run_dt < cutoff_dt:
+                candidates.append(run.run_id)
+        if page * 100 >= total:
+            break
+        page += 1
+    return candidates
+
+
+def _parse_cutoff(value: str) -> datetime:
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise RequestValidationError(
+            error_code="invalid_cutoff",
+            message="cutoff must be an ISO 8601 datetime.",
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
 
 
 @router.post(

--- a/src/trading_system/api/routes/order_audit.py
+++ b/src/trading_system/api/routes/order_audit.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from trading_system.api.schemas import OrderAuditListDTO, OrderAuditRecordDTO
+
+router = APIRouter(prefix="/api/v1/order-audit", tags=["order-audit"])
+
+
+@router.get("", response_model=OrderAuditListDTO)
+def list_order_audit_records(
+    request: Request,
+    scope: str | None = None,
+    owner_id: str | None = None,
+    symbol: str | None = None,
+    event: str | None = None,
+    limit: int = 100,
+) -> OrderAuditListDTO:
+    repo = getattr(request.app.state, "order_audit_repository", None)
+    if repo is None:
+        return OrderAuditListDTO(records=[], total=0)
+    records = repo.list(
+        scope=scope,
+        owner_id=owner_id,
+        symbol=symbol,
+        event=event,
+        limit=max(1, min(limit, 500)),
+    )
+    return OrderAuditListDTO(
+        records=[
+            OrderAuditRecordDTO(
+                record_id=record.record_id,
+                scope=record.scope,
+                owner_id=record.owner_id,
+                event=record.event,
+                symbol=record.symbol,
+                side=record.side,
+                requested_quantity=record.requested_quantity,
+                filled_quantity=record.filled_quantity,
+                price=record.price,
+                status=record.status,
+                reason=record.reason,
+                timestamp=record.timestamp,
+                payload=record.payload,
+                broker_order_id=record.broker_order_id,
+            )
+            for record in records
+        ],
+        total=len(records),
+    )

--- a/src/trading_system/api/routes/order_audit.py
+++ b/src/trading_system/api/routes/order_audit.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import csv
+import io
+import json
+
 from fastapi import APIRouter, Request
+from fastapi.responses import Response
 
 from trading_system.api.schemas import OrderAuditListDTO, OrderAuditRecordDTO
+from trading_system.execution.order_audit import OrderAuditRecord
 
 router = APIRouter(prefix="/api/v1/order-audit", tags=["order-audit"])
 
@@ -14,6 +20,12 @@ def list_order_audit_records(
     owner_id: str | None = None,
     symbol: str | None = None,
     event: str | None = None,
+    status: str | None = None,
+    side: str | None = None,
+    broker_order_id: str | None = None,
+    start: str | None = None,
+    end: str | None = None,
+    sort: str = "desc",
     limit: int = 100,
 ) -> OrderAuditListDTO:
     repo = getattr(request.app.state, "order_audit_repository", None)
@@ -24,27 +36,144 @@ def list_order_audit_records(
         owner_id=owner_id,
         symbol=symbol,
         event=event,
+        status=status,
+        side=side,
+        broker_order_id=broker_order_id,
+        start=start,
+        end=end,
+        sort=_normalize_sort(sort),
         limit=max(1, min(limit, 500)),
     )
-    return OrderAuditListDTO(
-        records=[
-            OrderAuditRecordDTO(
-                record_id=record.record_id,
-                scope=record.scope,
-                owner_id=record.owner_id,
-                event=record.event,
-                symbol=record.symbol,
-                side=record.side,
-                requested_quantity=record.requested_quantity,
-                filled_quantity=record.filled_quantity,
-                price=record.price,
-                status=record.status,
-                reason=record.reason,
-                timestamp=record.timestamp,
-                payload=record.payload,
-                broker_order_id=record.broker_order_id,
-            )
+    return OrderAuditListDTO(records=[_to_dto(record) for record in records], total=len(records))
+
+
+@router.get("/export")
+def export_order_audit_records(
+    request: Request,
+    scope: str | None = None,
+    owner_id: str | None = None,
+    symbol: str | None = None,
+    event: str | None = None,
+    status: str | None = None,
+    side: str | None = None,
+    broker_order_id: str | None = None,
+    start: str | None = None,
+    end: str | None = None,
+    sort: str = "desc",
+    format: str = "csv",
+    limit: int = 1000,
+) -> Response:
+    repo = getattr(request.app.state, "order_audit_repository", None)
+    export_format = format.strip().lower()
+    if export_format not in {"csv", "jsonl"}:
+        return Response("format must be one of: csv, jsonl", status_code=400)
+    if repo is None:
+        records: list[OrderAuditRecord] = []
+    else:
+        records = repo.list(
+            scope=scope,
+            owner_id=owner_id,
+            symbol=symbol,
+            event=event,
+            status=status,
+            side=side,
+            broker_order_id=broker_order_id,
+            start=start,
+            end=end,
+            sort=_normalize_sort(sort),
+            limit=max(1, min(limit, 5000)),
+        )
+    headers = {
+        "X-Order-Audit-Record-Count": str(len(records)),
+        "X-Order-Audit-Applied-Filters": json.dumps(
+            {
+                "scope": scope,
+                "owner_id": owner_id,
+                "symbol": symbol,
+                "event": event,
+                "status": status,
+                "side": side,
+                "broker_order_id": broker_order_id,
+                "start": start,
+                "end": end,
+                "sort": _normalize_sort(sort),
+                "limit": max(1, min(limit, 5000)),
+            },
+            default=str,
+        ),
+    }
+    if export_format == "jsonl":
+        body = "\n".join(
+            json.dumps(_to_dto(record).model_dump(), default=str)
             for record in records
-        ],
-        total=len(records),
+        )
+        if body:
+            body += "\n"
+        return Response(body, media_type="application/x-ndjson", headers=headers)
+
+    return Response(_to_csv(records), media_type="text/csv", headers=headers)
+
+
+def _to_dto(record: OrderAuditRecord) -> OrderAuditRecordDTO:
+    return OrderAuditRecordDTO(
+        record_id=record.record_id,
+        scope=record.scope,
+        owner_id=record.owner_id,
+        event=record.event,
+        symbol=record.symbol,
+        side=record.side,
+        requested_quantity=record.requested_quantity,
+        filled_quantity=record.filled_quantity,
+        price=record.price,
+        status=record.status,
+        reason=record.reason,
+        timestamp=record.timestamp,
+        payload=record.payload,
+        broker_order_id=record.broker_order_id,
     )
+
+
+def _to_csv(records: list[OrderAuditRecord]) -> str:
+    output = io.StringIO()
+    fieldnames = [
+        "record_id",
+        "scope",
+        "owner_id",
+        "event",
+        "symbol",
+        "side",
+        "requested_quantity",
+        "filled_quantity",
+        "price",
+        "status",
+        "reason",
+        "timestamp",
+        "broker_order_id",
+        "payload",
+    ]
+    writer = csv.DictWriter(output, fieldnames=fieldnames)
+    writer.writeheader()
+    for record in records:
+        writer.writerow(
+            {
+                "record_id": record.record_id,
+                "scope": record.scope,
+                "owner_id": record.owner_id,
+                "event": record.event,
+                "symbol": record.symbol,
+                "side": record.side,
+                "requested_quantity": record.requested_quantity,
+                "filled_quantity": record.filled_quantity,
+                "price": record.price,
+                "status": record.status,
+                "reason": record.reason,
+                "timestamp": record.timestamp,
+                "broker_order_id": record.broker_order_id,
+                "payload": json.dumps(record.payload, default=str),
+            }
+        )
+    return output.getvalue()
+
+
+def _normalize_sort(sort: str) -> str:
+    return "asc" if sort == "asc" else "desc"

--- a/src/trading_system/api/schemas.py
+++ b/src/trading_system/api/schemas.py
@@ -106,6 +106,30 @@ class BacktestRunAcceptedDTO(BaseModel):
     status: Literal["queued", "succeeded", "failed"]
 
 
+class BacktestDispatcherStatusDTO(BaseModel):
+    running: bool
+    queue_depth: int
+    max_queue_size: int
+
+
+class BacktestRetentionPreviewDTO(BaseModel):
+    cutoff: str
+    status: str | None = None
+    candidate_count: int
+    run_ids: list[str]
+
+
+class BacktestRetentionPruneRequestDTO(BaseModel):
+    cutoff: str
+    status: str | None = None
+    confirm: str | None = None
+
+
+class BacktestRetentionPruneResponseDTO(BaseModel):
+    deleted_count: int
+    run_ids: list[str]
+
+
 class BacktestRunStatusDTO(BaseModel):
     run_id: str
     status: Literal["queued", "running", "succeeded", "failed"]
@@ -191,6 +215,28 @@ class LiveRuntimeSessionRecordDTO(BaseModel):
 
 class LiveRuntimeSessionListDTO(BaseModel):
     sessions: list[LiveRuntimeSessionRecordDTO]
+    total: int
+
+
+class OrderAuditRecordDTO(BaseModel):
+    record_id: str
+    scope: Literal["backtest", "live_session"] | str
+    owner_id: str
+    event: str
+    symbol: str | None = None
+    side: str | None = None
+    requested_quantity: str | None = None
+    filled_quantity: str | None = None
+    price: str | None = None
+    status: str | None = None
+    reason: str | None = None
+    timestamp: str
+    payload: dict
+    broker_order_id: str | None = None
+
+
+class OrderAuditListDTO(BaseModel):
+    records: list[OrderAuditRecordDTO]
     total: int
 
 

--- a/src/trading_system/api/server.py
+++ b/src/trading_system/api/server.py
@@ -14,6 +14,7 @@ from trading_system.api.routes.analytics import router as analytics_router
 from trading_system.api.routes.backtest import router as backtest_router
 from trading_system.api.routes.dashboard import router as dashboard_router
 from trading_system.api.routes.live_runtime import router as live_runtime_router
+from trading_system.api.routes.order_audit import router as order_audit_router
 from trading_system.api.routes.patterns import router as patterns_router
 from trading_system.api.routes.strategies import router as strategies_router
 from trading_system.api.schemas import ErrorResponseDTO
@@ -23,6 +24,7 @@ from trading_system.app.live_runtime_history import create_live_runtime_session_
 from trading_system.app.services import build_services
 from trading_system.app.settings import SettingsValidationError as AppSettingsValidationError
 from trading_system.config.settings import SettingsValidationError as ConfigSettingsValidationError
+from trading_system.execution.order_audit import create_order_audit_repository
 
 load_dotenv()
 
@@ -35,6 +37,7 @@ def create_app(live_loop=None) -> FastAPI:
     app.include_router(analytics_router)
     app.include_router(backtest_router)
     app.include_router(live_runtime_router)
+    app.include_router(order_audit_router)
     app.include_router(patterns_router)
     app.include_router(strategies_router)
     app.include_router(dashboard_router)
@@ -42,8 +45,13 @@ def create_app(live_loop=None) -> FastAPI:
     app.state.live_loop = live_loop
     app.state.backtest_dispatcher = dispatcher
     app.state.live_runtime_history_repository = create_live_runtime_session_repository()
+    app.state.order_audit_repository = create_order_audit_repository()
+    backtest_module._ORDER_AUDIT_REPOSITORY = app.state.order_audit_repository
     app.state.live_runtime_controller = LiveRuntimeController(
-        services_builder=build_services,
+        services_builder=lambda settings: build_services(
+            settings,
+            order_audit_repository=app.state.order_audit_repository,
+        ),
         attach_loop=lambda loop: setattr(app.state, 'live_loop', loop),
         history_repository=app.state.live_runtime_history_repository,
     )

--- a/src/trading_system/app/loop.py
+++ b/src/trading_system/app/loop.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from trading_system.app.equity_writer import EquityWriterProtocol
 from trading_system.app.state import AppRunnerState, LiveRuntimeState
 from trading_system.core.compat import UTC
+from trading_system.execution.order_audit import append_step_order_audit_events
 from trading_system.execution.reconciliation import reconcile
 from trading_system.execution.step import TradingContext, execute_trading_step
 
@@ -37,6 +38,7 @@ class LiveTradingLoop:
         default_factory=lambda: _resolve_env_int("TRADING_SYSTEM_RECONCILIATION_INTERVAL", 300)
     )
     equity_writer: EquityWriterProtocol | None = field(default=None)
+    audit_owner_id: str | None = field(default=None)
     runtime: LiveRuntimeState = field(default_factory=LiveRuntimeState, init=False)
     _last_processed_timestamps: dict[str, datetime] = field(default_factory=dict, init=False)
     _last_reconciliation: datetime | None = field(default=None, init=False)
@@ -92,6 +94,9 @@ class LiveTradingLoop:
             portfolio_risk=self.services.portfolio_risk,
             runtime_state=self.runtime,
             marks=self.runtime.last_marks,
+            order_audit_repository=self.services.order_audit_repository,
+            order_audit_scope="live_session",
+            order_audit_owner_id=self.audit_owner_id,
         )
 
         while self.state != AppRunnerState.STOPPED:
@@ -175,10 +180,16 @@ class LiveTradingLoop:
                 if last_ts is not None and bar.timestamp <= last_ts:
                     continue
 
-                execute_trading_step(
+                events = execute_trading_step(
                     bar=bar,
                     strategy=self.services.strategy_for(symbol),
                     context=context,
+                )
+                append_step_order_audit_events(
+                    repository=context.order_audit_repository,
+                    scope=context.order_audit_scope,
+                    owner_id=context.order_audit_owner_id,
+                    events=events,
                 )
                 self._last_processed_timestamps[symbol] = bar.timestamp
                 last_ts = bar.timestamp

--- a/src/trading_system/app/loop.py
+++ b/src/trading_system/app/loop.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from trading_system.app.equity_writer import EquityWriterProtocol
 from trading_system.app.state import AppRunnerState, LiveRuntimeState
 from trading_system.core.compat import UTC
+from trading_system.execution.broker import AccountBalanceSnapshot
 from trading_system.execution.order_audit import append_step_order_audit_events
 from trading_system.execution.reconciliation import reconcile
 from trading_system.execution.step import TradingContext, execute_trading_step
@@ -133,7 +134,15 @@ class LiveTradingLoop:
                             "traceback": traceback.format_exc(),
                         }
                     )
-                time.sleep(self.poll_interval)
+                try:
+                    time.sleep(self.poll_interval)
+                except KeyboardInterrupt:
+                    self.state = AppRunnerState.STOPPED
+                    self.services.logger.emit(
+                        "system.shutdown",
+                        severity=20,
+                        payload={"reason": "keyboard_interrupt"},
+                    )
 
     def _check_heartbeat(self) -> None:
         now = datetime.now(UTC)
@@ -218,6 +227,23 @@ class LiveTradingLoop:
             and (now - self._last_reconciliation).total_seconds() < self.reconciliation_interval
         ):
             return
+        try:
+            open_orders = self.services.broker_simulator.get_open_orders()
+        except Exception as exc:
+            self._last_reconciliation = now
+            self.runtime.last_reconciliation_at = now
+            self.runtime.last_reconciliation_status = "skipped"
+            self.services.logger.emit(
+                "portfolio.reconciliation.skipped",
+                severity=40,
+                payload={
+                    "reason": "open_orders_unavailable",
+                    "error": str(exc),
+                    "pending_source": "open_orders",
+                },
+            )
+            return
+
         snapshot = self.services.broker_simulator.get_account_balance()
         if snapshot is None:
             self._last_reconciliation = now
@@ -225,10 +251,27 @@ class LiveTradingLoop:
             self.runtime.last_reconciliation_status = "skipped"
             self.services.logger.emit(
                 "portfolio.reconciliation.skipped",
-                severity=30,
-                payload={"reason": "snapshot_unavailable"},
+                    severity=30,
+                payload={"reason": "snapshot_unavailable", "pending_source": "unavailable"},
             )
             return
+        pending_source = "balance_snapshot"
+        if open_orders is not None:
+            pending_source = "open_orders"
+            snapshot = AccountBalanceSnapshot(
+                cash=snapshot.cash,
+                positions=snapshot.positions,
+                average_costs=snapshot.average_costs,
+                pending_symbols=open_orders.pending_symbols,
+            )
+        self.services.logger.emit(
+            "portfolio.reconciliation.pending_source",
+            severity=20,
+            payload={
+                "pending_source": pending_source,
+                "pending_symbol_count": len(snapshot.pending_symbols),
+            },
+        )
         reconcile(
             book=self.services.portfolio,
             snapshot=snapshot,

--- a/src/trading_system/app/main.py
+++ b/src/trading_system/app/main.py
@@ -9,10 +9,12 @@ from trading_system.app.settings import (
     LiveExecutionMode,
     SettingsValidationError,
 )
+from trading_system.config.settings import load_app_settings
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Trading system application entrypoint")
+    parser.add_argument("--config", default=None, help="YAML config path")
     parser.add_argument("--mode", default="backtest", help="Runtime mode (backtest|live)")
     parser.add_argument("--symbols", default="BTCUSDT", help="Comma-separated symbols")
     parser.add_argument("--provider", default="mock", help="Market data provider")
@@ -28,6 +30,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-position", default="1.0", help="Risk max position")
     parser.add_argument("--max-notional", default="100000", help="Risk max notional")
     parser.add_argument("--max-order-size", default="0.25", help="Risk max order size")
+    parser.add_argument("--strategy-profile-id", default=None, help="Stored strategy profile id")
     return parser
 
 
@@ -36,18 +39,23 @@ def run(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        settings = AppSettings.from_cli(
-            mode=args.mode,
-            symbols=args.symbols,
-            provider=args.provider,
-            broker=args.broker,
-            live_execution=args.live_execution,
-            starting_cash=args.starting_cash,
-            fee_bps=args.fee_bps,
-            trade_quantity=args.trade_quantity,
-            max_position=args.max_position,
-            max_notional=args.max_notional,
-            max_order_size=args.max_order_size,
+        settings = (
+            load_app_settings(args.config)
+            if args.config is not None
+            else AppSettings.from_cli(
+                mode=args.mode,
+                symbols=args.symbols,
+                provider=args.provider,
+                broker=args.broker,
+                live_execution=args.live_execution,
+                starting_cash=args.starting_cash,
+                fee_bps=args.fee_bps,
+                trade_quantity=args.trade_quantity,
+                max_position=args.max_position,
+                max_notional=args.max_notional,
+                max_order_size=args.max_order_size,
+                strategy_profile_id=args.strategy_profile_id,
+            )
         )
         settings.validate()
 

--- a/src/trading_system/app/services.py
+++ b/src/trading_system/app/services.py
@@ -32,6 +32,7 @@ from trading_system.execution.broker import (
     ResilientBroker,
 )
 from trading_system.execution.kis_adapter import KisBrokerAdapter
+from trading_system.execution.order_audit import OrderAuditRepository
 from trading_system.integrations.kis import KisApiClient, is_krx_market_open
 from trading_system.notifications.webhook import WebhookNotifier, build_webhook_notifier
 from trading_system.patterns.repository import PatternSetRepository
@@ -98,8 +99,9 @@ class AppServices:
     strategies: dict[str, Strategy] | None = None
     portfolio_risk: PortfolioRiskLimits | None = None
     webhook_notifier: WebhookNotifier | None = None
+    order_audit_repository: OrderAuditRepository | None = None
 
-    def run(self) -> BacktestResult:
+    def run(self, audit_owner_id: str | None = None) -> BacktestResult:
         if self.mode != AppMode.BACKTEST:
             raise RuntimeError(f"Unsupported mode '{self.mode}'.")
 
@@ -112,6 +114,9 @@ class AppServices:
             portfolio_risk=self.portfolio_risk,
             runtime_state=LiveRuntimeState(state=AppRunnerState.RUNNING),
             marks={},
+            order_audit_repository=self.order_audit_repository,
+            order_audit_scope="backtest",
+            order_audit_owner_id=audit_owner_id,
         )
         return run_backtest(
             bars=bars,
@@ -172,7 +177,11 @@ class AppServices:
 
         resolved_session_id = session_id or datetime.now(UTC).strftime("live_%Y%m%d_%H%M%S")
         equity_writer = _create_equity_writer(resolved_session_id)
-        return LiveTradingLoop(services=self, equity_writer=equity_writer)
+        return LiveTradingLoop(
+            services=self,
+            equity_writer=equity_writer,
+            audit_owner_id=resolved_session_id,
+        )
 
     def run_live_execution(self) -> None:
         if self.mode != AppMode.LIVE:
@@ -209,7 +218,11 @@ class AppServices:
         return sorted(merged, key=lambda bar: (bar.timestamp, symbol_order[bar.symbol]))
 
 
-def build_services(settings: AppSettings) -> AppServices:
+def build_services(
+    settings: AppSettings,
+    *,
+    order_audit_repository: OrderAuditRepository | None = None,
+) -> AppServices:
     ensure_logging()
     logger = StructuredLogger("trading_system", log_format=StructuredLogFormat.JSON)
     kis_client = _build_kis_client_if_needed(settings)
@@ -270,6 +283,7 @@ def build_services(settings: AppSettings) -> AppServices:
         live_preflight_check=_build_live_preflight(settings, kis_client=kis_client),
         portfolio_repository=(portfolio_repository if settings.mode == AppMode.LIVE else None),
         webhook_notifier=webhook_notifier,
+        order_audit_repository=order_audit_repository,
     )
 
 

--- a/src/trading_system/app/settings.py
+++ b/src/trading_system/app/settings.py
@@ -77,6 +77,7 @@ class AppSettings:
         max_position: str,
         max_notional: str,
         max_order_size: str,
+        strategy_profile_id: str | None = None,
     ) -> "AppSettings":
         parsed_symbols = tuple(
             symbol.strip().upper()
@@ -107,7 +108,11 @@ class AppSettings:
                 fee_bps=_to_decimal(fee_bps, "fee_bps"),
                 trade_quantity=_to_decimal(trade_quantity, "trade_quantity"),
             ),
-            strategy=None,
+            strategy=(
+                PatternSignalStrategySettings(profile_id=strategy_profile_id.strip())
+                if strategy_profile_id is not None and strategy_profile_id.strip()
+                else None
+            ),
         )
 
     def validate(self) -> None:

--- a/src/trading_system/backtest/dispatcher.py
+++ b/src/trading_system/backtest/dispatcher.py
@@ -26,6 +26,13 @@ class QueuedBacktestRun:
     metadata: object | None = None
 
 
+@dataclass(slots=True, frozen=True)
+class BacktestDispatcherSnapshot:
+    running: bool
+    queue_depth: int
+    max_queue_size: int
+
+
 class BacktestRunDispatcher:
     def __init__(
         self,
@@ -37,6 +44,7 @@ class BacktestRunDispatcher:
         self._repo_factory = repo_factory
         self._executor = executor
         self._queue: queue.Queue[QueuedBacktestRun | object] = queue.Queue(maxsize=max_queue_size)
+        self._max_queue_size = max_queue_size
         self._worker: threading.Thread | None = None
         self._stop_requested = threading.Event()
 
@@ -53,6 +61,13 @@ class BacktestRunDispatcher:
 
     def is_running(self) -> bool:
         return self._worker is not None and self._worker.is_alive()
+
+    def snapshot(self) -> BacktestDispatcherSnapshot:
+        return BacktestDispatcherSnapshot(
+            running=self.is_running(),
+            queue_depth=self._queue.qsize(),
+            max_queue_size=self._max_queue_size,
+        )
 
     def submit(self, item: QueuedBacktestRun) -> None:
         if self._worker is None or not self._worker.is_alive():

--- a/src/trading_system/backtest/engine.py
+++ b/src/trading_system/backtest/engine.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from trading_system.analytics.metrics import cumulative_return
 from trading_system.core.types import MarketBar
+from trading_system.execution.order_audit import append_step_order_audit_events
 from trading_system.execution.step import TradingContext as BacktestContext
 from trading_system.execution.step import execute_trading_step
 from trading_system.portfolio.book import PortfolioBook
@@ -54,6 +55,12 @@ def run_backtest(
             else strategy
         )
         events = execute_trading_step(bar, active_strategy, context)
+        append_step_order_audit_events(
+            repository=context.order_audit_repository,
+            scope=context.order_audit_scope,
+            owner_id=context.order_audit_owner_id,
+            events=events,
+        )
         
         if events.signal:
             _record_event(signal_events, "strategy.signal", events.signal)

--- a/src/trading_system/config/settings.py
+++ b/src/trading_system/config/settings.py
@@ -55,6 +55,16 @@ class BacktestSettings:
 
 
 @dataclass(slots=True)
+class StrategySettings:
+    type: str = "pattern_signal"
+    profile_id: str | None = None
+    pattern_set_id: str | None = None
+    label_to_side: dict[str, str] | None = None
+    trade_quantity: Decimal | None = None
+    threshold_overrides: dict[str, float] | None = None
+
+
+@dataclass(slots=True)
 class ExecutionSettings:
     broker: str
 
@@ -72,6 +82,7 @@ class Settings:
     risk: RiskSettings
     portfolio_risk: PortfolioRiskSettings | None
     backtest: BacktestSettings
+    strategy: StrategySettings | None
     api: ApiSettings
 
 
@@ -101,6 +112,7 @@ def load_settings(path: str | Path) -> Settings:
     backtest_section = _as_dict(payload["backtest"], "backtest")
     api_section = _as_dict(payload.get("api", {}), "api")
     portfolio_risk_section = _as_optional_dict(payload.get("portfolio_risk"), "portfolio_risk")
+    strategy_section = _as_optional_dict(payload.get("strategy"), "strategy")
 
     settings = Settings(
         app=AppSettings(
@@ -199,6 +211,7 @@ def load_settings(path: str | Path) -> Settings:
                 minimum=Decimal("0"),
             ),
         ),
+        strategy=_parse_strategy_settings(strategy_section),
         api=ApiSettings(
             cors_allow_origins=_as_non_empty_str_list(
                 api_section.get("cors_allow_origins", ["*"]),
@@ -220,6 +233,72 @@ def load_settings(path: str | Path) -> Settings:
             )
 
     return settings
+
+
+def load_app_settings(path: str | Path):
+    settings = load_settings(path)
+    from trading_system.app.settings import (
+        AppMode as RuntimeAppMode,
+    )
+    from trading_system.app.settings import (
+        AppSettings as RuntimeAppSettings,
+    )
+    from trading_system.app.settings import (
+        BacktestSettings as RuntimeBacktestSettings,
+    )
+    from trading_system.app.settings import (
+        LiveExecutionMode,
+        PatternSignalStrategySettings,
+    )
+    from trading_system.app.settings import (
+        PortfolioRiskSettings as RuntimePortfolioRiskSettings,
+    )
+    from trading_system.app.settings import (
+        RiskSettings as RuntimeRiskSettings,
+    )
+    from trading_system.strategy.base import SignalSide
+
+    strategy = None
+    if settings.strategy is not None:
+        strategy = PatternSignalStrategySettings(
+            type=settings.strategy.type,
+            profile_id=settings.strategy.profile_id,
+            pattern_set_id=settings.strategy.pattern_set_id,
+            label_to_side={
+                label: SignalSide(side)
+                for label, side in (settings.strategy.label_to_side or {}).items()
+            },
+            trade_quantity=settings.strategy.trade_quantity,
+            threshold_overrides=settings.strategy.threshold_overrides or {},
+        )
+
+    return RuntimeAppSettings(
+        mode=RuntimeAppMode(settings.app.mode.value),
+        symbols=settings.market_data.symbols,
+        provider=settings.market_data.provider,
+        broker=settings.execution.broker,
+        live_execution=LiveExecutionMode.PREFLIGHT,
+        risk=RuntimeRiskSettings(
+            max_position=settings.risk.max_position,
+            max_notional=settings.risk.max_notional,
+            max_order_size=settings.risk.max_order_size,
+        ),
+        backtest=RuntimeBacktestSettings(
+            starting_cash=settings.backtest.starting_cash,
+            fee_bps=settings.backtest.fee_bps,
+            trade_quantity=settings.backtest.trade_quantity,
+        ),
+        strategy=strategy,
+        portfolio_risk=(
+            RuntimePortfolioRiskSettings(
+                max_daily_drawdown_pct=settings.portfolio_risk.max_daily_drawdown_pct,
+                sl_pct=settings.portfolio_risk.sl_pct,
+                tp_pct=settings.portfolio_risk.tp_pct,
+            )
+            if settings.portfolio_risk is not None
+            else None
+        ),
+    )
 
 
 def _require_key(payload: dict[str, Any], key: str, path: str) -> Any:
@@ -300,6 +379,83 @@ def _as_non_empty_str_list(value: Any, path: str) -> tuple[str, ...]:
         raise SettingsValidationError(f"Invalid value for '{path}': at least one item is required.")
 
     return tuple(normalized_values)
+
+
+def _parse_strategy_settings(section: dict[str, Any] | None) -> StrategySettings | None:
+    if section is None:
+        return None
+    strategy_type = _as_non_empty_str(section.get("type", "pattern_signal"), "strategy.type")
+    if strategy_type != "pattern_signal":
+        raise SettingsValidationError("Invalid value for 'strategy.type': expected pattern_signal.")
+    profile_id = _as_optional_non_empty_str(section.get("profile_id"), "strategy.profile_id")
+    pattern_set_id = _as_optional_non_empty_str(
+        section.get("pattern_set_id"),
+        "strategy.pattern_set_id",
+    )
+    label_to_side = _as_optional_label_to_side(section.get("label_to_side"))
+    trade_quantity = _as_optional_decimal(
+        section.get("trade_quantity"),
+        "strategy.trade_quantity",
+        minimum=Decimal("0"),
+    )
+    threshold_overrides = _as_optional_threshold_overrides(section.get("threshold_overrides"))
+    return StrategySettings(
+        type=strategy_type,
+        profile_id=profile_id,
+        pattern_set_id=pattern_set_id,
+        label_to_side=label_to_side,
+        trade_quantity=trade_quantity,
+        threshold_overrides=threshold_overrides,
+    )
+
+
+def _as_optional_non_empty_str(value: Any, path: str) -> str | None:
+    if value is None:
+        return None
+    return _as_non_empty_str(value, path)
+
+
+def _as_optional_label_to_side(value: Any) -> dict[str, str] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise SettingsValidationError(
+            "Invalid type for 'strategy.label_to_side': expected mapping."
+        )
+    parsed: dict[str, str] = {}
+    for label, side in value.items():
+        normalized_label = _as_non_empty_str(label, "strategy.label_to_side key")
+        normalized_side = _as_non_empty_str(side, f"strategy.label_to_side.{normalized_label}")
+        if normalized_side not in {"buy", "sell", "hold"}:
+            raise SettingsValidationError(
+                "Invalid value for 'strategy.label_to_side': expected buy, sell, or hold."
+            )
+        parsed[normalized_label] = normalized_side
+    return parsed
+
+
+def _as_optional_threshold_overrides(value: Any) -> dict[str, float] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise SettingsValidationError(
+            "Invalid type for 'strategy.threshold_overrides': expected mapping."
+        )
+    parsed: dict[str, float] = {}
+    for label, threshold in value.items():
+        normalized_label = _as_non_empty_str(label, "strategy.threshold_overrides key")
+        try:
+            parsed_threshold = float(threshold)
+        except (TypeError, ValueError) as exc:
+            raise SettingsValidationError(
+                "Invalid type for 'strategy.threshold_overrides': expected numeric values."
+            ) from exc
+        if parsed_threshold < 0 or parsed_threshold > 1:
+            raise SettingsValidationError(
+                "Invalid value for 'strategy.threshold_overrides': expected values between 0 and 1."
+            )
+        parsed[normalized_label] = parsed_threshold
+    return parsed
 
 
 def _as_decimal(

--- a/src/trading_system/execution/broker.py
+++ b/src/trading_system/execution/broker.py
@@ -29,10 +29,33 @@ class FillEvent:
     fill_price: Decimal
     fee: Decimal
     status: FillStatus
+    broker_order_id: str | None = None
 
     @property
     def signed_quantity(self) -> Decimal:
         return self.filled_quantity if self.side == OrderSide.BUY else -self.filled_quantity
+
+
+@dataclass(slots=True, frozen=True)
+class OpenOrder:
+    broker_order_id: str
+    symbol: str
+    side: OrderSide
+    requested_quantity: Decimal
+    remaining_quantity: Decimal
+    status: str
+    submitted_at: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class OpenOrderSnapshot:
+    orders: tuple[OpenOrder, ...]
+
+    @property
+    def pending_symbols(self) -> tuple[str, ...]:
+        return tuple(
+            sorted({order.symbol for order in self.orders if order.remaining_quantity > 0})
+        )
 
 
 @dataclass(slots=True, frozen=True)
@@ -104,6 +127,9 @@ class BrokerSimulator(Protocol):
     def get_account_balance(self) -> AccountBalanceSnapshot | None:
         """Return an account snapshot when the broker supports reconciliation."""
 
+    def get_open_orders(self) -> OpenOrderSnapshot | None:
+        """Return unresolved/open orders when the broker supports the capability."""
+
 
 @dataclass(slots=True)
 class PolicyBrokerSimulator:
@@ -144,6 +170,9 @@ class PolicyBrokerSimulator:
     def get_account_balance(self) -> AccountBalanceSnapshot | None:
         return None
 
+    def get_open_orders(self) -> OpenOrderSnapshot | None:
+        return None
+
 
 @dataclass(slots=True)
 class ResilientBroker:
@@ -169,6 +198,18 @@ class ResilientBroker:
         return execute_with_resilience(
             operation="broker_account_balance",
             callback=lambda: self.delegate.get_account_balance(),
+            retry=self.retry_policy,
+            timeout=self.timeout_policy,
+            circuit_breaker=self.circuit_breaker_policy,
+            circuit_state=self._circuit_state,
+        )
+
+    def get_open_orders(self) -> OpenOrderSnapshot | None:
+        if not hasattr(self.delegate, "get_open_orders"):
+            return None
+        return execute_with_resilience(
+            operation="broker_open_orders",
+            callback=lambda: self.delegate.get_open_orders(),
             retry=self.retry_policy,
             timeout=self.timeout_policy,
             circuit_breaker=self.circuit_breaker_policy,

--- a/src/trading_system/execution/kis_adapter.py
+++ b/src/trading_system/execution/kis_adapter.py
@@ -2,7 +2,12 @@ from dataclasses import dataclass
 from decimal import Decimal
 
 from trading_system.core.types import MarketBar
-from trading_system.execution.broker import AccountBalanceSnapshot, FillEvent, FillStatus
+from trading_system.execution.broker import (
+    AccountBalanceSnapshot,
+    FillEvent,
+    FillStatus,
+    OpenOrderSnapshot,
+)
 from trading_system.execution.orders import OrderRequest
 from trading_system.integrations.kis import KisApiClient, KisApiError, KisOrderResult
 
@@ -33,6 +38,10 @@ class KisBrokerAdapter:
         except (KisApiError, KeyError, Exception):
             return None
 
+    def get_open_orders(self) -> OpenOrderSnapshot:
+        access_token = self.client.issue_access_token()
+        return self.client.inquire_open_orders(access_token=access_token)
+
 
 def _to_fill_event(
     *,
@@ -51,6 +60,7 @@ def _to_fill_event(
         fill_price=fill_price,
         fee=result.fee,
         status=status,
+        broker_order_id=result.order_id,
     )
 
 

--- a/src/trading_system/execution/order_audit.py
+++ b/src/trading_system/execution/order_audit.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+from trading_system.core.compat import UTC
+
+try:
+    import psycopg
+except ModuleNotFoundError:  # pragma: no cover - optional dependency in unit tests
+    psycopg = None  # type: ignore[assignment]
+
+_log = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class OrderAuditRecord:
+    record_id: str
+    scope: str
+    owner_id: str
+    event: str
+    symbol: str | None
+    side: str | None
+    requested_quantity: str | None
+    filled_quantity: str | None
+    price: str | None
+    status: str | None
+    reason: str | None
+    timestamp: str
+    payload: dict[str, Any]
+    broker_order_id: str | None = None
+
+
+class OrderAuditRepository(Protocol):
+    def append(self, record: OrderAuditRecord) -> None:
+        ...
+
+    def list(
+        self,
+        *,
+        scope: str | None = None,
+        owner_id: str | None = None,
+        symbol: str | None = None,
+        event: str | None = None,
+        limit: int = 100,
+    ) -> list[OrderAuditRecord]:
+        ...
+
+
+class FileOrderAuditRepository:
+    def __init__(self, base_dir: Path | str = "data/order_audit") -> None:
+        self._base_dir = Path(base_dir)
+        self._lock = threading.Lock()
+        os.makedirs(self._base_dir, exist_ok=True)
+        self._ensure_index()
+
+    def append(self, record: OrderAuditRecord) -> None:
+        path = self._record_path(record.record_id)
+        tmp = self._base_dir / f"{record.record_id}_{uuid.uuid4().hex}.tmp"
+        try:
+            tmp.write_text(json.dumps(asdict(record), default=str), encoding="utf-8")
+            os.replace(tmp, path)
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
+
+        with self._lock:
+            index = self._read_index()
+            index["records"].append(_index_entry(record))
+            self._write_index(index)
+
+    def list(
+        self,
+        *,
+        scope: str | None = None,
+        owner_id: str | None = None,
+        symbol: str | None = None,
+        event: str | None = None,
+        limit: int = 100,
+    ) -> list[OrderAuditRecord]:
+        with self._lock:
+            entries = list(self._read_index().get("records", []))
+        entries = _filter_entries(
+            entries,
+            scope=scope,
+            owner_id=owner_id,
+            symbol=symbol,
+            event=event,
+        )
+        entries = sorted(entries, key=lambda item: item.get("timestamp", ""), reverse=True)
+        selected = entries[: max(1, min(limit, 500))]
+        records: list[OrderAuditRecord] = []
+        for entry in selected:
+            record = self._read_record(entry["record_id"])
+            if record is not None:
+                records.append(record)
+        return records
+
+    def _record_path(self, record_id: str) -> Path:
+        return self._base_dir / f"{record_id}.json"
+
+    def _index_path(self) -> Path:
+        return self._base_dir / "_index.json"
+
+    def _ensure_index(self) -> None:
+        if not self._index_path().exists():
+            self._write_index({"records": []})
+
+    def _read_index(self) -> dict[str, Any]:
+        try:
+            return json.loads(self._index_path().read_text(encoding="utf-8"))
+        except Exception:
+            return {"records": []}
+
+    def _write_index(self, payload: dict[str, Any]) -> None:
+        tmp = self._base_dir / f"_index_{uuid.uuid4().hex}.tmp"
+        try:
+            tmp.write_text(json.dumps(payload, default=str), encoding="utf-8")
+            os.replace(tmp, self._index_path())
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
+
+    def _read_record(self, record_id: str) -> OrderAuditRecord | None:
+        path = self._record_path(record_id)
+        if not path.exists():
+            return None
+        return _deserialize_record(json.loads(path.read_text(encoding="utf-8")))
+
+
+class SupabaseOrderAuditRepository:
+    def __init__(self, database_url: str) -> None:
+        self._database_url = database_url
+        self._conn: Any = None
+        self._schema_checked = False
+
+    def append(self, record: OrderAuditRecord) -> None:
+        with self._get_conn().cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO order_audit_records
+                    (
+                        record_id, scope, owner_id, event, symbol, side,
+                        requested_quantity, filled_quantity, price, status, reason,
+                        timestamp, payload, broker_order_id
+                    )
+                VALUES (
+                    %s, %s, %s, %s, %s, %s,
+                    %s, %s, %s, %s, %s,
+                    %s, %s::jsonb, %s
+                )
+                """,
+                (
+                    record.record_id,
+                    record.scope,
+                    record.owner_id,
+                    record.event,
+                    record.symbol,
+                    record.side,
+                    record.requested_quantity,
+                    record.filled_quantity,
+                    record.price,
+                    record.status,
+                    record.reason,
+                    record.timestamp,
+                    json.dumps(record.payload, default=str),
+                    record.broker_order_id,
+                ),
+            )
+
+    def list(
+        self,
+        *,
+        scope: str | None = None,
+        owner_id: str | None = None,
+        symbol: str | None = None,
+        event: str | None = None,
+        limit: int = 100,
+    ) -> list[OrderAuditRecord]:
+        conditions: list[str] = []
+        params: list[object] = []
+        if scope is not None:
+            conditions.append("scope = %s")
+            params.append(scope)
+        if owner_id is not None:
+            conditions.append("owner_id = %s")
+            params.append(owner_id)
+        if symbol is not None:
+            conditions.append("symbol = %s")
+            params.append(symbol)
+        if event is not None:
+            conditions.append("event = %s")
+            params.append(event)
+        where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+        with self._get_conn().cursor() as cur:
+            cur.execute(
+                f"""
+                SELECT
+                    record_id, scope, owner_id, event, symbol, side,
+                    requested_quantity, filled_quantity, price, status, reason,
+                    timestamp, payload, broker_order_id
+                FROM order_audit_records
+                {where}
+                ORDER BY timestamp DESC
+                LIMIT %s
+                """,
+                [*params, max(1, min(limit, 500))],
+            )
+            rows = cur.fetchall()
+        return [_deserialize_db_row(row) for row in rows]
+
+    def _get_conn(self):
+        if self._conn is None or self._conn.closed:
+            if psycopg is None:
+                raise ModuleNotFoundError("psycopg is required for SupabaseOrderAuditRepository.")
+            self._conn = psycopg.connect(self._database_url, autocommit=True)
+            self._schema_checked = False
+        self._ensure_schema()
+        return self._conn
+
+    def _ensure_schema(self) -> None:
+        if self._schema_checked:
+            return
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS order_audit_records (
+                    record_id          TEXT PRIMARY KEY,
+                    scope              TEXT NOT NULL,
+                    owner_id           TEXT NOT NULL,
+                    event              TEXT NOT NULL,
+                    symbol             TEXT,
+                    side               TEXT,
+                    requested_quantity TEXT,
+                    filled_quantity    TEXT,
+                    price              TEXT,
+                    status             TEXT,
+                    reason             TEXT,
+                    timestamp          TIMESTAMPTZ NOT NULL,
+                    payload            JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    broker_order_id    TEXT,
+                    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_order_audit_scope_owner_timestamp
+                ON order_audit_records (scope, owner_id, timestamp DESC)
+                """
+            )
+            cur.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_order_audit_symbol_timestamp
+                ON order_audit_records (symbol, timestamp DESC)
+                """
+            )
+        self._schema_checked = True
+
+
+def create_order_audit_repository() -> OrderAuditRepository:
+    database_url = os.getenv("DATABASE_URL")
+    if database_url:
+        return SupabaseOrderAuditRepository(database_url)
+    base_dir = Path(os.getenv("TRADING_SYSTEM_ORDER_AUDIT_DIR", "data/order_audit"))
+    return FileOrderAuditRepository(base_dir)
+
+
+def append_step_order_audit_events(
+    *,
+    repository: OrderAuditRepository | None,
+    scope: str | None,
+    owner_id: str | None,
+    events: Any,
+) -> None:
+    if repository is None or scope is None or owner_id is None:
+        return
+    for event_name, payload in _iter_step_events(events):
+        try:
+            repository.append(
+                _record_from_event(
+                    scope=scope,
+                    owner_id=owner_id,
+                    event=event_name,
+                    payload=payload,
+                )
+            )
+        except Exception as exc:
+            _log.warning("Failed to append order audit record: %s", exc)
+            continue
+
+
+def _iter_step_events(events: Any):
+    for name, event_name in (
+        ("order_created", "order.created"),
+        ("order_filled", "order.filled"),
+        ("order_rejected", "order.rejected"),
+        ("risk_rejected", "risk.rejected"),
+    ):
+        payload = getattr(events, name, None)
+        if payload:
+            yield event_name, payload
+
+
+def _record_from_event(
+    *,
+    scope: str,
+    owner_id: str,
+    event: str,
+    payload: dict[str, Any],
+) -> OrderAuditRecord:
+    timestamp = str(
+        payload.get("timestamp") or datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    )
+    return OrderAuditRecord(
+        record_id=f"oa_{uuid.uuid4().hex}",
+        scope=scope,
+        owner_id=owner_id,
+        event=event,
+        symbol=_optional_str(payload.get("symbol")),
+        side=_optional_str(payload.get("side")),
+        requested_quantity=_first_str(payload, "requested_quantity", "quantity"),
+        filled_quantity=_optional_str(payload.get("filled_quantity")),
+        price=_first_str(payload, "fill_price", "price"),
+        status=_optional_str(payload.get("status")),
+        reason=_optional_str(payload.get("reason")),
+        timestamp=timestamp,
+        payload=dict(payload),
+        broker_order_id=_optional_str(payload.get("broker_order_id")),
+    )
+
+
+def _first_str(payload: dict[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = payload.get(key)
+        if value is not None:
+            return str(value)
+    return None
+
+
+def _optional_str(value: Any) -> str | None:
+    return None if value is None else str(value)
+
+
+def _index_entry(record: OrderAuditRecord) -> dict[str, Any]:
+    return {
+        "record_id": record.record_id,
+        "scope": record.scope,
+        "owner_id": record.owner_id,
+        "event": record.event,
+        "symbol": record.symbol,
+        "timestamp": record.timestamp,
+    }
+
+
+def _filter_entries(
+    entries: list[dict[str, Any]],
+    *,
+    scope: str | None,
+    owner_id: str | None,
+    symbol: str | None,
+    event: str | None,
+) -> list[dict[str, Any]]:
+    filtered = entries
+    if scope is not None:
+        filtered = [item for item in filtered if item.get("scope") == scope]
+    if owner_id is not None:
+        filtered = [item for item in filtered if item.get("owner_id") == owner_id]
+    if symbol is not None:
+        filtered = [item for item in filtered if item.get("symbol") == symbol]
+    if event is not None:
+        filtered = [item for item in filtered if item.get("event") == event]
+    return filtered
+
+
+def _deserialize_record(data: dict[str, Any]) -> OrderAuditRecord:
+    return OrderAuditRecord(
+        record_id=data["record_id"],
+        scope=data["scope"],
+        owner_id=data["owner_id"],
+        event=data["event"],
+        symbol=data.get("symbol"),
+        side=data.get("side"),
+        requested_quantity=data.get("requested_quantity"),
+        filled_quantity=data.get("filled_quantity"),
+        price=data.get("price"),
+        status=data.get("status"),
+        reason=data.get("reason"),
+        timestamp=data["timestamp"],
+        payload=dict(data.get("payload", {})),
+        broker_order_id=data.get("broker_order_id"),
+    )
+
+
+def _deserialize_db_row(row: tuple[Any, ...]) -> OrderAuditRecord:
+    (
+        record_id,
+        scope,
+        owner_id,
+        event,
+        symbol,
+        side,
+        requested_quantity,
+        filled_quantity,
+        price,
+        status,
+        reason,
+        timestamp,
+        payload,
+        broker_order_id,
+    ) = row
+    parsed_payload = payload if isinstance(payload, dict) else json.loads(payload or "{}")
+    return OrderAuditRecord(
+        record_id=record_id,
+        scope=scope,
+        owner_id=owner_id,
+        event=event,
+        symbol=symbol,
+        side=side,
+        requested_quantity=requested_quantity,
+        filled_quantity=filled_quantity,
+        price=price,
+        status=status,
+        reason=reason,
+        timestamp=_serialize_timestamp(timestamp),
+        payload=parsed_payload,
+        broker_order_id=broker_order_id,
+    )
+
+
+def _serialize_timestamp(value: Any) -> str:
+    return value.isoformat().replace("+00:00", "Z") if hasattr(value, "isoformat") else str(value)

--- a/src/trading_system/execution/order_audit.py
+++ b/src/trading_system/execution/order_audit.py
@@ -49,6 +49,12 @@ class OrderAuditRepository(Protocol):
         owner_id: str | None = None,
         symbol: str | None = None,
         event: str | None = None,
+        status: str | None = None,
+        side: str | None = None,
+        broker_order_id: str | None = None,
+        start: str | None = None,
+        end: str | None = None,
+        sort: str = "desc",
         limit: int = 100,
     ) -> list[OrderAuditRecord]:
         ...
@@ -83,6 +89,12 @@ class FileOrderAuditRepository:
         owner_id: str | None = None,
         symbol: str | None = None,
         event: str | None = None,
+        status: str | None = None,
+        side: str | None = None,
+        broker_order_id: str | None = None,
+        start: str | None = None,
+        end: str | None = None,
+        sort: str = "desc",
         limit: int = 100,
     ) -> list[OrderAuditRecord]:
         with self._lock:
@@ -93,9 +105,18 @@ class FileOrderAuditRepository:
             owner_id=owner_id,
             symbol=symbol,
             event=event,
+            status=status,
+            side=side,
+            broker_order_id=broker_order_id,
+            start=start,
+            end=end,
         )
-        entries = sorted(entries, key=lambda item: item.get("timestamp", ""), reverse=True)
-        selected = entries[: max(1, min(limit, 500))]
+        entries = sorted(
+            entries,
+            key=lambda item: item.get("timestamp", ""),
+            reverse=_normalize_sort(sort) == "desc",
+        )
+        selected = entries[: max(1, min(limit, 5000))]
         records: list[OrderAuditRecord] = []
         for entry in selected:
             record = self._read_record(entry["record_id"])
@@ -182,6 +203,12 @@ class SupabaseOrderAuditRepository:
         owner_id: str | None = None,
         symbol: str | None = None,
         event: str | None = None,
+        status: str | None = None,
+        side: str | None = None,
+        broker_order_id: str | None = None,
+        start: str | None = None,
+        end: str | None = None,
+        sort: str = "desc",
         limit: int = 100,
     ) -> list[OrderAuditRecord]:
         conditions: list[str] = []
@@ -198,7 +225,23 @@ class SupabaseOrderAuditRepository:
         if event is not None:
             conditions.append("event = %s")
             params.append(event)
+        if status is not None:
+            conditions.append("status = %s")
+            params.append(status)
+        if side is not None:
+            conditions.append("side = %s")
+            params.append(side)
+        if broker_order_id is not None:
+            conditions.append("broker_order_id = %s")
+            params.append(broker_order_id)
+        if start is not None:
+            conditions.append("timestamp >= %s")
+            params.append(start)
+        if end is not None:
+            conditions.append("timestamp <= %s")
+            params.append(end)
         where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+        direction = "ASC" if _normalize_sort(sort) == "asc" else "DESC"
         with self._get_conn().cursor() as cur:
             cur.execute(
                 f"""
@@ -208,10 +251,10 @@ class SupabaseOrderAuditRepository:
                     timestamp, payload, broker_order_id
                 FROM order_audit_records
                 {where}
-                ORDER BY timestamp DESC
+                ORDER BY timestamp {direction}
                 LIMIT %s
                 """,
-                [*params, max(1, min(limit, 500))],
+                [*params, max(1, min(limit, 5000))],
             )
             rows = cur.fetchall()
         return [_deserialize_db_row(row) for row in rows]
@@ -356,6 +399,9 @@ def _index_entry(record: OrderAuditRecord) -> dict[str, Any]:
         "owner_id": record.owner_id,
         "event": record.event,
         "symbol": record.symbol,
+        "side": record.side,
+        "status": record.status,
+        "broker_order_id": record.broker_order_id,
         "timestamp": record.timestamp,
     }
 
@@ -367,6 +413,11 @@ def _filter_entries(
     owner_id: str | None,
     symbol: str | None,
     event: str | None,
+    status: str | None,
+    side: str | None,
+    broker_order_id: str | None,
+    start: str | None,
+    end: str | None,
 ) -> list[dict[str, Any]]:
     filtered = entries
     if scope is not None:
@@ -377,7 +428,21 @@ def _filter_entries(
         filtered = [item for item in filtered if item.get("symbol") == symbol]
     if event is not None:
         filtered = [item for item in filtered if item.get("event") == event]
+    if status is not None:
+        filtered = [item for item in filtered if item.get("status") == status]
+    if side is not None:
+        filtered = [item for item in filtered if item.get("side") == side]
+    if broker_order_id is not None:
+        filtered = [item for item in filtered if item.get("broker_order_id") == broker_order_id]
+    if start is not None:
+        filtered = [item for item in filtered if str(item.get("timestamp", "")) >= start]
+    if end is not None:
+        filtered = [item for item in filtered if str(item.get("timestamp", "")) <= end]
     return filtered
+
+
+def _normalize_sort(sort: str) -> str:
+    return "asc" if sort == "asc" else "desc"
 
 
 def _deserialize_record(data: dict[str, Any]) -> OrderAuditRecord:

--- a/src/trading_system/execution/step.py
+++ b/src/trading_system/execution/step.py
@@ -134,6 +134,8 @@ def execute_trading_step(bar: MarketBar, strategy: Strategy, context: TradingCon
                     timestamp=_bar_timestamp(bar.timestamp),
                 )
             )
+            if fill.broker_order_id is not None:
+                events.order_filled["broker_order_id"] = fill.broker_order_id
             _emit_event(context.logger, "order.filled", events.order_filled)
         else:
             events.order_rejected = event_payload(
@@ -195,21 +197,24 @@ def _check_sl_tp(bar: MarketBar, context: TradingContext) -> None:
             context.portfolio.apply_fill(
                 fill.symbol, fill.signed_quantity, fill.fill_price, fee=fill.fee
             )
+            payload = event_payload(
+                OrderFilledEvent(
+                    symbol=fill.symbol,
+                    side=fill.side.value,
+                    requested_quantity=fill.requested_quantity,
+                    filled_quantity=fill.filled_quantity,
+                    fill_price=fill.fill_price,
+                    fee=fill.fee,
+                    status=fill.status.value,
+                    timestamp=_bar_timestamp(bar.timestamp),
+                )
+            )
+            if fill.broker_order_id is not None:
+                payload["broker_order_id"] = fill.broker_order_id
             _emit_event(
                 context.logger,
                 "order.filled",
-                event_payload(
-                    OrderFilledEvent(
-                        symbol=fill.symbol,
-                        side=fill.side.value,
-                        requested_quantity=fill.requested_quantity,
-                        filled_quantity=fill.filled_quantity,
-                        fill_price=fill.fill_price,
-                        fee=fill.fee,
-                        status=fill.status.value,
-                        timestamp=_bar_timestamp(bar.timestamp),
-                    )
-                ),
+                payload,
             )
 
 
@@ -299,6 +304,8 @@ def _liquidate_current_symbol_position(
             timestamp=_bar_timestamp(bar.timestamp),
         )
     )
+    if fill.broker_order_id is not None:
+        events.order_filled["broker_order_id"] = fill.broker_order_id
     _emit_event(context.logger, "order.filled", events.order_filled, severity=30)
 
 

--- a/src/trading_system/execution/step.py
+++ b/src/trading_system/execution/step.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from trading_system.app.state import AppRunnerState, LiveRuntimeState
 from trading_system.core.ops import (
@@ -21,6 +21,9 @@ from trading_system.risk.limits import RiskLimits
 from trading_system.risk.portfolio_limits import PortfolioRiskLimits
 from trading_system.strategy.base import Strategy
 
+if TYPE_CHECKING:
+    from trading_system.execution.order_audit import OrderAuditRepository
+
 
 @dataclass(slots=True)
 class TradingContext:
@@ -31,6 +34,9 @@ class TradingContext:
     portfolio_risk: PortfolioRiskLimits | None = None
     runtime_state: LiveRuntimeState | None = None
     marks: dict[str, Decimal] | None = None
+    order_audit_repository: "OrderAuditRepository | None" = None
+    order_audit_scope: str | None = None
+    order_audit_owner_id: str | None = None
 
 
 @dataclass(slots=True)

--- a/src/trading_system/integrations/kis.py
+++ b/src/trading_system/integrations/kis.py
@@ -13,6 +13,7 @@ from urllib.request import Request, urlopen
 
 from trading_system.core.compat import UTC
 from trading_system.core.ops import EnvSecretProvider, SecretProvider
+from trading_system.execution.broker import OpenOrder, OpenOrderSnapshot
 from trading_system.execution.orders import OrderRequest, OrderSide
 
 KST = timezone(timedelta(hours=9))
@@ -123,6 +124,7 @@ class KisApiClient:
     _PRICE_PATH = "/uapi/domestic-stock/v1/quotations/inquire-price"
     _ORDER_PATH = "/uapi/domestic-stock/v1/trading/order-cash"
     _BALANCE_PATH = "/uapi/domestic-stock/v1/trading/inquire-balance"
+    _OPEN_ORDERS_PATH = "/uapi/domestic-stock/v1/trading/inquire-psbl-rvsecncl"
     _DEFAULT_MARKET_DIV = "J"
     _SYMBOL_PATTERN = re.compile(r"^\d{6}$")
 
@@ -319,9 +321,57 @@ class KisApiClient:
             "pending_symbols": tuple(sorted(pending_symbols)),
         }
 
+    def inquire_open_orders(self, *, access_token: str) -> OpenOrderSnapshot:
+        params = urlencode(
+            {
+                "CANO": self._credentials.account_number,
+                "ACNT_PRDT_CD": self._credentials.product_code,
+                "CTX_AREA_FK100": "",
+                "CTX_AREA_NK100": "",
+                "INQR_DVSN_1": "0",
+                "INQR_DVSN_2": "0",
+            }
+        )
+        response = self._transport.request(
+            "GET",
+            f"{self._base_url}{self._OPEN_ORDERS_PATH}?{params}",
+            headers={
+                "authorization": f"Bearer {access_token}",
+                "appkey": self._credentials.app_key,
+                "appsecret": self._credentials.app_secret,
+                "tr_id": self._open_orders_tr_id(),
+            },
+        )
+        result_code = str(response.body.get("rt_cd", "0"))
+        if response.status_code >= 400 or result_code not in {"", "0"}:
+            raise KisResponseError(
+                "KIS open-order query failed "
+                f"(status={response.status_code}, rt_cd={result_code}, "
+                f"msg1={response.body.get('msg1', '')})."
+            )
+
+        output = response.body.get("output")
+        if output is None:
+            output = response.body.get("output1")
+        if output is None:
+            output = []
+        if not isinstance(output, list):
+            raise KisResponseError("KIS open-order response output was missing or invalid.")
+
+        orders = tuple(
+            order
+            for item in output
+            if (order := _parse_open_order(item)) is not None
+        )
+        return OpenOrderSnapshot(orders=orders)
+
     def _balance_tr_id(self) -> str:
         configured = os.getenv("TRADING_SYSTEM_KIS_BALANCE_TR_ID", "TTTC8434R")
         return configured.strip() or "TTTC8434R"
+
+    def _open_orders_tr_id(self) -> str:
+        configured = os.getenv("TRADING_SYSTEM_KIS_OPEN_ORDERS_TR_ID", "TTTC8036R")
+        return configured.strip() or "TTTC8036R"
 
     def _parse_order_response(
         self, *, order: OrderRequest, response: HttpResponse
@@ -376,6 +426,80 @@ def _has_pending_balance_signal(
 
     available_qty = _as_decimal(raw_available_qty, "ord_psbl_qty")
     return available_qty < holding_qty
+
+
+def _parse_open_order(item: Any) -> OpenOrder | None:
+    if not isinstance(item, dict):
+        raise KisResponseError("KIS open-order item was not a mapping.")
+
+    symbol = str(item.get("pdno") or item.get("PDNO") or "").strip()
+    if not symbol:
+        raise KisResponseError("KIS open-order item missing symbol field 'pdno'.")
+    _validate_domestic_symbol(symbol)
+
+    broker_order_id = str(item.get("odno") or item.get("ODNO") or "").strip()
+    if not broker_order_id:
+        raise KisResponseError("KIS open-order item missing order id field 'odno'.")
+
+    requested_quantity = _as_decimal(
+        item.get("ord_qty") or item.get("ORD_QTY"),
+        "ord_qty",
+        default=Decimal("0"),
+    )
+    filled_quantity = _as_decimal(
+        item.get("tot_ccld_qty") or item.get("ccld_qty") or item.get("CCLD_QTY"),
+        "tot_ccld_qty",
+        default=Decimal("0"),
+    )
+    remaining_raw = item.get("rmn_qty") or item.get("ord_rmn_qty") or item.get("ORD_RMN_QTY")
+    remaining_quantity = (
+        _as_decimal(remaining_raw, "rmn_qty")
+        if remaining_raw not in (None, "")
+        else max(requested_quantity - filled_quantity, Decimal("0"))
+    )
+    if remaining_quantity <= 0:
+        return None
+
+    side = _parse_open_order_side(item)
+    status = str(
+        item.get("ord_stat_name")
+        or item.get("ord_stat")
+        or item.get("ORD_STAT")
+        or "open"
+    )
+    submitted_at = _optional_clean_str(
+        item.get("ord_tmd") or item.get("ord_dt") or item.get("ORD_TMD")
+    )
+    return OpenOrder(
+        broker_order_id=broker_order_id,
+        symbol=symbol,
+        side=side,
+        requested_quantity=requested_quantity,
+        remaining_quantity=remaining_quantity,
+        status=status,
+        submitted_at=submitted_at,
+    )
+
+
+def _parse_open_order_side(item: dict[str, Any]) -> OrderSide:
+    value = str(
+        item.get("sll_buy_dvsn_cd")
+        or item.get("sll_buy_dvsn_name")
+        or item.get("SLL_BUY_DVSN_CD")
+        or ""
+    ).strip().lower()
+    if value in {"01", "sell", "매도"}:
+        return OrderSide.SELL
+    if value in {"02", "buy", "매수"}:
+        return OrderSide.BUY
+    raise KisResponseError("KIS open-order item missing or invalid side field.")
+
+
+def _optional_clean_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
 
 
 def _as_dict(value: Any, field_name: str) -> dict[str, Any]:

--- a/tests/integration/test_kis_reconciliation_integration.py
+++ b/tests/integration/test_kis_reconciliation_integration.py
@@ -1,7 +1,9 @@
 """Integration tests for KIS reconciliation flow."""
 
 from decimal import Decimal
+from unittest.mock import MagicMock
 
+from trading_system.app.loop import LiveTradingLoop
 from trading_system.core.ops import StructuredLogFormat, StructuredLogger
 from trading_system.execution.broker import AccountBalanceSnapshot
 from trading_system.execution.reconciliation import reconcile
@@ -75,3 +77,21 @@ def test_reconciliation_removes_liquidated_position() -> None:
     assert book.cash == Decimal("710000")
     assert "005930" not in book.positions
     assert "005930" not in book.average_costs
+
+
+def test_live_reconciliation_skips_fail_closed_when_open_order_query_fails() -> None:
+    services = MagicMock()
+    services.logger = MagicMock()
+    services.portfolio = PortfolioBook(
+        cash=Decimal("1000000"),
+        positions={"005930": Decimal("5")},
+    )
+    services.broker_simulator.get_open_orders.side_effect = RuntimeError("open orders failed")
+
+    loop = LiveTradingLoop(services=services)
+
+    loop._maybe_reconcile()
+
+    services.broker_simulator.get_account_balance.assert_not_called()
+    assert services.portfolio.cash == Decimal("1000000")
+    assert services.portfolio.positions["005930"] == Decimal("5")

--- a/tests/integration/test_order_audit_integration.py
+++ b/tests/integration/test_order_audit_integration.py
@@ -1,10 +1,38 @@
+from decimal import Decimal
 from types import SimpleNamespace
 
 from trading_system.api.routes import backtest as backtest_routes
 from trading_system.api.routes.order_audit import list_order_audit_records
 from trading_system.api.schemas import BacktestRunRequestDTO
+from trading_system.app.loop import LiveTradingLoop
+from trading_system.app.sample_data import build_sample_bars
+from trading_system.app.services import AppServices
+from trading_system.app.settings import AppMode, LiveExecutionMode
 from trading_system.backtest.file_repository import FileBacktestRunRepository
+from trading_system.core.ops import StructuredLogFormat, StructuredLogger
+from trading_system.data.provider import InMemoryMarketDataProvider
+from trading_system.execution.broker import (
+    BpsCommissionPolicy,
+    BpsSlippagePolicy,
+    FixedRatioFillPolicy,
+    PolicyBrokerSimulator,
+    ResilientBroker,
+)
 from trading_system.execution.order_audit import FileOrderAuditRepository
+from trading_system.execution.step import TradingContext
+from trading_system.portfolio.book import PortfolioBook
+from trading_system.risk.limits import RiskLimits
+from trading_system.strategy.example import MomentumStrategy
+
+
+class _FailingOrderAuditRepository:
+    def append(self, record):
+        del record
+        raise RuntimeError("audit unavailable")
+
+    def list(self, **kwargs):
+        del kwargs
+        return []
 
 
 def _base_payload() -> dict:
@@ -53,3 +81,99 @@ def test_backtest_order_audit_records_are_queryable(tmp_path):
     assert response.total >= 1
     assert {record.owner_id for record in response.records} == {accepted.run_id}
     assert "order.created" in {record.event for record in response.records}
+
+
+def test_live_session_order_audit_records_are_queryable_without_testclient(tmp_path):
+    audit_repo = FileOrderAuditRepository(tmp_path / "order_audit")
+    services = AppServices(
+        mode=AppMode.LIVE,
+        provider="mock",
+        broker="paper",
+        live_execution=LiveExecutionMode.PAPER,
+        strategy=MomentumStrategy(trade_quantity=Decimal("0.1")),
+        strategies=None,
+        data_provider=InMemoryMarketDataProvider({"BTCUSDT": build_sample_bars("BTCUSDT")[:2]}),
+        risk_limits=RiskLimits(
+            max_position=Decimal("1"),
+            max_notional=Decimal("100000"),
+            max_order_size=Decimal("0.25"),
+        ),
+        broker_simulator=ResilientBroker(
+            delegate=PolicyBrokerSimulator(
+                fill_quantity_policy=FixedRatioFillPolicy(),
+                slippage_policy=BpsSlippagePolicy(),
+                commission_policy=BpsCommissionPolicy(),
+            )
+        ),
+        portfolio=PortfolioBook(cash=Decimal("10000")),
+        symbols=("BTCUSDT",),
+        logger=StructuredLogger("test.live.audit", log_format=StructuredLogFormat.JSON),
+        order_audit_repository=audit_repo,
+    )
+    loop = LiveTradingLoop(services=services, audit_owner_id="session-1")
+    context = TradingContext(
+        portfolio=services.portfolio,
+        risk_limits=services.risk_limits,
+        broker=services.broker_simulator,
+        logger=services.logger,
+        runtime_state=loop.runtime,
+        marks=loop.runtime.last_marks,
+        order_audit_repository=audit_repo,
+        order_audit_scope="live_session",
+        order_audit_owner_id="session-1",
+    )
+
+    loop._run_tick(context)
+    response = list_order_audit_records(
+        SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(order_audit_repository=audit_repo))),
+        scope="live_session",
+        owner_id="session-1",
+    )
+
+    assert response.total >= 1
+    assert {record.owner_id for record in response.records} == {"session-1"}
+    assert "order.created" in {record.event for record in response.records}
+
+
+def test_live_session_audit_append_failure_does_not_fail_tick():
+    services = AppServices(
+        mode=AppMode.LIVE,
+        provider="mock",
+        broker="paper",
+        live_execution=LiveExecutionMode.PAPER,
+        strategy=MomentumStrategy(trade_quantity=Decimal("0.1")),
+        strategies=None,
+        data_provider=InMemoryMarketDataProvider({"BTCUSDT": build_sample_bars("BTCUSDT")[:2]}),
+        risk_limits=RiskLimits(
+            max_position=Decimal("1"),
+            max_notional=Decimal("100000"),
+            max_order_size=Decimal("0.25"),
+        ),
+        broker_simulator=ResilientBroker(
+            delegate=PolicyBrokerSimulator(
+                fill_quantity_policy=FixedRatioFillPolicy(),
+                slippage_policy=BpsSlippagePolicy(),
+                commission_policy=BpsCommissionPolicy(),
+            )
+        ),
+        portfolio=PortfolioBook(cash=Decimal("10000")),
+        symbols=("BTCUSDT",),
+        logger=StructuredLogger("test.live.audit.failure", log_format=StructuredLogFormat.JSON),
+        order_audit_repository=_FailingOrderAuditRepository(),
+    )
+    loop = LiveTradingLoop(services=services, audit_owner_id="session-failure")
+    context = TradingContext(
+        portfolio=services.portfolio,
+        risk_limits=services.risk_limits,
+        broker=services.broker_simulator,
+        logger=services.logger,
+        runtime_state=loop.runtime,
+        marks=loop.runtime.last_marks,
+        order_audit_repository=services.order_audit_repository,
+        order_audit_scope="live_session",
+        order_audit_owner_id="session-failure",
+    )
+
+    loop._run_tick(context)
+
+    assert services.portfolio.positions["BTCUSDT"] == Decimal("0.1")

--- a/tests/integration/test_order_audit_integration.py
+++ b/tests/integration/test_order_audit_integration.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+from trading_system.api.routes import backtest as backtest_routes
+from trading_system.api.routes.order_audit import list_order_audit_records
+from trading_system.api.schemas import BacktestRunRequestDTO
+from trading_system.backtest.file_repository import FileBacktestRunRepository
+from trading_system.execution.order_audit import FileOrderAuditRepository
+
+
+def _base_payload() -> dict:
+    return {
+        "mode": "backtest",
+        "symbols": ["BTCUSDT"],
+        "provider": "mock",
+        "broker": "paper",
+        "live_execution": "preflight",
+        "risk": {
+            "max_position": "1",
+            "max_notional": "100000",
+            "max_order_size": "0.25",
+        },
+        "backtest": {
+            "starting_cash": "10000",
+            "fee_bps": "5",
+            "trade_quantity": "0.1",
+        },
+    }
+
+
+def test_backtest_order_audit_records_are_queryable(tmp_path):
+    run_repo = FileBacktestRunRepository(tmp_path / "runs")
+    audit_repo = FileOrderAuditRepository(tmp_path / "order_audit")
+    original_run_repo = backtest_routes._RUN_REPOSITORY
+    original_audit_repo = backtest_routes._ORDER_AUDIT_REPOSITORY
+    backtest_routes._RUN_REPOSITORY = run_repo
+    backtest_routes._ORDER_AUDIT_REPOSITORY = audit_repo
+    try:
+        accepted = backtest_routes.create_backtest_run(
+            BacktestRunRequestDTO.model_validate(_base_payload()),
+            request=None,
+        )
+        response = list_order_audit_records(
+            SimpleNamespace(
+                app=SimpleNamespace(state=SimpleNamespace(order_audit_repository=audit_repo))
+            ),
+            scope="backtest",
+            owner_id=accepted.run_id,
+        )
+    finally:
+        backtest_routes._RUN_REPOSITORY = original_run_repo
+        backtest_routes._ORDER_AUDIT_REPOSITORY = original_audit_repo
+
+    assert response.total >= 1
+    assert {record.owner_id for record in response.records} == {accepted.run_id}
+    assert "order.created" in {record.event for record in response.records}

--- a/tests/test_live_loop.py
+++ b/tests/test_live_loop.py
@@ -1,8 +1,12 @@
+from decimal import Decimal
 from unittest.mock import MagicMock
 
 from trading_system.app.loop import LiveTradingLoop
 from trading_system.app.state import AppRunnerState
+from trading_system.execution.broker import AccountBalanceSnapshot, OpenOrder, OpenOrderSnapshot
+from trading_system.execution.orders import OrderSide
 from trading_system.execution.step import TradingContext
+from trading_system.portfolio.book import PortfolioBook
 
 
 class MockExceptionLoop(LiveTradingLoop):
@@ -64,4 +68,67 @@ def test_live_loop_keyboard_interrupt():
         "system.shutdown",
         severity=20,
         payload={"reason": "keyboard_interrupt"}
+    )
+
+
+def test_live_loop_reconciliation_uses_open_orders_as_pending_source():
+    services = MagicMock()
+    services.logger = MagicMock()
+    services.portfolio = PortfolioBook(
+        cash=Decimal("100"),
+        positions={"005930": Decimal("1")},
+        average_costs={"005930": Decimal("70000")},
+    )
+    services.broker_simulator.get_open_orders.return_value = OpenOrderSnapshot(
+        orders=(
+            OpenOrder(
+                broker_order_id="90001",
+                symbol="005930",
+                side=OrderSide.BUY,
+                requested_quantity=Decimal("3"),
+                remaining_quantity=Decimal("1"),
+                status="open",
+            ),
+        )
+    )
+    services.broker_simulator.get_account_balance.return_value = AccountBalanceSnapshot(
+        cash=Decimal("120"),
+        positions={"005930": Decimal("2")},
+        average_costs={"005930": Decimal("71000")},
+        pending_symbols=(),
+    )
+
+    loop = LiveTradingLoop(services=services, poll_interval=1, heartbeat_interval=1)
+
+    loop._maybe_reconcile()
+
+    assert services.portfolio.cash == Decimal("100")
+    assert services.portfolio.positions["005930"] == Decimal("1")
+    services.logger.emit.assert_any_call(
+        "portfolio.reconciliation.pending_source",
+        severity=20,
+        payload={"pending_source": "open_orders", "pending_symbol_count": 1},
+    )
+
+
+def test_live_loop_reconciliation_skips_when_open_order_query_fails():
+    services = MagicMock()
+    services.logger = MagicMock()
+    services.portfolio = PortfolioBook(cash=Decimal("100"), positions={"005930": Decimal("1")})
+    services.broker_simulator.get_open_orders.side_effect = RuntimeError("open orders failed")
+
+    loop = LiveTradingLoop(services=services, poll_interval=1, heartbeat_interval=1)
+
+    loop._maybe_reconcile()
+
+    services.broker_simulator.get_account_balance.assert_not_called()
+    assert services.portfolio.cash == Decimal("100")
+    services.logger.emit.assert_any_call(
+        "portfolio.reconciliation.skipped",
+        severity=40,
+        payload={
+            "reason": "open_orders_unavailable",
+            "error": "open orders failed",
+            "pending_source": "open_orders",
+        },
     )

--- a/tests/unit/test_app_main.py
+++ b/tests/unit/test_app_main.py
@@ -73,6 +73,56 @@ def test_cli_multi_symbol_backtest_runs_successfully(capsys) -> None:
     assert exit_code == 0
 
 
+def test_cli_accepts_strategy_profile_id(capsys) -> None:
+    exit_code = run(
+        [
+            "--mode",
+            "backtest",
+            "--symbols",
+            "BTCUSDT",
+            "--strategy-profile-id",
+            "sample_bullish_profile",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Smoke backtest result" in captured.out
+
+
+def test_cli_accepts_yaml_config(capsys, tmp_path) -> None:
+    config_path = tmp_path / "settings.yaml"
+    config_path.write_text(
+        """
+app:
+  environment: local
+  timezone: Asia/Seoul
+  mode: backtest
+market_data:
+  provider: mock
+  symbols:
+    - BTCUSDT
+execution:
+  broker: paper
+risk:
+  max_position: 1
+  max_notional: 100000
+  max_order_size: 0.25
+backtest:
+  starting_cash: 10000
+  fee_bps: 5
+  trade_quantity: 0.1
+""".strip(),
+        encoding="utf-8",
+    )
+
+    exit_code = run(["--config", str(config_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Smoke backtest result" in captured.out
+
+
 def test_cli_returns_validation_error_for_unsupported_provider(capsys) -> None:
     exit_code = run(["--mode", "backtest", "--provider", "unknown"])
 

--- a/tests/unit/test_backtest_engine.py
+++ b/tests/unit/test_backtest_engine.py
@@ -14,6 +14,7 @@ from trading_system.execution.broker import (
     FixedRatioFillPolicy,
     PolicyBrokerSimulator,
 )
+from trading_system.execution.order_audit import OrderAuditRecord
 from trading_system.portfolio.book import PortfolioBook
 from trading_system.risk.limits import RiskLimits
 from trading_system.strategy.base import SignalSide, StrategySignal
@@ -29,6 +30,17 @@ class StubStrategy:
         signal = self.signals[self._index]
         self._index += 1
         return signal
+
+
+class RecordingAuditRepository:
+    def __init__(self) -> None:
+        self.records: list[OrderAuditRecord] = []
+
+    def append(self, record: OrderAuditRecord) -> None:
+        self.records.append(record)
+
+    def list(self, **kwargs):
+        return self.records
 
 
 def test_run_backtest_executes_buy_at_close_and_records_return() -> None:
@@ -219,6 +231,29 @@ def test_run_backtest_emits_structured_events_for_fill_and_risk_rejection(caplog
     assert "order.created" in events
     assert "order.filled" in events
     assert "risk.rejected" in events
+
+
+def test_run_backtest_appends_order_audit_records() -> None:
+    audit_repo = RecordingAuditRepository()
+    context = BacktestContext(
+        portfolio=PortfolioBook(cash=Decimal("1000")),
+        risk_limits=_limits(),
+        broker=_broker(),
+        order_audit_repository=audit_repo,
+        order_audit_scope="backtest",
+        order_audit_owner_id="run-1",
+    )
+
+    run_backtest(
+        _bars([Decimal("100")]),
+        StubStrategy(
+            [StrategySignal(side=SignalSide.BUY, quantity=Decimal("1"), reason="entry")]
+        ),
+        context,
+    )
+
+    assert [record.event for record in audit_repo.records] == ["order.created", "order.filled"]
+    assert {record.owner_id for record in audit_repo.records} == {"run-1"}
 
 def _limits() -> RiskLimits:
     return RiskLimits(

--- a/tests/unit/test_backtest_retention_routes.py
+++ b/tests/unit/test_backtest_retention_routes.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from trading_system.api.errors import RequestValidationError
+from trading_system.api.routes import backtest as backtest_routes
+from trading_system.api.schemas import BacktestRetentionPruneRequestDTO
+from trading_system.backtest.dispatcher import BacktestDispatcherSnapshot
+from trading_system.backtest.dto import BacktestRunDTO
+from trading_system.backtest.repository import InMemoryBacktestRunRepository
+
+
+class FakeDispatcher:
+    def snapshot(self) -> BacktestDispatcherSnapshot:
+        return BacktestDispatcherSnapshot(running=True, queue_depth=2, max_queue_size=32)
+
+
+def test_dispatcher_status_maps_snapshot():
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(backtest_dispatcher=FakeDispatcher()))
+    )
+
+    response = backtest_routes.get_backtest_dispatcher_status(request)
+
+    assert response.running is True
+    assert response.queue_depth == 2
+    assert response.max_queue_size == 32
+
+
+def test_retention_preview_and_prune_require_confirmation():
+    repo = InMemoryBacktestRunRepository()
+    repo.save(
+        BacktestRunDTO.failed(
+            run_id="old-run",
+            started_at="2024-01-01T00:00:00Z",
+            finished_at="2024-01-01T00:01:00Z",
+            input_symbols=["BTCUSDT"],
+            mode="backtest",
+            error="old",
+        )
+    )
+    original_repo = backtest_routes._RUN_REPOSITORY
+    backtest_routes._RUN_REPOSITORY = repo
+    try:
+        preview = backtest_routes.preview_backtest_retention(
+            cutoff="2025-01-01T00:00:00Z",
+            status="failed",
+        )
+        with pytest.raises(RequestValidationError):
+            backtest_routes.prune_backtest_retention(
+                BacktestRetentionPruneRequestDTO(
+                    cutoff="2025-01-01T00:00:00Z",
+                    status="failed",
+                )
+            )
+        pruned = backtest_routes.prune_backtest_retention(
+            BacktestRetentionPruneRequestDTO(
+                cutoff="2025-01-01T00:00:00Z",
+                status="failed",
+                confirm="DELETE",
+            )
+        )
+    finally:
+        backtest_routes._RUN_REPOSITORY = original_repo
+
+    assert preview.run_ids == ["old-run"]
+    assert pruned.deleted_count == 1
+    assert repo.get("old-run") is None

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 import pytest
 
-from trading_system.config.settings import SettingsValidationError, load_settings
+from trading_system.config.settings import SettingsValidationError, load_app_settings, load_settings
 
 
 def test_load_settings_parses_base_schema(tmp_path) -> None:
@@ -40,6 +40,88 @@ backtest:
     assert settings.backtest.fee_bps == Decimal("5.0")
     assert settings.app.reconciliation_interval is None
     assert settings.portfolio_risk is None
+    assert settings.strategy is None
+
+
+def test_load_settings_parses_strategy_profile_section(tmp_path) -> None:
+    config_path = tmp_path / "settings.yaml"
+    config_path.write_text(
+        """
+app:
+  environment: local
+  timezone: Asia/Seoul
+  mode: backtest
+market_data:
+  provider: mock
+  symbols:
+    - BTCUSDT
+execution:
+  broker: paper
+risk:
+  max_position: 1
+  max_notional: 100000
+  max_order_size: 0.25
+backtest:
+  starting_cash: 10000
+  fee_bps: 5
+  trade_quantity: 0.1
+strategy:
+  type: pattern_signal
+  profile_id: sample_bullish_profile
+""".strip(),
+        encoding="utf-8",
+    )
+
+    settings = load_settings(config_path)
+    app_settings = load_app_settings(config_path)
+
+    assert settings.strategy is not None
+    assert settings.strategy.profile_id == "sample_bullish_profile"
+    assert app_settings.strategy is not None
+    assert app_settings.strategy.profile_id == "sample_bullish_profile"
+
+
+def test_load_settings_parses_inline_strategy_section(tmp_path) -> None:
+    config_path = tmp_path / "settings.yaml"
+    config_path.write_text(
+        """
+app:
+  environment: local
+  timezone: Asia/Seoul
+  mode: backtest
+market_data:
+  provider: mock
+  symbols:
+    - BTCUSDT
+execution:
+  broker: paper
+risk:
+  max_position: 1
+  max_notional: 100000
+  max_order_size: 0.25
+backtest:
+  starting_cash: 10000
+  fee_bps: 5
+  trade_quantity: 0.1
+strategy:
+  type: pattern_signal
+  pattern_set_id: bullish
+  label_to_side:
+    bullish: buy
+  trade_quantity: 2
+  threshold_overrides:
+    bullish: 0.9
+""".strip(),
+        encoding="utf-8",
+    )
+
+    app_settings = load_app_settings(config_path)
+
+    assert app_settings.strategy is not None
+    assert app_settings.strategy.pattern_set_id == "bullish"
+    assert app_settings.strategy.label_to_side["bullish"].value == "buy"
+    assert app_settings.strategy.trade_quantity == Decimal("2")
+    assert app_settings.strategy.threshold_overrides == {"bullish": 0.9}
 
 
 def test_load_settings_parses_reconciliation_interval_and_portfolio_risk(tmp_path) -> None:

--- a/tests/unit/test_kis_integration.py
+++ b/tests/unit/test_kis_integration.py
@@ -93,6 +93,7 @@ def test_kis_broker_adapter_maps_successful_order_to_fill_event() -> None:
     assert fill.filled_quantity == Decimal("3")
     assert fill.fill_price == Decimal("70100")
     assert fill.status.value == "filled"
+    assert fill.broker_order_id == "12345"
 
 
 def test_kis_broker_adapter_maps_partial_fill_status() -> None:
@@ -222,6 +223,42 @@ def test_kis_broker_adapter_returns_none_when_pending_signal_is_unavailable() ->
     adapter = KisBrokerAdapter(client=client)
 
     assert adapter.get_account_balance() is None
+
+
+def test_kis_api_client_inquire_open_orders_returns_snapshot() -> None:
+    client = KisApiClient.from_env(
+        secret_provider=_StubSecretProvider(),
+        transport=_OpenOrdersTransport(),
+    )
+
+    snapshot = client.inquire_open_orders(access_token="kis-access-token")
+
+    assert snapshot.pending_symbols == ("005930",)
+    assert snapshot.orders[0].broker_order_id == "90001"
+    assert snapshot.orders[0].side == OrderSide.BUY
+    assert snapshot.orders[0].remaining_quantity == Decimal("2")
+
+
+def test_kis_api_client_inquire_open_orders_ignores_fully_filled_orders() -> None:
+    client = KisApiClient.from_env(
+        secret_provider=_StubSecretProvider(),
+        transport=_NoOpenOrdersTransport(),
+    )
+
+    snapshot = client.inquire_open_orders(access_token="kis-access-token")
+
+    assert snapshot.orders == ()
+    assert snapshot.pending_symbols == ()
+
+
+def test_kis_api_client_inquire_open_orders_requires_order_id() -> None:
+    client = KisApiClient.from_env(
+        secret_provider=_StubSecretProvider(),
+        transport=_MalformedOpenOrdersTransport(),
+    )
+
+    with pytest.raises(KisResponseError, match="order id"):
+        client.inquire_open_orders(access_token="kis-access-token")
 
 
 def test_is_krx_market_open_during_trading_hours() -> None:
@@ -399,6 +436,68 @@ class _MissingPendingSignalBalanceTransport:
                     },
                 ],
                 "output2": [{"dnca_tot_amt": "5000000"}],
+            },
+        )
+
+
+class _OpenOrdersTransport:
+    def request(self, method: str, url: str, *, headers: dict[str, str], body=None) -> HttpResponse:
+        del headers, body
+        assert method == "GET"
+        assert "/inquire-psbl-rvsecncl" in url
+        return HttpResponse(
+            status_code=200,
+            body={
+                "rt_cd": "0",
+                "output": [
+                    {
+                        "odno": "90001",
+                        "pdno": "005930",
+                        "sll_buy_dvsn_cd": "02",
+                        "ord_qty": "5",
+                        "tot_ccld_qty": "3",
+                        "ord_stat_name": "open",
+                        "ord_tmd": "093000",
+                    }
+                ],
+            },
+        )
+
+
+class _NoOpenOrdersTransport:
+    def request(self, method: str, url: str, *, headers: dict[str, str], body=None) -> HttpResponse:
+        del method, url, headers, body
+        return HttpResponse(
+            status_code=200,
+            body={
+                "rt_cd": "0",
+                "output": [
+                    {
+                        "odno": "90002",
+                        "pdno": "005930",
+                        "sll_buy_dvsn_cd": "02",
+                        "ord_qty": "5",
+                        "tot_ccld_qty": "5",
+                    }
+                ],
+            },
+        )
+
+
+class _MalformedOpenOrdersTransport:
+    def request(self, method: str, url: str, *, headers: dict[str, str], body=None) -> HttpResponse:
+        del method, url, headers, body
+        return HttpResponse(
+            status_code=200,
+            body={
+                "rt_cd": "0",
+                "output": [
+                    {
+                        "pdno": "005930",
+                        "sll_buy_dvsn_cd": "02",
+                        "ord_qty": "5",
+                    }
+                ],
             },
         )
 

--- a/tests/unit/test_order_audit_repository.py
+++ b/tests/unit/test_order_audit_repository.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from trading_system.execution.order_audit import (
+    FileOrderAuditRepository,
+    OrderAuditRecord,
+    SupabaseOrderAuditRepository,
+)
+
+
+def _record(**kwargs) -> OrderAuditRecord:
+    defaults = dict(
+        record_id="oa_1",
+        scope="backtest",
+        owner_id="run-1",
+        event="order.filled",
+        symbol="BTCUSDT",
+        side="buy",
+        requested_quantity="1",
+        filled_quantity="1",
+        price="100",
+        status="filled",
+        reason=None,
+        timestamp="2024-01-01T00:00:00Z",
+        payload={"symbol": "BTCUSDT", "status": "filled"},
+        broker_order_id=None,
+    )
+    defaults.update(kwargs)
+    return OrderAuditRecord(**defaults)
+
+
+def _make_supabase_repo():
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_conn.closed = False
+
+    repo = SupabaseOrderAuditRepository("postgresql://fake/db")
+    repo._conn = mock_conn
+    return repo, mock_cursor
+
+
+def test_file_order_audit_repository_appends_and_filters(tmp_path):
+    repo = FileOrderAuditRepository(tmp_path)
+    repo.append(_record(record_id="oa_1", owner_id="run-1", symbol="BTCUSDT"))
+    repo.append(_record(record_id="oa_2", owner_id="run-2", symbol="ETHUSDT"))
+
+    records = repo.list(scope="backtest", owner_id="run-1")
+
+    assert len(records) == 1
+    assert records[0].record_id == "oa_1"
+    assert records[0].payload["status"] == "filled"
+
+
+def test_supabase_order_audit_repository_creates_schema_on_append():
+    repo, cursor = _make_supabase_repo()
+
+    repo.append(_record())
+
+    calls = [call.args[0] for call in cursor.execute.call_args_list]
+    assert any("CREATE TABLE IF NOT EXISTS order_audit_records" in sql for sql in calls)
+    assert any("INSERT INTO order_audit_records" in sql for sql in calls)
+
+
+def test_supabase_order_audit_repository_list_deserializes_rows():
+    repo, cursor = _make_supabase_repo()
+    cursor.fetchall.return_value = [
+        (
+            "oa_1",
+            "backtest",
+            "run-1",
+            "order.filled",
+            "BTCUSDT",
+            "buy",
+            "1",
+            "1",
+            "100",
+            "filled",
+            None,
+            "2024-01-01T00:00:00Z",
+            {"symbol": "BTCUSDT"},
+            None,
+        )
+    ]
+
+    records = repo.list(scope="backtest", owner_id="run-1")
+
+    assert len(records) == 1
+    assert records[0].record_id == "oa_1"
+    assert records[0].symbol == "BTCUSDT"

--- a/tests/unit/test_order_audit_repository.py
+++ b/tests/unit/test_order_audit_repository.py
@@ -54,6 +54,39 @@ def test_file_order_audit_repository_appends_and_filters(tmp_path):
     assert records[0].payload["status"] == "filled"
 
 
+def test_file_order_audit_repository_applies_extended_filters(tmp_path):
+    repo = FileOrderAuditRepository(tmp_path)
+    repo.append(
+        _record(
+            record_id="oa_1",
+            timestamp="2024-01-01T00:00:00Z",
+            status="filled",
+            side="buy",
+            broker_order_id="broker-1",
+        )
+    )
+    repo.append(
+        _record(
+            record_id="oa_2",
+            timestamp="2024-01-02T00:00:00Z",
+            status="rejected",
+            side="sell",
+            broker_order_id="broker-2",
+        )
+    )
+
+    records = repo.list(
+        status="filled",
+        side="buy",
+        broker_order_id="broker-1",
+        start="2024-01-01T00:00:00Z",
+        end="2024-01-01T23:59:59Z",
+        sort="asc",
+    )
+
+    assert [record.record_id for record in records] == ["oa_1"]
+
+
 def test_supabase_order_audit_repository_creates_schema_on_append():
     repo, cursor = _make_supabase_repo()
 
@@ -90,3 +123,29 @@ def test_supabase_order_audit_repository_list_deserializes_rows():
     assert len(records) == 1
     assert records[0].record_id == "oa_1"
     assert records[0].symbol == "BTCUSDT"
+
+
+def test_supabase_order_audit_repository_list_applies_extended_filters():
+    repo, cursor = _make_supabase_repo()
+    cursor.fetchall.return_value = []
+
+    repo.list(
+        scope="backtest",
+        owner_id="run-1",
+        status="filled",
+        side="buy",
+        broker_order_id="broker-1",
+        start="2024-01-01T00:00:00Z",
+        end="2024-01-02T00:00:00Z",
+        sort="asc",
+    )
+
+    select_call = cursor.execute.call_args_list[-1]
+    sql = select_call.args[0]
+    params = select_call.args[1]
+    assert "status = %s" in sql
+    assert "side = %s" in sql
+    assert "broker_order_id = %s" in sql
+    assert "timestamp >= %s" in sql
+    assert "ORDER BY timestamp ASC" in sql
+    assert "broker-1" in params

--- a/tests/unit/test_order_audit_routes.py
+++ b/tests/unit/test_order_audit_routes.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from trading_system.api.routes.order_audit import list_order_audit_records
+from trading_system.execution.order_audit import OrderAuditRecord
+
+
+class FakeOrderAuditRepository:
+    def list(self, **kwargs):
+        assert kwargs["scope"] == "backtest"
+        assert kwargs["owner_id"] == "run-1"
+        return [
+            OrderAuditRecord(
+                record_id="oa_1",
+                scope="backtest",
+                owner_id="run-1",
+                event="order.filled",
+                symbol="BTCUSDT",
+                side="buy",
+                requested_quantity="1",
+                filled_quantity="1",
+                price="100",
+                status="filled",
+                reason=None,
+                timestamp="2024-01-01T00:00:00Z",
+                payload={"symbol": "BTCUSDT"},
+            )
+        ]
+
+
+def test_list_order_audit_records_maps_repository_records():
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(order_audit_repository=FakeOrderAuditRepository()))
+    )
+
+    response = list_order_audit_records(request, scope="backtest", owner_id="run-1")
+
+    assert response.total == 1
+    assert response.records[0].record_id == "oa_1"
+    assert response.records[0].owner_id == "run-1"

--- a/tests/unit/test_order_audit_routes.py
+++ b/tests/unit/test_order_audit_routes.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from trading_system.api.routes.order_audit import list_order_audit_records
+from trading_system.api.routes.order_audit import (
+    export_order_audit_records,
+    list_order_audit_records,
+)
 from trading_system.execution.order_audit import OrderAuditRecord
 
 
@@ -39,3 +42,37 @@ def test_list_order_audit_records_maps_repository_records():
     assert response.total == 1
     assert response.records[0].record_id == "oa_1"
     assert response.records[0].owner_id == "run-1"
+
+
+def test_export_order_audit_records_returns_csv():
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(order_audit_repository=FakeOrderAuditRepository()))
+    )
+
+    response = export_order_audit_records(
+        request,
+        scope="backtest",
+        owner_id="run-1",
+        format="csv",
+    )
+
+    assert response.status_code == 200
+    assert response.headers["x-order-audit-record-count"] == "1"
+    assert "record_id,scope,owner_id" in response.body.decode()
+    assert "oa_1" in response.body.decode()
+
+
+def test_export_order_audit_records_returns_jsonl():
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(order_audit_repository=FakeOrderAuditRepository()))
+    )
+
+    response = export_order_audit_records(
+        request,
+        scope="backtest",
+        owner_id="run-1",
+        format="jsonl",
+    )
+
+    assert response.status_code == 200
+    assert '"record_id":"oa_1"' in response.body.decode().replace(" ", "")


### PR DESCRIPTION
## Summary

- Add broker open-order authority for KIS reconciliation and preserve broker order ids in order audit records.
- Extend order audit filtering/export with bounded CSV/JSONL responses and frontend owner-based export actions.
- Align strategy configuration across YAML and CLI, including `--config` and `--strategy-profile-id`.
- Update Phase 15 planning docs, configs, examples, architecture docs, and operational runbooks.

## Validation

- `python -m compileall -q src/trading_system`
- `ruff check src/trading_system tests`
- `pytest tests/unit/test_kis_integration.py tests/unit/test_reconciliation.py tests/test_live_loop.py tests/unit/test_order_audit_repository.py tests/unit/test_order_audit_routes.py tests/integration/test_kis_reconciliation_integration.py tests/integration/test_order_audit_integration.py tests/unit/test_config_settings.py tests/unit/test_app_main.py tests/unit/test_strategy_factory.py -q` (`70 passed`)
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `cd frontend && npm run test:e2e` (`3 passed`)

## Notes

- KIS open-order parsing is fixture-backed and may need field mapping adjustment against real KIS account responses.
- Order audit export is a bounded synchronous API response, not a background export pipeline.